### PR TITLE
Default pr list to open prs

### DIFF
--- a/lua/octo/menu.lua
+++ b/lua/octo/menu.lua
@@ -257,6 +257,10 @@ end
 
 function M.pull_requests(opts)
   opts = opts or {}
+  if not opts.states then
+    opts.states = "OPEN"
+  end
+
   local filter = get_filter(opts, "pull_request")
 
   if not opts.repo or opts.repo == vim.NIL then

--- a/lua/octo/menu.lua
+++ b/lua/octo/menu.lua
@@ -58,6 +58,8 @@ local function get_filter(opts, kind)
       val = json.stringify(val)
       val = string.gsub(val, '"OPEN"', "OPEN")
       val = string.gsub(val, '"CLOSED"', "CLOSED")
+      val = string.gsub(val, '"MERGED"', "MERGED")
+      val = string.gsub(val, '"ALL"', "ALL")
       filter = filter .. value .. ":" .. val .. ","
     end
   end

--- a/lua/octo/menu.lua
+++ b/lua/octo/menu.lua
@@ -59,7 +59,6 @@ local function get_filter(opts, kind)
       val = string.gsub(val, '"OPEN"', "OPEN")
       val = string.gsub(val, '"CLOSED"', "CLOSED")
       val = string.gsub(val, '"MERGED"', "MERGED")
-      val = string.gsub(val, '"ALL"', "ALL")
       filter = filter .. value .. ":" .. val .. ","
     end
   end


### PR DESCRIPTION

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Problem: In a production environment, it's common to have 1000s of PRs and unless I use a browser, I'm not going to know what is currently open and what is not. It's tedious to always type `Octo pr list states=OPEN`

Solution: default the state argument to "OPEN" - this matches the behavior of the gh-cli's `gh pr list` https://cli.github.com/manual/gh_pr_list

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
Added a default for `opts.states` in `menu.pull_requests`

### Describe how to verify it

1. Open vim
2. Run `Octo pr list` to verify that open works
3. Run `Octo pr list states=CLOSED` to verify that closed works
4. Run `Octo pr list states=MERGED` to verify that merged works

### Special notes for reviews

