### PR TITLE
Online reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ There is only an `Octo <object> <action> [arguments]` command:
 | card | add | |
 | | delete | |
 | | move | |
-| review| start| |
-| | comments| |
-| | submit| |
-| | view| |
+| review| start| Start a new review |
+| | comments| View in-progress review comments |
+| | submit| Submit the review |
+| | threads | View other people review threads (comment+replies)|
 
 * If repo is not provided, it will be derived from `<cwd>/.git/config`.
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,11 @@ There is only an `Octo <object> <action> [arguments]` command:
 | | close | |
 | | checkout | |
 | | commits | |
-| | files | |
+| | changes | |
 | | diff | |
 | | merge | [commit\|rebase\|squash] [delete] |
 | | ready| |
 | | checks | |
-| | reviews | |
 | | reload | |
 | | browser | |
 | gist | list | [repo] [key=value]*<br>[Available keys](https://cli.github.com/manual/gh_gist_list):  `repo`\|`public`\|`secret`<br>Mappings:<br>`<CR>`: Append Gist to buffer<br>`<C-b>`: Opens Gist in web browser |
@@ -75,6 +74,10 @@ There is only an `Octo <object> <action> [arguments]` command:
 | card | add | |
 | | delete | |
 | | move | |
+| review| start| |
+| | comments| |
+| | submit| |
+| | view| |
 
 * If repo is not provided, it will be derived from `<cwd>/.git/config`.
 
@@ -98,10 +101,10 @@ Octo issue list neovim/neovim labels=bug,help\ wanted states=OPEN
 Just edit the issue title, description or comments as a regular buffer and use `:w(rite)` to sync the issue with GitHub.
 
 ## PR review
-- Change to the directory containing the repo/PR
 - Open the PR (eg: `Octo pr list` or `Octo pr edit XXX`)
-- If not already in the PR branch, checkout the PR with `Octo pr checkout`
 - Start a review with `Octo review start`
+- Quickfix will be populated with the changed files 
+- Change quickfix entries with `]q` and `[q` or by selecting an entry in the quickfix window
 - Add comments with `<space>ca` or `:OctoAddReviewComment` on single or multiple lines
 - Add suggestions with `<space>sa` or `:OctoAddReviewSuggestion` on single or multiple lines
 - A new split will open. Enter the comment and save it (`:w`). Optionally close the split
@@ -122,11 +125,9 @@ Just edit the issue title, description or comments as a regular buffer and use `
 
 ![](https://camo.githubusercontent.com/97aaf7efe7c8ff45cbc4359f28339fd9f9dd7ba3609fbd14b0649a979af15431/68747470733a2f2f692e696d6775722e636f6d2f71495a5a6b48342e706e67) 
 
-- Change to the directory containing the repo/PR
 - Open the PR (eg: `Octo pr list` or `Octo pr edit XXX`)
-- If not already in the PR branch, checkout the PR with `Octo pr checkout`
-- Open review threads view with `Octo pr reviews`
-- Quickfix will be populated with changed files 
+- Open review threads view with `Octo review view`
+- Quickfix will be populated with the changed files 
 - Change quickfix entries with `]q` and `[q` or by selecting an entry in the quickfix window
 - Jump between comments with `]c` and `[c`
 - You can reply to a comment, delete them, add/remove reactions, etc. as if you where in an Octo issue buffer

--- a/after/syntax/octo_issue.vim
+++ b/after/syntax/octo_issue.vim
@@ -15,7 +15,7 @@ hi def link OctoNvimCommentHeading PreProc
 hi def link OctoNvimCommentUser String 
 hi def link OctoNvimIssueOpen MoreMsg
 hi def link OctoNvimIssueClosed ErrorMsg
-hi def link OctoNvimIssueMerged DiffAdd
+hi def link OctoNvimIssueMerged Keyword
 hi def link OctoNvimIssueId Question
 hi def link OctoNvimIssueTitle PreProc
 hi def link OctoNvimEmpty Comment

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -700,7 +700,7 @@ function M.submit_review()
   api.nvim_buf_set_keymap(bufnr, "n", "<C-m>", ":lua require'octo.reviews'.submit_review('COMMENT')<CR>", mapping_opts)
   api.nvim_buf_set_keymap(bufnr, "n", "<C-r>", ":lua require'octo.reviews'.submit_review('REQUEST_CHANGES')<CR>", mapping_opts)
   vim.cmd [[normal G]]
-  vim.cmd [[startinsert]]
+  --vim.cmd [[startinsert]]
 end
 
 function M.start_review()
@@ -710,6 +710,7 @@ function M.start_review()
   end
 
   reviews.review_comments = {}
+  reviews.review_files = {}
 
   local url = format("repos/%s/pulls/%d/files", repo, number)
   gh.run(

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -733,7 +733,7 @@ function M.start_review()
           end
           reviews.populate_changes_qf(changes, {
             pull_request_repo = repo,
-            pull_request_numer = number,
+            pull_request_number = number,
             pull_request_id = pr.id,
             baseRefName = pr.baseRefName,
             baseRefSHA = pr.baseRefSHA,

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -101,8 +101,8 @@ local commands = {
     submit = function()
       M.submit_review()
     end,
-    view = function()
-      M.view_reviews()
+    threads = function()
+      M.review_threads()
     end,
   },
   gist = {
@@ -645,7 +645,7 @@ function M.show_pr_diff()
   )
 end
 
-function M.view_reviews()
+function M.review_threads()
   local repo, number, _ = util.get_repo_number_pr()
   if not repo then
     return

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -725,9 +725,7 @@ function M.start_review()
             pull_request_repo = repo,
             pull_request_number = number,
             pull_request_id = pr.id,
-            baseRefName = pr.baseRefName,
             baseRefSHA = pr.baseRefSHA,
-            headRefName = pr.headRefName,
             headRefSHA = pr.headRefSHA
           })
         end

--- a/lua/octo/entry_maker.lua
+++ b/lua/octo/entry_maker.lua
@@ -116,8 +116,8 @@ function M.gen_from_git_changed_files()
     entry_display.create {
     separator = " ",
     items = {
-      --{width = 8},
-      --{width = string.len("modified")},
+      {width = 8},
+      {width = string.len("modified")},
       {width = 5},
       {width = 5},
       {remaining = true}
@@ -126,11 +126,11 @@ function M.gen_from_git_changed_files()
 
   local make_display = function(entry)
     return displayer {
-      --{entry.value:sub(1, 7), "TelescopeResultsNumber"},
-      --{entry.change.status, "OctoNvimDetailsLabel"},
+      {entry.value:sub(1, 7), "TelescopeResultsNumber"},
+      {entry.change.status, "OctoNvimDetailsLabel"},
       {format("+%d", entry.change.additions), "OctoNvimPullAdditions"},
       {format("-%d", entry.change.deletions), "OctoNvimPullDeletions"},
-      vim.split(entry.change.path, "\n")[1]
+      vim.split(entry.msg, "\n")[1]
     }
   end
 
@@ -140,9 +140,9 @@ function M.gen_from_git_changed_files()
     end
 
     return {
-      value = entry.path,
-      ordinal = entry.path,
-      msg = entry.path,
+      value = entry.sha,
+      ordinal = entry.sha .. " " .. entry.filename,
+      msg = entry.filename,
       display = make_display,
       change = entry
     }

--- a/lua/octo/entry_maker.lua
+++ b/lua/octo/entry_maker.lua
@@ -116,8 +116,8 @@ function M.gen_from_git_changed_files()
     entry_display.create {
     separator = " ",
     items = {
-      {width = 8},
-      {width = string.len("modified")},
+      --{width = 8},
+      --{width = string.len("modified")},
       {width = 5},
       {width = 5},
       {remaining = true}
@@ -126,11 +126,11 @@ function M.gen_from_git_changed_files()
 
   local make_display = function(entry)
     return displayer {
-      {entry.value:sub(1, 7), "TelescopeResultsNumber"},
-      {entry.change.status, "OctoNvimDetailsLabel"},
+      --{entry.value:sub(1, 7), "TelescopeResultsNumber"},
+      --{entry.change.status, "OctoNvimDetailsLabel"},
       {format("+%d", entry.change.additions), "OctoNvimPullAdditions"},
       {format("-%d", entry.change.deletions), "OctoNvimPullDeletions"},
-      vim.split(entry.msg, "\n")[1]
+      vim.split(entry.change.path, "\n")[1]
     }
   end
 
@@ -140,9 +140,9 @@ function M.gen_from_git_changed_files()
     end
 
     return {
-      value = entry.sha,
-      ordinal = entry.sha .. " " .. entry.filename,
-      msg = entry.filename,
+      value = entry.path,
+      ordinal = entry.path,
+      msg = entry.path,
       display = make_display,
       change = entry
     }

--- a/lua/octo/graphql.lua
+++ b/lua/octo/graphql.lua
@@ -286,6 +286,9 @@ query($endCursor: String) {
               nodes{
                 id
                 body
+                commit {
+                  oid
+                }
                 author { login }
                 authorAssociation
                 originalPosition
@@ -928,6 +931,19 @@ query {
     }
   }
   right: repository(owner: "%s", name: "%s") {
+    object(expression: "%s:%s") {
+      ... on Blob {
+        text
+      }
+    }
+  }
+}
+]]
+
+M.file_content_query =
+  [[
+query {
+  repository(owner: "%s", name: "%s") {
     object(expression: "%s:%s") {
       ... on Blob {
         text

--- a/lua/octo/graphql.lua
+++ b/lua/octo/graphql.lua
@@ -873,16 +873,16 @@ query($endCursor: String) {
   search(query: "%s", type: USER, first: 100) {
     nodes {
       ... on User {
-        id 
+        id
         login
       }
       ... on Organization {
-        id 
+        id
         login
         teams(first:100, after: $endCursor) {
           totalCount
           nodes {
-            id 
+            id
             name
           }
           pageInfo {
@@ -890,6 +890,47 @@ query($endCursor: String) {
             endCursor
           }
         }
+      }
+    }
+  }
+}
+]]
+
+M.changed_files_query =
+  [[
+query($endCursor: String) {
+  repository(owner: "%s", name: "%s") {
+    pullRequest(number: %d) {
+      files(first:100, after: $endCursor) {
+        nodes {
+          additions
+          deletions
+          path
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+]]
+
+M.diff_file_content_query =
+  [[
+query {
+  left: repository(owner: "%s", name: "%s") {
+    object(expression: "%s:%s") {
+      ... on Blob {
+        text
+      }
+    }
+  }
+  right: repository(owner: "%s", name: "%s") {
+    object(expression: "%s:%s") {
+      ... on Blob {
+        text
       }
     }
   }

--- a/lua/octo/graphql.lua
+++ b/lua/octo/graphql.lua
@@ -920,26 +920,6 @@ query($endCursor: String) {
 }
 ]]
 
-M.diff_file_content_query =
-  [[
-query {
-  left: repository(owner: "%s", name: "%s") {
-    object(expression: "%s:%s") {
-      ... on Blob {
-        text
-      }
-    }
-  }
-  right: repository(owner: "%s", name: "%s") {
-    object(expression: "%s:%s") {
-      ... on Blob {
-        text
-      }
-    }
-  }
-}
-]]
-
 M.file_content_query =
   [[
 query {

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -250,6 +250,13 @@ end
 
 function M.save_buffer()
   local bufnr = api.nvim_get_current_buf()
+
+  -- for comment buffers, dispatch it to the right module
+  if string.match(api.nvim_buf_get_name(bufnr), "octo://.+/.+/%d+/comment/.*") then
+    require"octo.reviews".save_review_comment()
+    return
+  end
+
   local ft = api.nvim_buf_get_option(bufnr, "filetype")
   local repo, number = util.get_repo_number({"octo_issue", "octo_reviewthread"})
   if not repo then
@@ -607,51 +614,6 @@ function M.apply_buffer_mappings(bufnr, kind)
       [[<cmd>lua require'octo.commands'.reaction_action('add', 'confused')<CR>]],
       mapping_opts
     )
-  end
-end
-
-M.win_opts = {}
-
-function M.restore_win_opts()
-  -- called when leaving an octo buffer to restore the win opts used outside octo
-  local win_id = api.nvim_get_current_win()
-  if vim.tbl_contains(vim.tbl_keys(M.win_opts), win_id) then
-    vim.wo[win_id].number = M.win_opts[win_id].number
-    vim.wo[win_id].relativenumber = M.win_opts[win_id].relativenumber
-    vim.wo[win_id].cursorline = M.win_opts[win_id].cursorline
-    vim.wo[win_id].signcolumn = M.win_opts[win_id].signcolumn
-    vim.wo[win_id].foldcolumn = M.win_opts[win_id].foldcolumn
-    vim.wo[win_id].wrap = M.win_opts[win_id].wrap
-  end
-end
-
-function M.set_octo_win_opts()
-  -- called when entering an octo buffer
-  M.save_win_opts()
-
-  local win_id = api.nvim_get_current_win()
-  if vim.tbl_contains(vim.tbl_keys(M.win_opts), win_id) then
-    vim.wo[win_id].number = false
-    vim.wo[win_id].relativenumber = false
-    vim.wo[win_id].cursorline = false
-    vim.wo[win_id].signcolumn = "yes"
-    vim.wo[win_id].foldcolumn = "1"
-    vim.wo[win_id].wrap = true
-  end
-end
-
-function M.save_win_opts()
-  -- called when entering an octo buffer for the first time in a given window
-  local win_id = api.nvim_get_current_win()
-  if not vim.tbl_contains(vim.tbl_keys(M.win_opts), win_id) then
-    M.win_opts[win_id] = {
-      number = vim.wo[win_id].number,
-      relativenumber = vim.wo[win_id].relativenumber,
-      cursorline = vim.wo[win_id].cursorline,
-      signcolumn = vim.wo[win_id].signcolumn,
-      foldcolumn = vim.wo[win_id].foldcolumn,
-      wrap = vim.wo[win_id].wrap,
-    }
   end
 end
 

--- a/lua/octo/menu.lua
+++ b/lua/octo/menu.lua
@@ -368,22 +368,26 @@ function M.changed_files()
   if not repo then
     return
   end
-  -- TODO: graphql
-  local url = format("repos/%s/pulls/%d/files", repo, number)
+
+  -- get list of changed files
+  local owner = vim.split(repo, "/")[1]
+  local name = vim.split(repo, "/")[2]
+  local query = format(graphql.changed_files_query, owner, name, number)
   gh.run(
     {
-      args = {"api", url},
+      args = {"api", "graphql", "--paginate", "-f", format("query=%s", query)},
       cb = function(output, stderr)
         if stderr and not util.is_blank(stderr) then
           api.nvim_err_writeln(stderr)
         elseif output then
           local results = json.parse(output)
+          local files = results.data.repository.pullRequest.files.nodes
           pickers.new(
             {},
             {
               prompt_prefix = "PR Files Changed >",
               finder = finders.new_table {
-                results = results,
+                results = files,
                 entry_maker = entry_maker.gen_from_git_changed_files()
               },
               sorter = conf.generic_sorter({}),

--- a/lua/octo/menu.lua
+++ b/lua/octo/menu.lua
@@ -368,26 +368,21 @@ function M.changed_files()
   if not repo then
     return
   end
-
-  -- get list of changed files
-  local owner = vim.split(repo, "/")[1]
-  local name = vim.split(repo, "/")[2]
-  local query = format(graphql.changed_files_query, owner, name, number)
+  local url = format("repos/%s/pulls/%d/files", repo, number)
   gh.run(
     {
-      args = {"api", "graphql", "--paginate", "-f", format("query=%s", query)},
+      args = {"api", url},
       cb = function(output, stderr)
         if stderr and not util.is_blank(stderr) then
           api.nvim_err_writeln(stderr)
         elseif output then
           local results = json.parse(output)
-          local files = results.data.repository.pullRequest.files.nodes
           pickers.new(
             {},
             {
               prompt_prefix = "PR Files Changed >",
               finder = finders.new_table {
-                results = files,
+                results = results,
                 entry_maker = entry_maker.gen_from_git_changed_files()
               },
               sorter = conf.generic_sorter({}),

--- a/lua/octo/menu.lua
+++ b/lua/octo/menu.lua
@@ -588,7 +588,7 @@ function M.review_comments()
       previewer = previewers.review_comment.new({}),
       attach_mappings = function()
 
-        -- TODO: delete comment
+        -- TODO: add action to delete comment
 
         actions.select_default:replace(function(prompt_bufnr)
           local comment = action_state.get_selected_entry(prompt_bufnr).comment

--- a/lua/octo/previewers.lua
+++ b/lua/octo/previewers.lua
@@ -172,8 +172,10 @@ M.changed_files =
       define_preview = function(self, entry)
         if self.state.bufname ~= entry.value or api.nvim_buf_line_count(self.state.bufnr) == 1 then
           local diff = entry.change.patch
-          api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, vim.split(diff, "\n"))
-          api.nvim_buf_set_option(self.state.bufnr, "filetype", "diff")
+          if diff then
+            api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, vim.split(diff, "\n"))
+            api.nvim_buf_set_option(self.state.bufnr, "filetype", "diff")
+          end
         end
       end
     }

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -177,7 +177,7 @@ function M.diff_changes_qf_entry()
       qf_winid = qf.winid,
       path = qf.items[qf.idx].module,
       bufname = left_bufname,
-      fugitive_bufnr = left_bufnr,
+      content_bufnr = left_bufnr,
       hunks = valid_hunks,
       ranges = valid_left_ranges,
     }
@@ -188,7 +188,7 @@ function M.diff_changes_qf_entry()
       qf_winid = qf.winid,
       path = qf.items[qf.idx].module,
       bufname = right_bufname,
-      fugitive_bufnr = right_bufnr,
+      content_bufnr = right_bufnr,
       hunks = valid_hunks,
       ranges = valid_right_ranges,
     }
@@ -223,7 +223,7 @@ function M.add_review_comment(isSuggestion)
     end
 
     -- create new buffer
-    local bufname = format("octo_comment://%s.%d.%d", string.gsub(props.bufname, "fugitive://", ""), line1, line2)
+    local bufname = format("octo_comment://%s.%d.%d", string.gsub(props.bufname, "octo://", ""), line1, line2)
     local comment_bufnr
     if vim.fn.bufnr(bufname) > -1 then
       comment_bufnr = vim.fn.bufnr(bufname)
@@ -266,7 +266,7 @@ function M.add_review_comment(isSuggestion)
     api.nvim_buf_set_virtual_text(comment_bufnr, constants.OCTO_TITLE_VT_NS, 0, header_vt, {})
 
     if isSuggestion then
-      local lines = api.nvim_buf_get_lines(props.fugitive_bufnr, line1-1, line2, false)
+      local lines = api.nvim_buf_get_lines(props.content_bufnr, line1-1, line2, false)
       writers.write_block({"```suggestion"}, {bufnr = comment_bufnr, mark = false})
       writers.write_block(lines, {bufnr = comment_bufnr, mark = false})
       writers.write_block({"```"}, {bufnr = comment_bufnr, mark = false})
@@ -289,7 +289,7 @@ function M.add_review_comment(isSuggestion)
       qf_winid = props.qf_winid,
       comment_bufnr = comment_bufnr,
       comment_winid = comment_winid,
-      fugitive_bufnr = bufnr,
+      content_bufnr = bufnr,
       line1 = line1,
       line2 = line2,
       body = ""
@@ -323,7 +323,7 @@ function M.save_review_comment()
     api.nvim_buf_set_option(bufnr, "modified", false)
 
     -- highlight commented lines
-    M.highlight_lines(comment.fugitive_bufnr, comment.line1, comment.line2)
+    M.highlight_lines(comment.content_bufnr, comment.line1, comment.line2)
   end
 end
 

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -114,7 +114,7 @@ function M.diff_changes_qf_entry()
     end
 
     -- prepare left buffer
-    local left_bufname = format("octo://%s/%s/file/%s/%s", owner, name, left_sha:sub(0,7), path)
+    local left_bufname = format("octo://%s/%s/pull/%d/file/%s/%s", owner, name, qf.context.pull_request_number, left_sha:sub(0,7), path)
     local left_bufnr = vim.fn.bufnr(left_bufname)
     if left_bufnr == -1 then
       left_bufnr = api.nvim_create_buf(false, true)
@@ -124,7 +124,7 @@ function M.diff_changes_qf_entry()
     end
 
     -- prepare right buffer
-    local right_bufname = format("octo://%s/%s/file/%s/%s", owner, name, right_sha:sub(0,8), path)
+    local right_bufname = format("octo://%s/%s/pull/%d/file/%s/%s", owner, name, qf.context.pull_request_number, right_sha:sub(0,7), path)
     local right_bufnr = vim.fn.bufnr(right_bufname)
     if right_bufnr == -1 then
       right_bufnr = api.nvim_create_buf(false, true)
@@ -136,18 +136,16 @@ function M.diff_changes_qf_entry()
     -- configure right win
     api.nvim_set_current_win(main_win)
     api.nvim_win_set_buf(main_win, right_bufnr)
-    api.nvim_win_set_option(main_win, "number", true)
-    api.nvim_win_set_option(main_win, "wrap", true)
     M.add_changes_qf_mappings()
-    vim.cmd('filetype detect')
+    vim.cmd [[filetype detect]]
+    vim.cmd [[doau BufEnter]]
     vim.cmd [[diffthis]]
 
     -- configure left win
     vim.cmd(format("leftabove vert sbuffer %d", left_bufnr))
-    api.nvim_win_set_option(0, "number", true)
-    api.nvim_win_set_option(0, "wrap", true)
     M.add_changes_qf_mappings()
-    vim.cmd('filetype detect')
+    vim.cmd [[filetype detect]]
+    vim.cmd [[doau BufEnter]]
     vim.cmd [[diffthis]]
 
     -- move to first chunk
@@ -223,7 +221,7 @@ function M.add_review_comment(isSuggestion)
     end
 
     -- create new buffer
-    local bufname = format("octo_comment://%s.%d.%d", string.gsub(props.bufname, "octo://", ""), line1, line2)
+    local bufname = format("%s:%d.%d", string.gsub(props.bufname, "/file/", "/comment/"), line1, line2)
     local comment_bufnr
     if vim.fn.bufnr(bufname) > -1 then
       comment_bufnr = vim.fn.bufnr(bufname)

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -106,6 +106,7 @@ function M.diff_changes_qf_entry()
     left_bufnr = api.nvim_create_buf(false, true)
     api.nvim_buf_set_name(left_bufnr, left_bufname)
     api.nvim_buf_set_lines(left_bufnr, 0, -1, false, {"Loading ..."})
+    api.nvim_buf_set_option(left_bufnr, "modifiable", false)
   end
   api.nvim_buf_set_var(left_bufnr, "OctoDiffProps", {
     side = "LEFT",
@@ -126,6 +127,7 @@ function M.diff_changes_qf_entry()
     right_bufnr = api.nvim_create_buf(false, true)
     api.nvim_buf_set_name(right_bufnr, right_bufname)
     api.nvim_buf_set_lines(right_bufnr, 0, -1, false, {"Loading ..."})
+    api.nvim_buf_set_option(right_bufnr, "modifiable", false)
   end
   api.nvim_buf_set_var(right_bufnr, "OctoDiffProps", {
     side = "RIGHT",
@@ -157,6 +159,7 @@ function M.diff_changes_qf_entry()
     -- load left content
     util.get_file_contents(repo, left_sha, path, function(lines)
       M.review_files[path].left_lines = lines
+      api.nvim_buf_set_option(left_bufnr, "modifiable", true)
       api.nvim_buf_set_lines(left_bufnr, 0, -1, false, lines)
       api.nvim_buf_set_option(left_bufnr, "modifiable", false)
 
@@ -170,6 +173,7 @@ function M.diff_changes_qf_entry()
     -- load right content
     util.get_file_contents(repo, right_sha, path, function(lines)
       M.review_files[path].right_lines = lines
+      api.nvim_buf_set_option(right_bufnr, "modifiable", true)
       api.nvim_buf_set_lines(right_bufnr, 0, -1, false, lines)
       api.nvim_buf_set_option(right_bufnr, "modifiable", false)
 

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -64,7 +64,7 @@ end
 function M.diff_changes_qf_entry()
   -- cleanup content buffers and windows
   vim.cmd [[cclose]]
-  vim.cmd [[only]]
+  vim.cmd [[silent! only]]
 
   -- local main_win = M.get_main_win()
   local main_win = api.nvim_get_current_win()
@@ -143,7 +143,7 @@ function M.diff_changes_qf_entry()
     vim.cmd [[diffthis]]
 
     -- configure left win
-    vim.cmd(format("vert sbuffer %d", left_bufnr))
+    vim.cmd(format("leftabove vert sbuffer %d", left_bufnr))
     api.nvim_win_set_option(0, "number", true)
     api.nvim_win_set_option(0, "wrap", true)
     M.add_changes_qf_mappings()
@@ -281,7 +281,7 @@ function M.add_review_comment(isSuggestion)
     -- create new comment
     local comment = {
       key = bufname,
-      path = vim.split(props.path, ":")[2],
+      path =props.path,
       side = props.side,
       diff_hunk = diff_hunk,
       sha = props.sha,
@@ -626,7 +626,7 @@ function M.prev_comment(repo, number, main_win)
 end
 
 function M.close_review_tab()
-  vim.cmd [[tabclose]]
+  vim.cmd [[silent! tabclose]]
 
   -- close fugitive buffers
   --M.clean_fugitive_buffers()

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -8,9 +8,6 @@ local graphql = require "octo.graphql"
 local format = string.format
 local vim = vim
 local api = vim.api
-local json = {
-  parse = vim.fn.json_decode
-}
 
 local M = {}
 

--- a/lua/octo/util.lua
+++ b/lua/octo/util.lua
@@ -439,4 +439,15 @@ function M.get_file_contents(repo, commit, path, cb)
    )
 end
 
+function M.set_timeout(delay, callback, ...)
+  local timer = vim.loop.new_timer()
+  local args = {...}
+  vim.loop.timer_start(timer, delay, 0, function ()
+    vim.loop.timer_stop(timer)
+    vim.loop.close(timer)
+    callback(unpack(args))
+  end)
+  return timer
+end
+
 return M

--- a/plugin/octo.vim
+++ b/plugin/octo.vim
@@ -60,14 +60,20 @@ function! octo#issue_complete(findstart, base) abort
 endfunction
 
 " autocommands
+function s:configure_octo_buffer() abort
+  if match(bufname(), "octo://.\\+/.\\+/pull/\\d\\+/file/") == -1
+    setlocal omnifunc=octo#issue_complete
+    setlocal nonumber norelativenumber nocursorline wrap
+    setlocal foldcolumn=1
+    setlocal signcolumn=yes
+  end
+endfunction
+
 augroup octo_autocmds
 au!
-au BufEnter octo://* setlocal omnifunc=octo#issue_complete
-"au BufEnter octo://* lua require"octo".set_octo_win_opts()
-"au BufLeave octo://* lua require"octo".restore_win_opts()
+au BufEnter octo://* call s:configure_octo_buffer()
 au BufReadCmd octo://* lua require'octo'.load_buffer()
 au BufWriteCmd octo://* lua require'octo'.save_buffer()
-au BufWriteCmd octo_comment://* lua require'octo.reviews'.save_review_comment()
 augroup END
 
 " sign definitions

--- a/plugin/octo.vim
+++ b/plugin/octo.vim
@@ -3,21 +3,33 @@ if exists('g:loaded_octo')
 endif
 
 " colors
-let g:octo_bubble_color = synIDattr(synIDtrans(hlID("NormalFloat")), "bg#")
-let g:octo_bubble_green = synIDattr(synIDtrans(hlID("DiffAdd")), "fg#")
-let g:octo_bubble_red = synIDattr(synIDtrans(hlID("DiffDelete")), "fg#")
-if get(g:, 'octo_bubble_color', '') != '' && get(g:, 'octo_bubble_green', '') != '' && get(g:, 'octo_bubble_red', '') != ''
-  execute('hi! OctoNvimBubbleDelimiter guifg='.g:octo_bubble_color)
-  execute('hi! OctoNvimBubbleBody guibg='.g:octo_bubble_color)
-  execute('hi! OctoNvimBubbleRed guifg='.g:octo_bubble_red.' guibg='.g:octo_bubble_color)
-  execute('hi! OctoNvimBubbleGreen guifg='.g:octo_bubble_green.' guibg='.g:octo_bubble_color)
-  execute('hi! OctoNvimDiffHunkPosition guibg='.g:octo_bubble_color)
+let g:octo_color_bubble_bg = synIDattr(synIDtrans(hlID("NormalFloat")), "bg#")
+let g:octo_color_green = synIDattr(synIDtrans(hlID("DiffAdd")), "fg#")
+let g:octo_color_blue = synIDattr(synIDtrans(hlID("DiffChange")), "fg#")
+let g:octo_color_red = synIDattr(synIDtrans(hlID("DiffDelete")), "fg#")
+
+if get(g:, 'octo_color_bubble_bg', '') != '' && get(g:, 'octo_color_green', '') != '' && get(g:, 'octo_color_red', '') != ''
+
+  " Bubble colors
+  execute('hi! OctoNvimBubbleDelimiter guifg='.g:octo_color_bubble_bg)
+  execute('hi! OctoNvimBubbleBody guibg='.g:octo_color_bubble_bg)
+  execute('hi! OctoNvimBubbleRed guifg='.g:octo_color_red.' guibg='.g:octo_color_bubble_bg)
+  execute('hi! OctoNvimBubbleGreen guifg='.g:octo_color_green.' guibg='.g:octo_color_bubble_bg)
+
+  " Hunks
+  execute('hi! OctoNvimDiffHunkPosition guibg='.g:octo_color_bubble_bg)
+
+  " Commented lines
   execute('hi! link OctoNvimCommentLine Visual')
-  execute('hi! link OctoNvimPassingTest DiffAdd')
-  execute('hi! link OctoNvimFailingTest DiffDelete')
-  execute('hi! link OctoNvimPullAdditions DiffAdd')
-  execute('hi! link OctoNvimPullDeletions DiffDelete')
-  execute('hi! link OctoNvimPullModifications DiffChange')
+
+  " Tests
+  execute('hi! OctoNvimPassingTest guifg='.g:octo_color_green)
+  execute('hi! OctoNvimFailingTest guifg='.g:octo_color_red)
+
+  " PR changes
+  execute('hi! OctoNvimPullAdditions guifg='.g:octo_color_green)
+  execute('hi! OctoNvimPullDeletions guifg='.g:octo_color_red)
+  execute('hi! OctoNvimPullModifications guifg='.g:octo_color_blue)
 endif
 
 function! s:command_complete(...)
@@ -51,8 +63,8 @@ endfunction
 augroup octo_autocmds
 au!
 au BufEnter octo://* setlocal omnifunc=octo#issue_complete
-au BufEnter octo://* lua require"octo".set_octo_win_opts()
-au BufLeave octo://* lua require"octo".restore_win_opts()
+"au BufEnter octo://* lua require"octo".set_octo_win_opts()
+"au BufLeave octo://* lua require"octo".restore_win_opts()
 au BufReadCmd octo://* lua require'octo'.load_buffer()
 au BufWriteCmd octo://* lua require'octo'.save_buffer()
 au BufWriteCmd octo_comment://* lua require'octo.reviews'.save_review_comment()


### PR DESCRIPTION
Addresses #93 
Get rid of fugitive requirement and get file contents from GitHub API enabling online PR reviews that do not require to have repos locally

- [x] Load all changed files asynchronously as soon as possible
- [ ] For `Octo review start` load left/base from GitHub and use local file for right/head when available or load it from GitHub when local file is not available
- [ ] For `Octo review threads` always load files from GitHub so we can see the exact same commit the comments were place into
- [x] Make all file content loading async
- [x] ~Consider using Telescope instead of the QF window~
- [x] Rename `Octo pr reviews` to ~`Octo review view`~ `Octo review threads`