### PR TITLE
Feature/highlight owned comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ Just edit the issue title, description or comments as a regular buffer and use `
 | `OctoNvimPullAdditions`     | `DiffAdd`        |
 | `OctoNvimPullDeletions`     | `DiffDelete`     |
 | `OctoNvimPullModifications` | `DiffChange`     |
-| `OctoNvimEditable`          | `NormalFloat`.bg|
+| `OctoNvimEditable`          | `NormalFloat`.bg |
+| `OctoNvimOwned`             | `PmenuSel`       |
 
 ## Settings
 

--- a/after/syntax/octo_issue.vim
+++ b/after/syntax/octo_issue.vim
@@ -19,6 +19,7 @@ hi def link OctoNvimDate Comment
 hi def link OctoNvimDetailsLabel Title 
 hi def link OctoNvimDetailsValue Identifier
 hi def link OctoNvimMissingDetails Comment
+hi def link OctoNvimOwned PmenuSel
 
 call matchadd('Conceal', ':heart:', 10, -1, {'conceal':'❤️'})
 call matchadd('Conceal', ':+1:', 10, -1, {'conceal':'👍'})

--- a/lua/octo/constants.lua
+++ b/lua/octo/constants.lua
@@ -3,6 +3,7 @@ local api = vim.api
 local M = {}
 
 M.OCTO_COMMENT_NS = api.nvim_create_namespace("octo_marks")
+M.OCTO_HEADER_NS = api.nvim_create_namespace("octo_header_marks")
 M.OCTO_TITLE_VT_NS = api.nvim_create_namespace("octo_title_vt")
 M.OCTO_REACTIONS_VT_NS = api.nvim_create_namespace("octo_reactions_vt")
 M.OCTO_DETAILS_VT_NS = api.nvim_create_namespace("octo_details_vt")

--- a/lua/octo/graphql.lua
+++ b/lua/octo/graphql.lua
@@ -240,6 +240,7 @@ M.create_issue_mutation =
             author {
               login
             }
+            viewerDidAuthor
           }
         }
         labels(first: 20) {
@@ -322,6 +323,7 @@ M.update_issue_state_mutation =
             author {
               login
             }
+            viewerDidAuthor
           }
         }
         labels(first: 20) {
@@ -421,6 +423,7 @@ M.update_pull_request_state_mutation =
             author {
               login
             }
+            viewerDidAuthor
           }
         }
         labels(first: 20) {
@@ -483,6 +486,7 @@ query($endCursor: String) {
               replyTo { id }
               author { login }
               authorAssociation
+              viewerDidAuthor
               outdated
               diffHunk
               reactionGroups {
@@ -624,6 +628,7 @@ query($endCursor: String) {
             author {
               login
             }
+            viewerDidAuthor
           }
           ... on PullRequestReview {
             id
@@ -638,6 +643,7 @@ query($endCursor: String) {
             author {
               login
             }
+            viewerDidAuthor
             state
             comments(last:100) {
               totalCount
@@ -652,6 +658,7 @@ query($endCursor: String) {
                 }
                 author { login }
                 authorAssociation
+                viewerDidAuthor
                 originalPosition
                 position
                 state
@@ -693,6 +700,7 @@ query($endCursor: String) {
               }
               author { login }
               authorAssociation
+              viewerDidAuthor
               outdated
               diffHunk
               reactionGroups {
@@ -757,6 +765,7 @@ query($endCursor: String) {
       author {
         login
       }
+      viewerDidAuthor
       participants(first:10) {
         nodes {
           login
@@ -800,6 +809,7 @@ query($endCursor: String) {
             author {
               login
             }
+            viewerDidAuthor
           }
           ... on ClosedEvent {
             createdAt

--- a/lua/octo/signs.lua
+++ b/lua/octo/signs.lua
@@ -86,6 +86,10 @@ function M.render_signcolumn(bufnr)
     end_line = c["end_line"]
     M.place_signs(bufnr, start_line, end_line, c.dirty)
 
+    if c.owned then
+      M.place("octo_owned", bufnr, c.header_line)
+    end
+
     -- comment virtual text
     if util.is_blank(c["body"]) then
       local comment_vt = {{constants.NO_BODY_MSG, "OctoNvimEmpty"}}

--- a/lua/octo/util.lua
+++ b/lua/octo/util.lua
@@ -180,7 +180,7 @@ function M.update_metadata(metadata, start_line, end_line, text)
 end
 
 function M.update_issue_metadata(bufnr)
-  local mark, text, start_line, end_line, metadata
+  local header_mark, body_mark, text, header_line, start_line, end_line, metadata
 
   local ft = api.nvim_buf_get_option(bufnr, "filetype")
   if ft == "octo_issue" then
@@ -209,8 +209,10 @@ function M.update_issue_metadata(bufnr)
   local comments = api.nvim_buf_get_var(bufnr, "comments")
   for i, m in ipairs(comments) do
     metadata = m
-    mark = api.nvim_buf_get_extmark_by_id(bufnr, constants.OCTO_COMMENT_NS, metadata.extmark, {details = true})
-    start_line, end_line, text = M.get_extmark_region(bufnr, mark)
+    header_mark = api.nvim_buf_get_extmark_by_id(bufnr, constants.OCTO_HEADER_NS, metadata.header_mark, {details = true})
+    body_mark = api.nvim_buf_get_extmark_by_id(bufnr, constants.OCTO_COMMENT_NS, metadata.extmark, {details = true})
+    header_line = header_mark[1]
+    start_line, end_line, text = M.get_extmark_region(bufnr, body_mark)
 
     if text == "" then
       -- comment has been removed
@@ -220,6 +222,7 @@ function M.update_issue_metadata(bufnr)
     end
 
     M.update_metadata(metadata, start_line, end_line, text)
+    metadata["header_line"] = header_line
     comments[i] = metadata
   end
   api.nvim_buf_set_var(bufnr, "comments", comments)

--- a/lua/octo/writers.lua
+++ b/lua/octo/writers.lua
@@ -370,6 +370,7 @@ function M.write_comment(bufnr, comment, kind, line)
   end
   local comment_vt_ns = api.nvim_create_namespace("")
   M.write_virtual_text(bufnr, comment_vt_ns, line - 1, header_vt)
+  local header_mark = api.nvim_buf_set_extmark(bufnr, constants.OCTO_HEADER_NS, line - 1, 0, { end_line = line })
 
   if kind == "PullRequestReview" and util.is_blank(comment.body) then
     -- do not render empty review comments
@@ -400,12 +401,14 @@ function M.write_comment(bufnr, comment, kind, line)
       dirty = false,
       saved_body = comment_body,
       body = comment_body,
+      header_mark = header_mark,
       extmark = comment_mark,
       namespace = comment_vt_ns,
       reaction_line = reaction_line,
       reaction_groups = comment.reactionGroups,
       kind = kind,
       first_comment_id = comment.first_comment_id,
+      owned = comment.viewerDidAuthor,
     }
   )
   api.nvim_buf_set_var(bufnr, "comments", comments_metadata)

--- a/plugin/octo.vim
+++ b/plugin/octo.vim
@@ -97,6 +97,7 @@ sign define octo_dirty_block_middle text=│ texthl=OctoNvimDirty linehl=OctoNvi
 sign define octo_clean_block_middle text=│ linehl=OctoNvimEditable
 sign define octo_clean_line text=[ linehl=OctoNvimEditable
 sign define octo_dirty_line text=[ texthl=OctoNvimDirty linehl=OctoNvimEditable
+sign define octo_owned linehl=OctoNvimOwned
 
 " folds
 lua require'octo.folds'


### PR DESCRIPTION
Closes: #115 (only for comments yet)

It is working... But there the positives things end. I'm not too happy with it. The visual experience is okayish, depending on the users colorscheme/highlight customizations. The naming of something is "owned" sounds a bit stupid, but I fail to come up with a better name for it. The GitHub API names this property `viewerDidAuthor`... :shrug: 
I tried to work along all the mechanism you have already established and just extend them. But some things do not really match (e.g. the `update_metadata` function). But I don't wanted to touch/refactor the surrounding code. Though it feels like a foreign piece. :expressionless: 
Looking forward to get constructive feedback that helps me to improve. :upside_down_face: 

PS: I have the implementation to highlight reactions the user has "participated" kinda ready. But it sucks in regards of the highlight group usage. I need to check how this can be improved in general.