### PR TITLE
add Github Enterprise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ The (addition) `viewer` means the user of the plugin or more precisely the user 
 - `g:octo_icon_user`: Icon used to signal user names (default: "")
 - `g:octo_icon_reaction_viewer_hint`: Icon as alternative or to complement the highlighting of reactions by the viewer himself (default: "")
 - `g:octo_snippet_context_lines`: Number of additional lines displayed from the diff-hunk for single-line comments (default: 3)
+- `g:octo_github_hostname`: Hostname to use for non-public, GHE (GitHub Enterprise) instances (default: null).
 
 ## FAQ
 

--- a/lua/octo/constants.lua
+++ b/lua/octo/constants.lua
@@ -20,7 +20,13 @@ M.NO_BODY_MSG = "No description provided."
 
 M.LONG_ISSUE_PATTERN = "%s([^/]+/[^#]+)#(%d+)%s"
 M.SHORT_ISSUE_PATTERN = "%s#(%d+)%s"
-M.URL_ISSUE_PATTERN = "[htps]+://.*github.com/([^/]+/[^/]+)/([pulisue]+)/(%d+)"
+local github_hostname = "" 
+if vim.g.octo_github_hostname then
+    github_hostname = vim.g.octo_github_hostname
+else
+    github_hostname = "github.com"
+end
+M.URL_ISSUE_PATTERN = ("[htps]+://.*" .. github_hostname .. "/([^/]+/[^/]+)/([pulisue]+)/(%d+)")
 
 M.USER_PATTERN = "@(%S+)"
 

--- a/lua/octo/gh.lua
+++ b/lua/octo/gh.lua
@@ -8,6 +8,10 @@ local function run(opts)
   if opts.args[1] == "api" then
     table.insert(opts.args, "-H")
     table.insert(opts.args, "Accept: application/vnd.github.v3+json;application/vnd.github.squirrel-girl-preview+json;application/vnd.github.comfort-fade-preview+json")
+    if vim.g.octo_github_hostname then
+      table.insert(opts.args, "--hostname")
+      table.insert(opts.args, vim.g.octo_github_hostname)
+    end
   end
 
   if opts.headers then


### PR DESCRIPTION
This PR adds basic support for Github Enterprise instances.
I briefly tested with the instance I have and the 'PR' and 'Issues" functions work as expected.
Gists do not, due to [underlying bug in GH CLI](https://github.com/cli/cli/issues/1745), there is a relatively easy [workaround available](https://github.com/cli/cli/issues/1745#issuecomment-694377743).

In fact, setting `GH_HOST` environment variable kinda renders this pull request useless because it makes the PR/issue commands work out of the box too so I would like to get your input/preferences on this.