### PR TITLE
add telescope interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Plug 'pwntester/octo.nvim'
 Plug 'nvim-lua/popup.nvim'
 Plug 'nvim-lua/plenary.nvim'
 Plug 'nvim-telescope/telescope.nvim'
+
+-- To use Telescope interface for octo pickers 
+lua require('telescope').load_extension('octo')
 ```
 
 ## Commands

--- a/lua/telescope/_extensions/octo.lua
+++ b/lua/telescope/_extensions/octo.lua
@@ -1,0 +1,9 @@
+local menu = require'octo.menu'
+return require'telescope'.register_extension {
+  exports = {
+    commits = menu.commits,
+    gists = menu.gists,
+    issues = menu.issues,
+    prs = menu.pull_requests,
+  },
+}


### PR DESCRIPTION
Currently, Trying to use Telescope octo command results :

```vim
stack traceback:
vim/shared.lua:64: in function 'gsplit'
vim/shared.lua:111: in function 'split'
...re/nvim/site/pack/packer/opt/octo.nvim/lua/octo/menu.lua:460: in 
function <...re/nvim/site/pack/packer/opt/octo.nvim/lua/octo/menu.lua:448>
...pack/packer/opt/telescope.nvim/lua/telescope/command.lua:90: 
in function <...pack/packer/opt/telescope.nvim/lua/telescope/commands.lua
```

I wonder why is that :thinking:
