### PR TITLE
Add @People mentioning to PR view

### DIFF
--- a/lua/octo/completion.lua
+++ b/lua/octo/completion.lua
@@ -49,7 +49,7 @@ local function get_repo_issues(repo, params)
 end
 
 function M.issue_complete(findstart, base)
-  -- the complete-functions
+  -- :help complete-functions
   if findstart == 1 then
     -- findstart
     local line = api.nvim_get_current_line()

--- a/lua/octo/completion.lua
+++ b/lua/octo/completion.lua
@@ -72,20 +72,20 @@ function M.issue_complete(findstart, base)
     end
     return -2
   elseif findstart == 0 then
-    local repo = api.nvim_buf_get_var(0, "repo")
-    local issues = get_repo_issues(repo)
     local entries = {}
     if vim.startswith(base, "@") then
       local users = api.nvim_buf_get_var(0, "taggable_users") or {}
       for _, user in pairs(users) do table.insert(entries, {word = format("@%s", user), abbr = user}) end
     else if vim.startswith(base, "#") then
+        local repo = api.nvim_buf_get_var(0, "repo")
+        local issues = get_repo_issues(repo)
         for _, i in ipairs(issues) do
-          if vim.startswith(tostring(i.number), base) then
+          if vim.startswith('#'..tostring(i.number), base) then
             table.insert(
               entries,
               {
-                word = tostring(i.number),
-                abbr = format("#%d", i.number),
+                abbr = tostring(i.number),
+                word = format("#%d", i.number),
                 menu = i.title
               }
               )

--- a/lua/octo/completion.lua
+++ b/lua/octo/completion.lua
@@ -1,52 +1,7 @@
-local gh = require("octo.gh")
 local format = string.format
 local api = vim.api
-local json = {
-  parse = vim.fn.json_decode,
-  stringify = vim.fn.json_encode
-}
 
 local M = {}
-
-local function get_url(url, params)
-  url = url .. "?foo=bar"
-  for k, v in pairs(params) do
-    url = format("%s&%s=%s", url, k, v)
-  end
-  return url
-end
-
-local function get_repo_issues(repo, params)
-  params = params or {}
-  local query_params = {
-    state = params.state or "open",
-    per_page = params.per_page or 50,
-    filter = params.filter,
-    labels = params.labels,
-    since = params.since
-  }
-
-  local query = get_url(format("repos/%s/issues", repo), query_params)
-  local body =
-    gh.run(
-    {
-      args = {"api", query},
-      mode = "sync"
-    }
-  )
-
-  local issues = json.parse(body)
-
-  -- TODO: filter out pull_requests (NOT WORKING)
-  vim.tbl_filter(
-    function(e)
-      return e.pull_request == nil
-    end,
-    issues
-  )
-
-  return issues
-end
 
 function M.issue_complete(findstart, base)
   -- :help complete-functions
@@ -80,8 +35,7 @@ function M.issue_complete(findstart, base)
       end
     else
       if vim.startswith(base, "#") then
-        local repo = api.nvim_buf_get_var(0, "repo")
-        local issues = get_repo_issues(repo)
+        local issues = api.nvim_buf_get_var(0, "issues") or {}
         for _, i in ipairs(issues) do
           if vim.startswith("#" .. tostring(i.number), base) then
             table.insert(

--- a/lua/octo/completion.lua
+++ b/lua/octo/completion.lua
@@ -75,12 +75,15 @@ function M.issue_complete(findstart, base)
     local entries = {}
     if vim.startswith(base, "@") then
       local users = api.nvim_buf_get_var(0, "taggable_users") or {}
-      for _, user in pairs(users) do table.insert(entries, {word = format("@%s", user), abbr = user}) end
-    else if vim.startswith(base, "#") then
+      for _, user in pairs(users) do
+        table.insert(entries, {word = format("@%s", user), abbr = user})
+      end
+    else
+      if vim.startswith(base, "#") then
         local repo = api.nvim_buf_get_var(0, "repo")
         local issues = get_repo_issues(repo)
         for _, i in ipairs(issues) do
-          if vim.startswith('#'..tostring(i.number), base) then
+          if vim.startswith("#" .. tostring(i.number), base) then
             table.insert(
               entries,
               {
@@ -88,7 +91,7 @@ function M.issue_complete(findstart, base)
                 word = format("#%d", i.number),
                 menu = i.title
               }
-              )
+            )
           end
         end
       end

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -416,8 +416,8 @@ end
 --   - The PR author
 --   - The authors of all the existing comments
 --   - The contributors of the repo
-local function async_fetch_taggable_users(bufnr, repo, issue_author)
-  local users = {issue_author}
+local function async_fetch_taggable_users(bufnr, repo)
+  local users = api.nvim_buf_get_var(bufnr, "taggable_users") or {}
   local comments_metadata = api.nvim_buf_get_var(bufnr, "comments")
   for _, c in pairs(comments_metadata) do table.insert(users, c.author) end
   api.nvim_buf_set_var(bufnr, "taggable_users", users)
@@ -652,7 +652,7 @@ function M.create_issue_buffer(issue, repo, create_buffer)
     200
   )
 
-  async_fetch_taggable_users(bufnr, repo, issue.user.login)
+  async_fetch_taggable_users(bufnr, repo)
 
   -- show signs
   signs.render_signcolumn(bufnr)

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -419,7 +419,9 @@ end
 local function async_fetch_taggable_users(bufnr, repo)
   local users = api.nvim_buf_get_var(bufnr, "taggable_users") or {}
   local comments_metadata = api.nvim_buf_get_var(bufnr, "comments")
-  for _, c in pairs(comments_metadata) do table.insert(users, c.author) end
+  for _, c in pairs(comments_metadata) do
+    table.insert(users, c.author)
+  end
   api.nvim_buf_set_var(bufnr, "taggable_users", users)
   gh.run(
     {
@@ -432,7 +434,7 @@ local function async_fetch_taggable_users(bufnr, repo)
         api.nvim_buf_set_var(bufnr, "taggable_users", users)
       end
     }
-    )
+  )
 end
 
 function M.create_issue_buffer(issue, repo, create_buffer)
@@ -479,11 +481,23 @@ function M.create_issue_buffer(issue, repo, create_buffer)
   api.nvim_buf_set_keymap(bufnr, "i", "@", "@<C-x><C-o>", mapping_opts)
   api.nvim_buf_set_keymap(bufnr, "i", "#", "#<C-x><C-o>", mapping_opts)
 
-  api.nvim_buf_set_keymap(bufnr, "n", "<space>gi", [[<cmd>lua require'octo.navigation'.go_to_issue()<CR>]], mapping_opts)
+  api.nvim_buf_set_keymap(
+    bufnr,
+    "n",
+    "<space>gi",
+    [[<cmd>lua require'octo.navigation'.go_to_issue()<CR>]],
+    mapping_opts
+  )
 
   api.nvim_buf_set_keymap(bufnr, "n", "<space>ca", [[<cmd>lua require'octo.commands'.add_comment()<CR>]], mapping_opts)
 
-  api.nvim_buf_set_keymap(bufnr, "n", "<space>cd", [[<cmd>lua require'octo.commands'.delete_comment()<CR>]], mapping_opts)
+  api.nvim_buf_set_keymap(
+    bufnr,
+    "n",
+    "<space>cd",
+    [[<cmd>lua require'octo.commands'.delete_comment()<CR>]],
+    mapping_opts
+  )
 
   api.nvim_buf_set_keymap(
     bufnr,
@@ -499,7 +513,13 @@ function M.create_issue_buffer(issue, repo, create_buffer)
     [[<cmd>lua require'octo.commands'.change_issue_state('open')<CR>]],
     mapping_opts
   )
-  api.nvim_buf_set_keymap(bufnr, "n", "<space>il", format("<cmd>lua require'octo.menu'.issues('%s')<CR>", repo), mapping_opts)
+  api.nvim_buf_set_keymap(
+    bufnr,
+    "n",
+    "<space>il",
+    format("<cmd>lua require'octo.menu'.issues('%s')<CR>", repo),
+    mapping_opts
+  )
 
   api.nvim_buf_set_keymap(bufnr, "n", "<space>co", [[<cmd>lua require'octo.commands'.checkout_pr()<CR>]], mapping_opts)
 

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -437,6 +437,20 @@ local function async_fetch_taggable_users(bufnr, repo)
   )
 end
 
+-- This function fetches the issues in the repo so they can be used for
+-- completion.
+local function async_fetch_issues(bufnr, repo)
+  gh.run(
+    {
+      args = {"api", format(format("repos/%s/issues", repo))},
+      cb = function(response)
+        local resp = json.parse(response)
+        api.nvim_buf_set_var(bufnr, "issues", resp)
+      end
+    }
+  )
+end
+
 function M.create_issue_buffer(issue, repo, create_buffer)
   if not issue["id"] then
     api.nvim_err_writeln(format("Cannot find issue in %s", repo))
@@ -673,6 +687,7 @@ function M.create_issue_buffer(issue, repo, create_buffer)
   )
 
   async_fetch_taggable_users(bufnr, repo)
+  async_fetch_issues(bufnr, repo)
 
   -- show signs
   signs.render_signcolumn(bufnr)

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -444,8 +444,12 @@ local function async_fetch_issues(bufnr, repo)
     {
       args = {"api", format(format("repos/%s/issues", repo))},
       cb = function(response)
+        local issues_metadata = {}
         local resp = json.parse(response)
-        api.nvim_buf_set_var(bufnr, "issues", resp)
+        for _, issue in ipairs(resp) do
+          table.insert(issues_metadata, {number = issue.number, title = issue.title})
+        end
+        api.nvim_buf_set_var(bufnr, "issues", issues_metadata)
       end
     }
   )

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -372,6 +372,7 @@ function M.write_comment(bufnr, comment, line)
   table.insert(
     comments_metadata,
     {
+      author = comment.user.login,
       id = comment.id,
       dirty = false,
       saved_body = comment_body,
@@ -406,6 +407,32 @@ function M.load_issue()
       end
     }
   )
+end
+
+-- This function accumulates all the taggable users into a single list that
+-- gets set as a buffer variable `taggable_users`. If this list of users
+-- is needed syncronously, this function will need to be refactored.
+-- The list of taggable users should contain:
+--   - The PR author
+--   - The authors of all the existing comments
+--   - The contributors of the repo
+local function async_fetch_taggable_users(bufnr, repo, issue_author)
+  local users = {issue_author}
+  local comments_metadata = api.nvim_buf_get_var(bufnr, "comments")
+  for _, c in pairs(comments_metadata) do table.insert(users, c.author) end
+  api.nvim_buf_set_var(bufnr, "taggable_users", users)
+  gh.run(
+    {
+      args = {"api", format("repos/%s/contributors", repo)},
+      cb = function(response)
+        local resp = json.parse(response)
+        for _, contributor in ipairs(resp) do
+          table.insert(users, contributor.login)
+        end
+        api.nvim_buf_set_var(bufnr, "taggable_users", users)
+      end
+    }
+    )
 end
 
 function M.create_issue_buffer(issue, repo, create_buffer)
@@ -444,9 +471,13 @@ function M.create_issue_buffer(issue, repo, create_buffer)
   api.nvim_buf_set_var(bufnr, "labels", issue.labels)
   api.nvim_buf_set_var(bufnr, "assignees", issue.assignees)
   api.nvim_buf_set_var(bufnr, "milestone", issue.milestone)
+  api.nvim_buf_set_var(bufnr, "taggable_users", {issue.user.login})
 
   -- local mappings
-  local mapping_opts = {script = true, silent = true}
+  local mapping_opts = {script = true, silent = true, noremap = true}
+
+  api.nvim_buf_set_keymap(bufnr, "i", "@", "@<C-x><C-o>", mapping_opts)
+  api.nvim_buf_set_keymap(bufnr, "i", "#", "#<C-x><C-o>", mapping_opts)
 
   api.nvim_buf_set_keymap(bufnr, "n", "<space>gi", [[<cmd>lua require'octo.navigation'.go_to_issue()<CR>]], mapping_opts)
 
@@ -620,6 +651,8 @@ function M.create_issue_buffer(issue, repo, create_buffer)
     end,
     200
   )
+
+  async_fetch_taggable_users(bufnr, repo, issue.user.login)
 
   -- show signs
   signs.render_signcolumn(bufnr)


### PR DESCRIPTION
### Description
This PR adds the ability to @mention people in the PR view. Related to #12. 

### Implementation
This works by accumulating a list of users from a couple different sources.
These include:
  - The author of the issue
  - The authors of existing comments
  - The contributors to the repo

This list of users is currently only used to @mention people so the api call to
fetch collaborators is started in the background without waiting for it to
complete. The accumulated list is then attached to the issue buffer under the
key `taggable_users`.

If the completion base starts with `@` inside the completion function, the
entries will be built from the `taggable_users` that should be attached to the
buffer.

I also added keymaps in insert mode for `@` and `#` to make them immediately
call the completion menu.

### Future Work
#12 mentions including users who were mentioned in existing comments or the
description. This is not included in this PR but I thought this could be a good
first step.

Thanks for taking the time to review.
