### PR TITLE
Fix issue #2 and allow for opts customization

### DIFF
--- a/lua/octo.lua
+++ b/lua/octo.lua
@@ -428,7 +428,7 @@ local function create_issue_buffer(issue, repo)
 	local extmarks = {}
 
 	-- create buffer
-	api.nvim_command(format('e octo://%s/%s', repo, number))
+	api.nvim_command(format('noautocmd e octo://%s/%s', repo, number))
 	local bufnr = api.nvim_get_current_buf()
 
 	-- delete extmarks

--- a/lua/octo.lua
+++ b/lua/octo.lua
@@ -624,7 +624,7 @@ local function get_url(url, params)
 	return url
 end
 
-local function get_repo_issues(repo, query_params)
+local function get_repo_issues(opts, repo, query_params)
 
 	-- this function should be used by fuzzy pickers as a source
 	-- and then use `get_issue()` as the sink
@@ -711,7 +711,7 @@ end
 --     curl.request(issues_url, opts, choose_issue)
 -- end
 
-local function get_issue(number, repo)
+local function get_issue(opts, number, repo)
 	if nil == repo or repo == 'nil' or repo == '' then
 		repo = get_repo_name()
 	end


### PR DESCRIPTION
This attempts to fix [issue #2 ](https://github.com/pwntester/octo.nvim/issues/2).

The default finders accept `opts` as a parameter. This matches that behaviour and ensures that the opts var is passed to functions that require it).

Secondly, autocommands are disabled when creating the issues buffer, as that triggers functions that try to read `b:` vars that haven't been set yet.