### PR TITLE
add folds for comments

### DIFF
--- a/lua/octo/folds.lua
+++ b/lua/octo/folds.lua
@@ -1,0 +1,3 @@
+function _G.OctoFoldText()
+  return "..."
+end

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -148,6 +148,8 @@ function M.create_buffer(type, obj, repo, create)
     bufnr = api.nvim_get_current_buf()
   end
 
+  api.nvim_set_current_buf(bufnr)
+
   -- clear buffer
   api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
 
@@ -159,6 +161,12 @@ function M.create_buffer(type, obj, repo, create)
   -- configure buffer
   api.nvim_buf_set_option(bufnr, "filetype", "octo_issue")
   api.nvim_buf_set_option(bufnr, "buftype", "acwrite")
+  vim.cmd [[setlocal fillchars=fold:⠀,foldopen:⠀,foldclose:⠀,foldsep:⠀]]
+  vim.cmd [[setlocal foldtext=v:lua.OctoFoldText()]]
+  vim.cmd [[setlocal foldmethod=manual]]
+  vim.cmd [[setlocal foldenable]]
+  vim.cmd [[setlocal foldcolumn=1]]
+  vim.cmd [[setlocal foldlevelstart=99]]
 
   -- register issue
   api.nvim_buf_set_var(bufnr, "iid", iid)

--- a/lua/octo/writers.lua
+++ b/lua/octo/writers.lua
@@ -342,6 +342,7 @@ function M.write_details(bufnr, issue, update)
 end
 
 function M.write_comment(bufnr, comment, line)
+
   -- heading
   line = line or api.nvim_buf_line_count(bufnr) + 1
   M.write_block({"", ""}, {bufnr = bufnr, mark = false, line = line})
@@ -360,8 +361,10 @@ function M.write_comment(bufnr, comment, line)
 
   local comment_vt_ns = api.nvim_buf_set_virtual_text(bufnr, 0, line - 1, header_vt, {})
 
+  local fold_start_line = line + 2
+
   -- body
-  line = line + 2
+  line = fold_start_line
   local comment_body = string.gsub(comment.body, "\r\n", "\n")
   if vim.startswith(comment_body, constants.NO_BODY_MSG) or util.is_blank(comment_body) then
     comment_body = " "
@@ -396,6 +399,11 @@ function M.write_comment(bufnr, comment, line)
     }
   )
   api.nvim_buf_set_var(bufnr, "comments", comments_metadata)
+
+  -- add fold
+  vim.cmd(format("%d,%dfold", fold_start_line - 1, line))
+  vim.cmd(format("%d,%dfoldopen!", fold_start_line - 1, line))
+
 end
 
 function M.write_diff_hunk(bufnr, diff_hunk, start_line)

--- a/plugin/octo.vim
+++ b/plugin/octo.vim
@@ -79,6 +79,9 @@ augroup END
 " sign definitions
 lua require'octo.signs'.setup()
 
+" folds
+lua require'octo.folds'
+
 " logged-in user
 if !exists("g:octo_loggedin_user")
   let g:octo_loggedin_user = v:null


### PR DESCRIPTION
Add manual folds for comments. By default all comments are unfolded.
Use `zc`/`zo` to close/open a fold, `zM`/`zR` to close/open all folds, etc.
