### PR TITLE
feature/review refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There is only an `Octo <object> <action> [arguments]` command:
 | | edit | [repo] <number> |
 | | list | [repo] [key=value]*<br>[Available keys](https://docs.github.com/en/free-pro-team@latest/graphql/reference/input-objects#issuefilters)<br>Mappings:<br>`<CR>`: Edit issue<br>`<C-b>`: Opens issue in web browser |
 | | search | |
-| | reload | |
+| | reload | same as doing `e!`|
 | | browser | |
 | pr | list | [repo] [key=value]<br>[Available keys](https://docs.github.com/en/free-pro-team@latest/graphql/reference/input-objects#issuefilters)<br>Mappings:<br>`<CR>`: Edit PR<br>`<C-b>`: Opens PR in web browser<br>`<C-o>`: Checkout PR |
 | | search | |
@@ -56,7 +56,7 @@ There is only an `Octo <object> <action> [arguments]` command:
 | | merge | [commit\|rebase\|squash] [delete] |
 | | ready| |
 | | checks | |
-| | reload | |
+| | reload | same as doing `e!`|
 | | browser | |
 | gist | list | [repo] [key=value]*<br>[Available keys](https://cli.github.com/manual/gh_gist_list):  `repo`\|`public`\|`secret`<br>Mappings:<br>`<CR>`: Append Gist to buffer<br>`<C-b>`: Opens Gist in web browser |
 | comment | add | |
@@ -84,7 +84,6 @@ There is only an `Octo <object> <action> [arguments]` command:
 | | resume| Edit a pending review for current PR |
 | | discard| Deletes a pending review for current PR if any |
 | | comments| View pending review comments |
-| | threads | View all review threads (comment+replies)|
 
 * If repo is not provided, it will be derived from `<cwd>/.git/config`.
 
@@ -114,39 +113,16 @@ Just edit the issue title, description or comments as a regular buffer and use `
 - Change quickfix entries with `]q` and `[q` or by selecting an entry in the quickfix window
 - Add comments with `<space>ca` or `:OctoAddReviewComment` on single or multiple lines
 - Add suggestions with `<space>sa` or `:OctoAddReviewSuggestion` on single or multiple lines
-- Edit comments/suggestions with `<space>ce`
-- A new split will open. Enter the comment and save it (`:w`). Optionally close the split
-
-![](https://i.imgur.com/l9z4tpg.png)
-
+- Edit/Delete comments as you would normally do in an Issue or PR buffer
 - Add as many comments as needed
 - Review comments with `Octo review comments`
   - Use <CR> to jump to the selected comment
-  - Use <c-e> to edit the selected comment
-  - Use <c-d> to delete the selected comment
-
-![](https://i.imgur.com/2DKPZq9.png)
-
-- When ready submit the review with `Octo review submit`
+- When ready, submit the review with `Octo review submit`
 - A new float window will pop up. Enter the top level review comment and exit to normal mode. Then press `<C-m>` to submit a comment, `<C-a>` to approve it or `<C-r>` to request changes
-
-![](https://i.imgur.com/aRHqIhg.png)
-
-## Viewing PR Reviews
-
-![](https://camo.githubusercontent.com/97aaf7efe7c8ff45cbc4359f28339fd9f9dd7ba3609fbd14b0649a979af15431/68747470733a2f2f692e696d6775722e636f6d2f71495a5a6b48342e706e67) 
-
-- Open the PR (eg: `Octo pr list` or `Octo pr edit XXX`)
-- Open review threads view with `Octo review threads`
-- Quickfix will be populated with the changed files 
-- Change quickfix entries with `]q` and `[q` or by selecting an entry in the quickfix window
-- Jump between comments with `]c` and `[c`
-- You can reply to a comment, delete them, add/remove reactions, etc. as if you where in an Octo issue buffer
 
 ## Completion
 - Issue/PR id completion (#)
 - User completion (@)
-
 
 ## Mappings
 `<Plug>(OctoOpenIssueAtCursor)`: Open issue/pr at cursor with Octo

--- a/README.md
+++ b/README.md
@@ -109,14 +109,17 @@ Just edit the issue title, description or comments as a regular buffer and use `
 ## PR review
 - Open the PR (eg: `Octo pr list` or `Octo pr edit XXX`)
 - Start a review with `Octo review start` or resume a pending review with `Octo review resume`
-- Quickfix will be populated with the changed files 
+- Quickfix will be populated with the PR changed files 
 - Change quickfix entries with `]q` and `[q` or by selecting an entry in the quickfix window
-- Add comments with `<space>ca` or `:OctoAddReviewComment` on single or multiple lines
-- Add suggestions with `<space>sa` or `:OctoAddReviewSuggestion` on single or multiple lines
-- Edit/Delete comments as you would normally do in an Issue or PR buffer
-- Add as many comments as needed
-- Review comments with `Octo review comments`
-  - Use <CR> to jump to the selected comment
+- Add comments with `<space>ca` or suggestions with `<space>sa` on single or multiple visual-selected lines
+  - A new buffer will appear in the alternate diff window. Cursor will be positioned in the new buffer
+  - When ready, save the buffer to commit changes to GitHub
+  - Move back to the diff window and move the cursor, the thread buffer will hide
+- Hold the cursor on a line with a comment to show a thread buffer with all the thread comments
+  - To modify, delete, react or reply to a comment, move to the window containing the thread buffer
+  - Perform any operations as if you were in a regular issue buffer 
+- Review pending comments with `Octo review comments`
+  - Use <CR> to jump to the selected pending comment
 - When ready, submit the review with `Octo review submit`
 - A new float window will pop up. Enter the top level review comment and exit to normal mode. Then press `<C-m>` to submit a comment, `<C-a>` to approve it or `<C-r>` to request changes
 

--- a/after/syntax/octo.vim
+++ b/after/syntax/octo.vim
@@ -1,8 +1,14 @@
-" store and remove current syntax value
-if exists('b:current_syntax')
-  let old_syntax = b:current_syntax
-  unlet b:current_syntax
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
 endif
+
+if !exists('main_syntax')
+  let main_syntax = 'octo'
+endif
+
+runtime! syntax/markdown.vim ftplugin/markdown.vim ftplugin/markdown_*.vim ftplugin/markdown/*.vim
+unlet! b:current_syntax
 
 call matchadd('Conceal', ':heart:', 10, -1, {'conceal':'❤️'})
 call matchadd('Conceal', ':+1:', 10, -1, {'conceal':'👍'})
@@ -21,7 +27,7 @@ call matchadd('Conceal', ':man_shrugging:', 10, -1, {'conceal':'🤷'})
 call matchadd('Conceal', ':face_palm:', 10, -1, {'conceal':'🤦'})
 call matchadd('Conceal', ':man_facepalmin:', 10, -1, {'conceal':'🤦'})
 
-" restore current syntax value
-if exists('old_syntax')
-  let b:current_syntax = old_syntax
+let b:current_syntax = "octo"
+if main_syntax ==# 'octo'
+  unlet main_syntax
 endif

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -277,7 +277,7 @@ function M.add_comment()
     viewerCanUpdate = true,
     viewerCanDelete = true,
     viewerDidAuthor = true,
-    pullRequestReview = { id = reviews.getReviewId() },
+    pullRequestReview = { id = reviews.get_review_id() },
     reactionGroups = {
       { content = "THUMBS_UP", users = { totalCount = 0 } },
       { content = "THUMBS_DOWN", users = { totalCount = 0 } },

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -482,16 +482,14 @@ function M.change_state(type, state)
 end
 
 function M.create_issue(repo)
-  if not repo then
-    repo = util.get_remote_name()
-  end
+  if not repo then repo = util.get_remote_name() end
   if not repo then
     print("[Octo] Cant find repo name")
     return
   end
 
   vim.fn.inputsave()
-  local title = vim.fn.input("Enter title: ")
+  local title = vim.fn.input(format("Creating issue in %s. Enter title: ", repo))
   vim.fn.inputrestore()
 
   local repo_id = util.get_repo_id(repo)

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -389,7 +389,6 @@ function M.resolve_thread()
                 isResolved = thread.isResolved
               }, thread_line - 2)
             local threads = resp.data.resolveReviewThread.thread.pullRequest.reviewThreads.nodes
-print(vim.inspect(threads))
             require"octo.reviews".update_threads(threads)
             --vim.cmd(string.format("%d,%dfoldclose", thread_line, thread_line))
           end

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -977,7 +977,7 @@ function M.add_user(subject)
 
   local iid_ok, iid = pcall(api.nvim_buf_get_var, 0, "iid")
   if not iid_ok or not iid then
-    api.nvim_err_writeln("Cannot get issue/pr id")
+    api.nvim_err_writeln("[Octo] Cannot get issue/pr id")
   end
 
   menu.select_user(

--- a/lua/octo/constants.lua
+++ b/lua/octo/constants.lua
@@ -18,7 +18,7 @@ M.OCTO_EVENT_VT_NS = api.nvim_create_namespace("octo_details_vt")
 
 M.NO_BODY_MSG = "No description provided."
 
-M.LONG_ISSUE_PATTERN = "([A-Za-z0-9_. -]+/[A-Za-z0-9_. -]+)#(%d+)"
+M.LONG_ISSUE_PATTERN = "([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(%d+)"
 M.SHORT_ISSUE_PATTERN = "%s#(%d+)"
 M.URL_ISSUE_PATTERN = ("[htps]+://[^/]+/([^/]+/[^/]+)/([pulisue]+)/(%d+)")
 

--- a/lua/octo/entry_maker.lua
+++ b/lua/octo/entry_maker.lua
@@ -150,18 +150,15 @@ function M.gen_from_git_changed_files()
   end
 end
 
-function M.gen_from_review_comment(linenr_length)
+function M.gen_from_review_thread(linenr_length)
   local make_display = function(entry)
-    if not entry then
-      return nil
-    end
+    if not entry then return nil end
 
     local columns = {
-      {entry.comment.path, "TelescopeResultsNumber"},
-      {entry.comment.commit},
-      {entry.comment.diffSide},
-      {entry.comment.startLine},
-      {entry.comment.line}
+      {entry.thread.path, "TelescopeResultsNumber"},
+      {entry.thread.diffSide},
+      {entry.thread.startLine},
+      {entry.thread.line}
     }
 
     local displayer =
@@ -169,26 +166,24 @@ function M.gen_from_review_comment(linenr_length)
       separator = " ",
       items = {
         {remaining = true},
-        {width = 7},
         {width = 5},
         {width = linenr_length},
         {width = linenr_length}
       }
     }
-
     return displayer(columns)
   end
 
-  return function(comment)
-    if not comment or vim.tbl_isempty(comment) then
+  return function(thread)
+    if not thread or vim.tbl_isempty(thread) then
       return nil
     end
 
     return {
-      value = comment.path..":"..comment.startLine..":"..comment.line,
-      ordinal = comment.path..":"..comment.startLine..":"..comment.line,
+      value = thread.path..":"..thread.startLine..":"..thread.line,
+      ordinal = thread.path..":"..thread.startLine..":"..thread.line,
       display = make_display,
-      comment = comment
+      thread = thread
     }
   end
 end

--- a/lua/octo/folds.lua
+++ b/lua/octo/folds.lua
@@ -4,11 +4,14 @@ end
 
 local M = {}
 
-function M.create(start_line, end_line, is_opened)
-  vim.cmd(string.format("%d,%dfold", start_line, end_line))
-  if is_opened then
-    vim.cmd(string.format("%d,%dfoldopen", start_line, end_line))
-  end
+function M.create(bufnr, start_line, end_line, is_opened)
+  vim.api.nvim_buf_call(bufnr, function()
+    vim.cmd [[setlocal foldmethod=manual]]
+    vim.cmd(string.format("%d,%dfold", start_line, end_line))
+    if is_opened then
+      vim.cmd(string.format("%d,%dfoldopen", start_line, end_line))
+    end
+  end)
 end
 
 return M

--- a/lua/octo/graphql.lua
+++ b/lua/octo/graphql.lua
@@ -76,6 +76,38 @@ M.start_review_mutation =
       pullRequestReview {
         id
         state
+        pullRequest {
+          reviewThreads(last:100) {
+            nodes {	
+              id
+              path
+              diffSide
+              startDiffSide
+              line
+              startLine
+              isResolved
+              isCollapsed
+              isOutdated
+              comments(first:100) {
+                nodes {
+                  id
+                  body
+                  diffHunk
+                  commit { abbreviatedOid }
+                  author {login}
+                  authorAssociation
+                  viewerDidAuthor
+                  viewerCanUpdate
+                  viewerCanDelete
+                  state
+                  pullRequestReview {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -562,19 +594,24 @@ M.pending_review_threads_query =
 query { 
   repository(owner:"%s", name:"%s") {
     pullRequest (number: %d){
-      reviews(first:1, states:PENDING) {
+      reviews(first:100, states:PENDING) {
         nodes {
           id
+          viewerDidAuthor
         }
       }
-      reviewThreads(last:50) {
+      reviewThreads(last:100) {
         nodes {	
+          id
           path
           diffSide
           startDiffSide
           line
           startLine
-          comments(first:1) {
+          isResolved
+          isCollapsed
+          isOutdated
+          comments(first:100) {
             nodes {
               id
               body

--- a/lua/octo/graphql.lua
+++ b/lua/octo/graphql.lua
@@ -47,6 +47,50 @@ M.resolve_review_thread_mutation =
         isOutdated
         isResolved
         path
+        pullRequest {
+          reviewThreads(last:100) {
+            nodes {	
+              id
+              path
+              diffSide
+              startDiffSide
+              line
+              originalLine
+              startLine
+              originalStartLine
+              isResolved
+              isCollapsed
+              isOutdated
+              comments(first:100) {
+                nodes {
+                  id
+                  body
+                  diffHunk
+                  commit { abbreviatedOid }
+                  author {login}
+                  authorAssociation
+                  viewerDidAuthor
+                  viewerCanUpdate
+                  viewerCanDelete
+                  state
+                  replyTo { id }
+                  pullRequestReview {
+                    id
+                    state
+                  }
+                  path
+                  reactionGroups {
+                    content
+                    viewerHasReacted
+                    users {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -63,6 +107,50 @@ M.unresolve_review_thread_mutation =
         isOutdated
         isResolved
         path
+        pullRequest {
+          reviewThreads(last:100) {
+            nodes {	
+              id
+              path
+              diffSide
+              startDiffSide
+              line
+              originalLine
+              startLine
+              originalStartLine
+              isResolved
+              isCollapsed
+              isOutdated
+              comments(first:100) {
+                nodes {
+                  id
+                  body
+                  diffHunk
+                  commit { abbreviatedOid }
+                  author {login}
+                  authorAssociation
+                  viewerDidAuthor
+                  viewerCanUpdate
+                  viewerCanDelete
+                  state
+                  replyTo { id }
+                  pullRequestReview {
+                    id
+                    state
+                  }
+                  path
+                  reactionGroups {
+                    content
+                    viewerHasReacted
+                    users {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -81,10 +169,12 @@ M.start_review_mutation =
             nodes {	
               id
               path
+              line
+              originalLine
+              startLine
+              originalStartLine
               diffSide
               startDiffSide
-              line
-              startLine
               isResolved
               isCollapsed
               isOutdated
@@ -100,9 +190,12 @@ M.start_review_mutation =
                   viewerCanUpdate
                   viewerCanDelete
                   state
+                  replyTo { id }
                   pullRequestReview {
                     id
+                    state
                   }
+                  path
                   reactionGroups {
                     content
                     viewerHasReacted
@@ -139,6 +232,7 @@ mutation {
   deletePullRequestReview(input: {pullRequestReviewId: "%s"}) { 
     pullRequestReview {
       id
+      state
     }
   }
 }
@@ -150,12 +244,8 @@ M.add_pull_request_review_thread_mutation =
 mutation { 
   addPullRequestReviewThread(input: { pullRequestReviewId: "%s", body: "%s", path: "%s", side: %s, line:%d}) { 
     thread {
-      path
-      diffSide
-      startDiffSide
-      line
-      startLine
-      comments(first:1) {
+      id
+      comments(last:100) {
         nodes {
           id
           body
@@ -164,9 +254,65 @@ mutation {
           author {login}
           authorAssociation
           viewerDidAuthor
+          viewerCanUpdate
+          viewerCanDelete
           state
+          replyTo { id }
           pullRequestReview {
             id
+            state
+          }
+          path
+          reactionGroups {
+            content
+            viewerHasReacted
+            users {
+              totalCount
+            }
+          }
+        } 
+      }
+      pullRequest {
+        reviewThreads(last:100) {
+          nodes {	
+            id
+            path
+            diffSide
+            startDiffSide
+            line
+            originalLine
+            startLine
+            originalStartLine
+            isResolved
+            isCollapsed
+            isOutdated
+            comments(first:100) {
+              nodes {
+                id
+                body
+                diffHunk
+                commit { abbreviatedOid }
+                author {login}
+                authorAssociation
+                viewerDidAuthor
+                viewerCanUpdate
+                viewerCanDelete
+                state
+                replyTo { id }
+                pullRequestReview {
+                  id
+                  state
+                }
+                path
+                reactionGroups {
+                  content
+                  viewerHasReacted
+                  users {
+                    totalCount
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -181,12 +327,8 @@ M.add_pull_request_review_multiline_thread_mutation =
 mutation { 
   addPullRequestReviewThread(input: { pullRequestReviewId: "%s", body: "%s", path: "%s", startSide: %s, side: %s, startLine: %d, line:%d}) { 
     thread {
-      path
-      diffSide
-      startDiffSide
-      line
-      startLine
-      comments(first:1) {
+      id
+      comments(last:100) {
         nodes {
           id
           body
@@ -195,9 +337,65 @@ mutation {
           author {login}
           authorAssociation
           viewerDidAuthor
+          viewerCanUpdate
+          viewerCanDelete
           state
+          replyTo { id }
           pullRequestReview {
             id
+            state
+          }
+          path
+          reactionGroups {
+            content
+            viewerHasReacted
+            users {
+              totalCount
+            }
+          }
+        } 
+      }
+      pullRequest {
+        reviewThreads(last:100) {
+          nodes {	
+            id
+            path
+            diffSide
+            startDiffSide
+            line
+            originalLine
+            startLine
+            originalStartLine
+            isResolved
+            isCollapsed
+            isOutdated
+            comments(first:100) {
+              nodes {
+                id
+                body
+                diffHunk
+                commit { abbreviatedOid }
+                author {login}
+                authorAssociation
+                viewerDidAuthor
+                viewerCanUpdate
+                viewerCanDelete
+                state
+                replyTo { id }
+                pullRequestReview {
+                  id
+                  state
+                }
+                path
+                reactionGroups {
+                  content
+                  viewerHasReacted
+                  users {
+                    totalCount
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -242,6 +440,50 @@ M.update_pull_request_review_comment_mutation =
       pullRequestReviewComment {
         id
         body
+        pullRequest {
+          reviewThreads(last:100) {
+            nodes {	
+              id
+              path
+              diffSide
+              startDiffSide
+              line
+              originalLine
+              startLine
+              originalStartLine
+              isResolved
+              isCollapsed
+              isOutdated
+              comments(first:100) {
+                nodes {
+                  id
+                  body
+                  diffHunk
+                  commit { abbreviatedOid }
+                  author {login}
+                  authorAssociation
+                  viewerDidAuthor
+                  viewerCanUpdate
+                  viewerCanDelete
+                  state
+                  replyTo { id }
+                  pullRequestReview {
+                    id
+                    state
+                  }
+                  path
+                  reactionGroups {
+                    content
+                    viewerHasReacted
+                    users {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -254,6 +496,7 @@ M.update_pull_request_review_mutation =
     updatePullRequestReview(input: {pullRequestReviewId: "%s", body: "%s"}) {
       pullRequestReview {
         id
+        state
         body
       }
     }
@@ -261,17 +504,61 @@ M.update_pull_request_review_mutation =
 ]]
 
 -- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreviewcomment
--- M.add_pull_request_review_comment_mutation =
--- [[
---   mutation {
---     addPullRequestReviewComment(input: {inReplyTo: "%s", body: "%s"}) {
---       comment{
---         id
---         body
---       }
---     }
---   }
--- ]]
+M.add_pull_request_review_comment_mutation =
+[[
+  mutation {
+    addPullRequestReviewComment(input: {inReplyTo: "%s", body: "%s", pullRequestReviewId: "%s"}) {
+      comment {
+        id
+        body
+        pullRequest {
+          reviewThreads(last:100) {
+            nodes {	
+              id
+              path
+              diffSide
+              startDiffSide
+              line
+              originalLine
+              startLine
+              originalStartLine
+              isResolved
+              isCollapsed
+              isOutdated
+              comments(first:100) {
+                nodes {
+                  id
+                  body
+                  diffHunk
+                  commit { abbreviatedOid }
+                  author {login}
+                  authorAssociation
+                  viewerDidAuthor
+                  viewerCanUpdate
+                  viewerCanDelete
+                  state
+                  replyTo { id }
+                  pullRequestReview {
+                    id
+                    state
+                  }
+                  path
+                  reactionGroups {
+                    content
+                    viewerHasReacted
+                    users {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+]]
 
 -- M.add_pull_request_review_comment_mutation =
 -- [[
@@ -302,6 +589,50 @@ M.delete_pull_request_review_comment_mutation =
     deletePullRequestReviewComment(input: {id: "%s"}) {
       pullRequestReview {
         id
+        pullRequest {
+          reviewThreads(last:100) {
+            nodes {	
+              id
+              path
+              diffSide
+              startDiffSide
+              line
+              originalLine
+              startLine
+              originalStartLine
+              isResolved
+              isCollapsed
+              isOutdated
+              comments(first:100) {
+                nodes {
+                  id
+                  body
+                  diffHunk
+                  commit { abbreviatedOid }
+                  author {login}
+                  authorAssociation
+                  viewerDidAuthor
+                  viewerCanUpdate
+                  viewerCanDelete
+                  state
+                  replyTo { id }
+                  pullRequestReview {
+                    id
+                    state
+                  }
+                  path
+                  reactionGroups {
+                    content
+                    viewerHasReacted
+                    users {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -614,7 +945,9 @@ query {
           diffSide
           startDiffSide
           line
+          originalLine
           startLine
+          originalStartLine
           isResolved
           isCollapsed
           isOutdated
@@ -630,9 +963,12 @@ query {
               viewerCanUpdate
               viewerCanDelete
               state
+              replyTo { id }
               pullRequestReview {
                 id
+                state
               }
+              path
               reactionGroups {
                 content
                 viewerHasReacted
@@ -677,6 +1013,11 @@ query($endCursor: String) {
               commit {
                 oid
               }
+              pullRequestReview {
+                id
+                state
+              }
+              path
               replyTo { id }
               author { login }
               authorAssociation
@@ -877,9 +1218,7 @@ query($endCursor: String) {
               totalCount
               nodes{
                 id
-                replyTo {
-                  id
-                }
+                replyTo { id }
                 body
                 commit {
                   oid
@@ -930,6 +1269,11 @@ query($endCursor: String) {
               commit {
                 oid
               }
+              pullRequestReview {
+                id
+                state
+              }
+              path
               author { login }
               authorAssociation
               viewerDidAuthor

--- a/lua/octo/graphql.lua
+++ b/lua/octo/graphql.lua
@@ -668,6 +668,8 @@ M.create_issue_mutation =
         closedAt
         updatedAt
         url
+        viewerDidAuthor
+        viewerCanUpdate
         milestone {
           title
           state
@@ -687,22 +689,69 @@ M.create_issue_mutation =
             totalCount
           }
         }
-        comments(first: 100) {
+        projectCards(last: 20) {
           nodes {
             id
-            body
-            createdAt
-            reactionGroups {
-              content
-              viewerHasReacted
-              users {
-                totalCount
+            state
+            column {
+              name
+            }
+            project {
+              name
+            }
+          }
+        }
+        timelineItems(first: 100, after: $endCursor) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            __typename
+            ... on IssueComment {
+              id
+              body
+              createdAt
+              reactionGroups {
+                content
+                viewerHasReacted
+                users {
+                  totalCount
+                }
+              }
+              author {
+                login
+              }
+              viewerDidAuthor
+              viewerCanUpdate
+              viewerCanDelete
+            }
+            ... on ClosedEvent {
+              createdAt
+              actor {
+                login
               }
             }
-            author {
-              login
+            ... on ReopenedEvent {
+              createdAt
+              actor {
+                login
+              }
             }
-            viewerDidAuthor
+            ... on AssignedEvent {
+              actor {
+                login
+              }
+              assignee {
+                ... on Organization {
+                  name
+                }
+                ... on User {
+                  login
+                }
+              }
+              createdAt
+            }
           }
         }
         labels(first: 20) {

--- a/lua/octo/graphql.lua
+++ b/lua/octo/graphql.lua
@@ -103,6 +103,13 @@ M.start_review_mutation =
                   pullRequestReview {
                     id
                   }
+                  reactionGroups {
+                    content
+                    viewerHasReacted
+                    users {
+                      totalCount
+                    }
+                  }
                 }
               }
             }
@@ -625,6 +632,13 @@ query {
               state
               pullRequestReview {
                 id
+              }
+              reactionGroups {
+                content
+                viewerHasReacted
+                users {
+                  totalCount
+                }
               }
             }
           }

--- a/lua/octo/graphql.lua
+++ b/lua/octo/graphql.lua
@@ -1976,7 +1976,33 @@ query {
 
 M.user_query =
   [[
+query($endCursor: String) {
+  search(query: "%s", type: USER, first: 100) {
+    nodes {
+      ... on User {
+        id
+        login
+      }
+      ... on Organization {
+        id
+        login
+        teams(first:100, after: $endCursor) {
+          totalCount
+          nodes {
+            id
+            name
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+}
 ]]
+
 
 local function escape_chars(string)
   local escaped, _ = string.gsub(

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -38,7 +38,7 @@ function M.configure_octo_buffer(bufnr)
       vim.cmd [[setlocal syntax=markdown]]
 
       -- autocmds
-      vim.cmd [[ augroup octo_reviewthread_autocmds ]]
+      vim.cmd [[ augroup octo_buffer_autocmds ]]
       vim.cmd(format([[ au! * <buffer=%d> ]], bufnr))
       vim.cmd(format([[ au TextChanged <buffer=%d> lua require"octo.signs".render_signcolumn() ]], bufnr))
       vim.cmd(format([[ au TextChangedI <buffer=%d> lua require"octo.signs".render_signcolumn() ]], bufnr))
@@ -316,20 +316,18 @@ end
 function M.save_buffer()
   local bufnr = api.nvim_get_current_buf()
 
-  local ft = api.nvim_buf_get_option(bufnr, "filetype")
-  local repo = util.get_repo_number({"octo_issue", "octo_reviewthread"})
+  local repo = util.get_repo_number({"issue", "pull", "reviewthread"})
   if not repo then
     return
   end
 
-  local bufname = api.nvim_buf_get_name(bufnr)
-  local kind = util.get_octo_kind(bufname)
+  local kind = util.get_octo_kind(bufnr)
 
   -- collect comment metadata
   util.update_issue_metadata(bufnr)
 
   -- title & body
-  if ft == "octo_issue" then
+  if kind == "issue" or kind == "pull" then
     do_save_title_and_body(bufnr, kind)
   end
 
@@ -493,7 +491,7 @@ function M.create_buffer(type, obj, repo, create)
   end
 
   -- configure buffer
-  api.nvim_buf_set_option(bufnr, "filetype", "octo_issue")
+  api.nvim_buf_set_option(bufnr, "filetype", "markdown") -- octo_issue
   api.nvim_buf_set_option(bufnr, "buftype", "acwrite")
   M.configure_octo_buffer(bufnr)
 
@@ -871,7 +869,8 @@ end
 
 function M.next_comment()
   local bufnr = api.nvim_get_current_buf()
-  if vim.bo[bufnr].ft == "octo_issue" then
+  local kind = util.get_octo_kind(bufnr)
+  if kind then
     local cursor = api.nvim_win_get_cursor(0)
     local current_line = cursor[1]
     local lines = util.get_sorted_comment_lines()
@@ -897,7 +896,8 @@ end
 
 function M.prev_comment()
   local bufnr = api.nvim_get_current_buf()
-  if vim.bo[bufnr].ft == "octo_issue" then
+  local kind = util.get_octo_kind(bufnr)
+  if kind then
     local cursor = api.nvim_win_get_cursor(0)
     local current_line = cursor[1]
     local lines = util.get_sorted_comment_lines()

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -35,7 +35,6 @@ function M.configure_octo_buffer(bufnr)
       vim.cmd [[setlocal foldmethod=manual]]
       vim.cmd [[setlocal foldenable]]
       vim.cmd [[setlocal foldlevelstart=99]]
-      vim.cmd [[setlocal syntax=markdown]]
 
       -- autocmds
       vim.cmd [[ augroup octo_buffer_autocmds ]]
@@ -491,7 +490,7 @@ function M.create_buffer(type, obj, repo, create)
   end
 
   -- configure buffer
-  api.nvim_buf_set_option(bufnr, "filetype", "markdown") -- octo_issue
+  api.nvim_buf_set_option(bufnr, "filetype", "octo")
   api.nvim_buf_set_option(bufnr, "buftype", "acwrite")
   M.configure_octo_buffer(bufnr)
 

--- a/lua/octo/menu.lua
+++ b/lua/octo/menu.lua
@@ -817,11 +817,9 @@ function M.select_user(cb)
   pickers.new(
     opts,
     {
-      prompt_prefix = "User Search >",
+      prompt_prefix = "User Search>",
       finder = function(prompt, process_result, process_complete)
-        if not prompt or prompt == "" then
-          return nil
-        end
+        if not prompt or prompt == "" then return nil end
         prompt = "repos:>10 " .. prompt
 
         -- skip requests for empty prompts

--- a/lua/octo/menu.lua
+++ b/lua/octo/menu.lua
@@ -572,43 +572,27 @@ end
 ---
 -- REVIEW COMMENTS
 ---
-function M.pending_comments(comments)
+function M.pending_threads(threads)
   local max_linenr_length = -1
-  for _, comment in ipairs(comments) do
-    max_linenr_length = math.max(max_linenr_length, #tostring(comment.startLine))
-    max_linenr_length = math.max(max_linenr_length, #tostring(comment.line))
+  for _, thread in ipairs(threads) do
+    max_linenr_length = math.max(max_linenr_length, #tostring(thread.startLine))
+    max_linenr_length = math.max(max_linenr_length, #tostring(thread.line))
   end
   pickers.new(
     {},
     {
-      prompt_prefix = "Review Comments >",
+      prompt_prefix = "Pending Review Comments>",
       finder = finders.new_table {
-        results = comments,
-        entry_maker = entry_maker.gen_from_review_comment(max_linenr_length)
+        results = threads,
+        entry_maker = entry_maker.gen_from_review_thread(max_linenr_length)
       },
       sorter = conf.generic_sorter({}),
-      previewer = previewers.review_comment.new({}),
-      attach_mappings = function(_, map)
-
-        -- update comment mapping
-        map("i", "<c-e>", function(prompt_bufnr)
-          local comment = action_state.get_selected_entry(prompt_bufnr).comment
-          actions.close(prompt_bufnr)
-          reviews.update_pending_review_comment(comment)
-        end)
-
-        -- delete comment mapping
-        map("i", "<c-d>", function(prompt_bufnr)
-          local comment = action_state.get_selected_entry(prompt_bufnr).comment
-          actions.close(prompt_bufnr)
-          reviews.delete_pending_review_comment(comment)
-        end)
-
-        -- jump to comment
+      previewer = previewers.review_thread.new({}),
+      attach_mappings = function()
         actions.select_default:replace(function(prompt_bufnr)
-          local comment = action_state.get_selected_entry(prompt_bufnr).comment
+          local thread = action_state.get_selected_entry(prompt_bufnr).thread
           actions.close(prompt_bufnr)
-          reviews.jump_to_pending_review_comment(comment)
+          reviews.jump_to_pending_review_thread(thread)
         end)
         return true
       end

--- a/lua/octo/previewers.lua
+++ b/lua/octo/previewers.lua
@@ -178,7 +178,7 @@ M.changed_files =
   {}
 )
 
-M.review_comment =
+M.review_thread =
   defaulter(
   function()
     return previewers.new_buffer_previewer {
@@ -188,9 +188,13 @@ M.review_comment =
       define_preview = function(self, entry)
         local bufnr = self.state.bufnr
         if self.state.bufname ~= entry.value or api.nvim_buf_line_count(bufnr) == 1 then
-          -- TODO: pretty print
-          writers.write_diff_hunk(bufnr, entry.comment.diffHunk)
-          api.nvim_buf_set_lines(bufnr, -1, -1, false, vim.split(entry.comment.body, "\n"))
+          api.nvim_buf_set_var(bufnr, "review_thread_map", {})
+          api.nvim_buf_set_var(bufnr, "comments", {})
+          writers.write_threads(bufnr, {entry.thread})
+          api.nvim_buf_call(bufnr, function()
+            vim.cmd [[setlocal foldmethod=manual]]
+            vim.cmd [[normal! zR]]
+          end)
         end
       end
     }

--- a/lua/octo/previewers.lua
+++ b/lua/octo/previewers.lua
@@ -41,7 +41,7 @@ M.issue =
                   writers.write_details(bufnr, issue)
                   writers.write_body(bufnr, issue)
                   writers.write_state(bufnr, issue.state:upper(), number)
-                  api.nvim_buf_set_option(bufnr, "filetype", "markdown")
+                  api.nvim_buf_set_option(bufnr, "filetype", "octo")
                 end
               end
             }
@@ -103,7 +103,7 @@ M.pull_request =
                   local reactions_line = api.nvim_buf_line_count(bufnr) - 1
                   writers.write_block(bufnr, {"", ""}, reactions_line)
                   writers.write_reactions(bufnr, pull_request.reactionGroups, reactions_line)
-                  api.nvim_buf_set_option(bufnr, "filetype", "markdown")
+                  api.nvim_buf_set_option(bufnr, "filetype", "octo")
                 end
               end
             }

--- a/lua/octo/previewers.lua
+++ b/lua/octo/previewers.lua
@@ -41,7 +41,7 @@ M.issue =
                   writers.write_details(bufnr, issue)
                   writers.write_body(bufnr, issue)
                   writers.write_state(bufnr, issue.state:upper(), number)
-                  api.nvim_buf_set_option(bufnr, "filetype", "octo_issue")
+                  api.nvim_buf_set_option(bufnr, "filetype", "markdown")
                 end
               end
             }
@@ -103,7 +103,7 @@ M.pull_request =
                   local reactions_line = api.nvim_buf_line_count(bufnr) - 1
                   writers.write_block(bufnr, {"", ""}, reactions_line)
                   writers.write_reactions(bufnr, pull_request.reactionGroups, reactions_line)
-                  api.nvim_buf_set_option(bufnr, "filetype", "octo_issue")
+                  api.nvim_buf_set_option(bufnr, "filetype", "markdown")
                 end
               end
             }

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -464,7 +464,7 @@ function M.submit_review()
     header = "Press <c-a> to approve, <c-m> to comment or <c-r> to request changes"
   })
   api.nvim_set_current_win(winid)
-  api.nvim_buf_set_option(bufnr, "syntax", "markdown")
+  api.nvim_buf_set_option(bufnr, "syntax", "octo")
 
   local mapping_opts = {script = true, silent = true, noremap = true}
   api.nvim_buf_set_keymap(bufnr, "i", "<CR>", "<CR>", mapping_opts)
@@ -617,7 +617,7 @@ function M.create_thread_buffer(repo, number, side, path)
   api.nvim_buf_set_var(thread_bufnr, "repo", repo)
   api.nvim_buf_set_var(thread_bufnr, "number", number)
   api.nvim_buf_set_var(thread_bufnr, "review_thread_map", {})
-  api.nvim_buf_set_option(thread_bufnr, "filetype", "markdown") -- octo_issue
+  api.nvim_buf_set_option(thread_bufnr, "filetype", "octo")
   api.nvim_buf_set_option(thread_bufnr, "buftype", "acwrite")
 
   -- add mappings to the thread window buffer

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -603,8 +603,7 @@ function M.create_thread_buffer(repo, number, line)
   api.nvim_buf_set_var(thread_bufnr, "repo", repo)
   api.nvim_buf_set_var(thread_bufnr, "number", number)
   api.nvim_buf_set_var(thread_bufnr, "review_thread_map", {})
-  -- TODO: get rid of octo_reviewthread ft
-  api.nvim_buf_set_option(thread_bufnr, "filetype", "octo_reviewthread")
+  api.nvim_buf_set_option(thread_bufnr, "filetype", "markdown") -- octo_issue
   api.nvim_buf_set_option(thread_bufnr, "buftype", "acwrite")
   api.nvim_buf_set_name(thread_bufnr, thread_bufname)
 

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -14,12 +14,13 @@ local json = {
 
 local M = {}
 
--- holds the comments for the current pending review
-local _review_threads = {}
--- holds the id of the current pending review
 local _review_id = -1
--- holds a cache of the changed files contents for the current pending review
+local _review_threads = {}
 local _review_files = {}
+
+function M.getReviewId()
+  return _review_id
+end
 
 -- sets the height of the quickfix window
 local qf_height = math.floor(vim.o.lines * 0.2)
@@ -127,7 +128,7 @@ function M.diff_changes_qf_entry(target)
   local left_bufname = format("octo://%s/pull/%d/file/LEFT/%s", repo, number, path)
   local left_bufnr = vim.fn.bufnr(left_bufname)
   if left_bufnr == -1 then
-    left_bufnr = api.nvim_create_buf(true, true)
+    left_bufnr = api.nvim_create_buf(false, true)
     api.nvim_buf_set_name(left_bufnr, left_bufname)
     api.nvim_buf_set_lines(left_bufnr, 0, -1, false, {"Loading ..."})
     api.nvim_buf_set_option(left_bufnr, "modifiable", false)
@@ -137,7 +138,7 @@ function M.diff_changes_qf_entry(target)
   local right_bufname = format("octo://%s/pull/%d/file/RIGHT/%s", repo, number, path)
   local right_bufnr = vim.fn.bufnr(right_bufname)
   if right_bufnr == -1 then
-    right_bufnr = api.nvim_create_buf(true, true)
+    right_bufnr = api.nvim_create_buf(false, true)
     api.nvim_buf_set_name(right_bufnr, right_bufname)
     api.nvim_buf_set_lines(right_bufnr, 0, -1, false, {"Loading ..."})
     api.nvim_buf_set_option(right_bufnr, "modifiable", false)
@@ -162,7 +163,9 @@ function M.diff_changes_qf_entry(target)
     hunks = valid_hunks,
     comment_ranges = valid_right_ranges,
     alt_win = left_win,
-    alt_bufnr = left_bufnr
+    alt_bufnr = left_bufnr,
+    repo = repo,
+    number = number
   })
 
   api.nvim_buf_set_var(left_bufnr, "OctoDiffProps", {
@@ -176,7 +179,9 @@ function M.diff_changes_qf_entry(target)
     hunks = valid_hunks,
     comment_ranges = valid_left_ranges,
     alt_win = right_win,
-    alt_bufnr = right_bufnr
+    alt_bufnr = right_bufnr,
+    repo = repo,
+    number = number
   })
 
   local write_diff_lines = function(lines, side)
@@ -239,519 +244,6 @@ function M.diff_changes_qf_entry(target)
   end
 end
 
-function M.add_review_comment(isSuggestion)
-  -- get visual selected line range
-  local line1, line2
-  if vim.fn.getpos("'<")[2] == vim.fn.getcurpos()[2] then
-    line1 = vim.fn.getpos("'<")[2]
-    line2 = vim.fn.getpos("'>")[2]
-  else
-    line1 = vim.fn.getcurpos()[2]
-    line2 = vim.fn.getcurpos()[2]
-  end
-
-  -- check we are in an octo diff buffer
-  local bufnr = api.nvim_get_current_buf()
-  local status, props = pcall(api.nvim_buf_get_var, bufnr, "OctoDiffProps")
-  if status and props then
-    -- check we are in a valid comment range
-    local diff_hunk
-    for i, range in ipairs(props.comment_ranges) do
-      if range[1] <= line1 and range[2] >= line2 then
-        diff_hunk = props.hunks[i]
-        break
-      end
-    end
-    if not diff_hunk then
-      api.nvim_err_writeln("Cannot place comments outside diff hunks")
-      return
-    end
-
-    -- create comment window and buffer
-    local comment_winid, comment_bufnr = window.create_centered_float({
-      header = format("Add comment for %s (from %d to %d) [%s]", props.path, line1, line2, props.diffSide)
-    })
-
-    local bufname = format("%s:%d.%d", string.gsub(props.bufname, "/file/", "/comment/"), line1, line2)
-    api.nvim_buf_set_name(comment_bufnr, bufname)
-    api.nvim_buf_set_option(comment_bufnr, "syntax", "markdown")
-    api.nvim_buf_set_option(comment_bufnr, "buftype", "acwrite")
-    api.nvim_buf_set_var(comment_bufnr, "OctoDiffProps", props)
-
-    if isSuggestion then
-      local lines = api.nvim_buf_get_lines(props.content_bufnr, line1-1, line2, false)
-      local suggestion = {"```suggestion"}
-      vim.list_extend(suggestion, lines)
-      table.insert(suggestion, "```")
-      api.nvim_buf_set_lines(comment_bufnr, 0, -1, false, suggestion)
-      api.nvim_buf_set_option(comment_bufnr, "modified", false)
-    end
-
-    -- change to insert mode
-    api.nvim_set_current_win(comment_winid)
-    vim.cmd [[normal G]]
-    vim.cmd [[startinsert]]
-  end
-end
-
-function M.edit_review_comment()
-  -- check we are in an octo diff buffer
-  local bufnr = api.nvim_get_current_buf()
-  local status, props = pcall(api.nvim_buf_get_var, bufnr, "OctoDiffProps")
-  if not status or not props then
-    api.nvim_err_writeln("Not in Octo diff buffer")
-    return
-  end
-
-  local threads = vim.tbl_values(_review_threads)
-  for _, thread in ipairs(threads) do
-    local cursor = api.nvim_win_get_cursor(0)
-    if util.is_thread_placed_in_buffer(thread, bufnr) and thread.startLine <= cursor[1] and thread.line >= cursor[1] then
-
-      -- create thread window and buffer
-      local _, comment_bufnr = window.create_centered_float({
-        header = format("Edit comment for %s (from %d to %d) [%s]", thread.path, thread.startLine, thread.line, props.diffSide)
-      })
-
-      local bufname = format("%s:%d.%d", string.gsub(props.bufname, "/file/", "/comment/"), thread.startLine, thread.line)
-      api.nvim_buf_set_name(comment_bufnr, bufname)
-      api.nvim_buf_set_option(comment_bufnr, "syntax", "markdown")
-      api.nvim_buf_set_option(comment_bufnr, "buftype", "acwrite")
-      props["id"] = thread.id
-      api.nvim_buf_set_var(comment_bufnr, "OctoDiffProps", props)
-      api.nvim_buf_set_lines(comment_bufnr, 0, -1, false, vim.split(thread.comments.nodes[1].body, "\n"))
-      return
-    end
-  end
-  api.nvim_err_writeln("No comment found at cursor line")
-end
-
--- called when saving a review comment buffer
-function M.save_review_comment()
-  local bufnr = api.nvim_get_current_buf()
-  local status, props = pcall(api.nvim_buf_get_var, bufnr, "OctoDiffProps")
-  if status and props then
-
-    -- extract comment body
-    local bufname = api.nvim_buf_get_name(bufnr)
-    local body = table.concat(api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
-    local startLine, line = string.match(bufname, ".*:(%d+)%.(%d+)$")
-
-    -- sync comment with GitHub
-    local query, op
-    if props.id then
-      -- update comment in GitHub
-      query = graphql("update_pull_request_review_comment_mutation", props.id, body)
-      op = "update"
-    else
-      -- create new comment with GitHub
-      op = "create"
-      if startLine == line then
-        query = graphql("add_pull_request_review_thread_mutation", _review_id, body, props.path, props.diffSide, line )
-      else
-        query = graphql("add_pull_request_review_multiline_thread_mutation", _review_id, body, props.path, props.diffSide, props.diffSide, startLine, line)
-      end
-    end
-    gh.run(
-      {
-        args = {"api", "graphql", "-f", format("query=%s", query)},
-        cb = function(output, stderr)
-          if stderr and not util.is_blank(stderr) then
-            api.nvim_err_writeln(stderr)
-          elseif output then
-            local resp = json.parse(output)
-
-            if op == "create" then
-              local thread = resp.data.addPullRequestReviewThread.thread
-              if thread.startLine == vim.NIL then
-                thread.startLine = thread.line
-                thread.startDiffSide = thread.diffSide
-              end
-
-              -- update comment buffer props
-              props.id = thread.id
-              api.nvim_buf_set_var(bufnr, "OctoDiffProps", props)
-
-              -- add new thread
-              _review_threads[props.id] = thread
-
-              --[[
-              {
-                id = first_comment.id,
-                path = thread.path,
-                startDiffSide = thread.startDiffSide,
-                diffSide = thread.diffSide,
-                diffHunk = first_comment.diffHunk,
-                commit = first_comment.commit.abbreviatedOid,
-                startLine = thread.startLine,
-                line = thread.line,
-                body = first_comment.body,
-                author = first_comment.author,
-                authorAssociation = first_comment.authorAssociation,
-                viewerDidAuthor = first_comment.viewerDidAuthor,
-                state = first_comment.state
-              }
-              ]]--
-            end
-          end
-        end
-      }
-    )
-  end
-end
-
----
---- Review threads
----
-function M.review_threads()
-  local repo, number, _ = util.get_repo_number_pr()
-  if not repo then
-    return
-  end
-  local owner, name = util.split_repo(repo)
-  local query = graphql("review_threads_query", owner, name, number)
-  gh.run(
-    {
-      args = {"api", "graphql", "-f", format("query=%s", query)},
-      cb = function(output, stderr)
-        if stderr and not util.is_blank(stderr) then
-          api.nvim_err_writeln(stderr)
-        elseif output then
-          local resp = json.parse(output)
-          M.populate_reviewthreads_qf(repo, number, resp.data.repository.pullRequest.reviewThreads.nodes)
-        end
-      end
-    }
-  )
-end
-
-function M.populate_reviewthreads_qf(repo, number, reviewthreads)
-  local items = {}
-  local ctxitems = {}
-  local qf = vim.fn.getqflist({winid = 0})
-  local qf_width = vim.fn.winwidth(qf.winid) * 0.4
-
-  local process_threads = function(threads)
-    for _, thread in ipairs(threads) do
-      local first_comment = thread.comments.nodes[1]
-      local mods = {}
-      if thread.isResolved then
-        table.insert(mods, "RESOLVED ")
-      end
-      if thread.isOutdated then
-        table.insert(mods, "OUTDATED ")
-      end
-      local comment_id = util.graph2rest(first_comment.id)
-      local lnum = thread.line
-      if not lnum or lnum == vim.NIL then
-        lnum = thread.originalLine
-      end
-      table.insert(
-        ctxitems,
-        {
-          commit = first_comment.commit.oid
-        }
-      )
-      table.insert(
-        items,
-        {
-          module = thread.path,
-          lnum = lnum,
-          text = format(
-            "%s (%s) %s%s...",
-            first_comment.author.login,
-            string.lower(first_comment.authorAssociation),
-            table.concat(mods, " "),
-            string.sub(vim.split(first_comment.body, "\n")[1], 0, qf_width)
-          ),
-          pattern = format("%s/%s", thread.id, comment_id)
-        }
-      )
-    end
-  end
-
-  local open_threads =
-    vim.tbl_filter(
-    function(item)
-      return not item.isResolved and not item.isOutdated
-    end,
-    reviewthreads
-  )
-  local outdated_not_resolved_threads =
-    vim.tbl_filter(
-    function(item)
-      return item.isOutdated and not item.isResolved
-    end,
-    reviewthreads
-  )
-  local resolved_threads =
-    vim.tbl_filter(
-    function(item)
-      return item.isResolved
-    end,
-    reviewthreads
-  )
-
-  -- add the unresolved threads first
-  process_threads(open_threads)
-  process_threads(outdated_not_resolved_threads)
-  process_threads(resolved_threads)
-
-  if #items == 0 then
-    api.nvim_err_writeln("No comments found")
-    return
-  end
-
-  -- populate qf
-  vim.fn.setqflist({}, "r", {context = {items = ctxitems} , items = items})
-
-  -- new tab to hold the main, qf and comment windows
-  if true then
-    vim.cmd(format("tabnew %s", items[1].filename))
-  end
-
-  local main_win = api.nvim_get_current_win()
-
-  -- save review comments in main window var
-  api.nvim_win_set_var(main_win, "reviewthreads", reviewthreads)
-
-  -- open qf
-  vim.cmd(format("%dcopen", qf_height))
-  local qf_win = vim.fn.getqflist({winid = 0}).winid
-
-  -- highlight qf entries
-  vim.cmd [[call matchadd("Comment", "\(.*\)")]]
-  vim.cmd [[call matchadd("OctoNvimUser", "|\\s\\zs[^(]+\\ze\(")]]
-  vim.cmd [[call matchadd("OctoNvimBubbleRed", "OUTDATED")]]
-  vim.cmd [[call matchadd("OctoNvimBubbleGreen", "RESOLVED")]]
-
-  -- bind <CR> for current quickfix window to properly set up diff split layout after selecting an item
-  -- there's probably a better way to map this without changing the window
-  vim.cmd(
-    format(
-      "nnoremap <silent><buffer> <CR> <CR><BAR>:lua require'octo.reviews'.show_reviewthread_qf_entry('%s', %d, %d)<CR>",
-      repo,
-      number,
-      main_win
-    )
-  )
-
-  -- add mappings to the qf window
-  M.add_reviewthread_qf_mappings(repo, number, main_win)
-
-  -- back to qf
-  api.nvim_set_current_win(qf_win)
-  api.nvim_win_set_option(qf_win, "number", false)
-  api.nvim_win_set_option(qf_win, "relativenumber", false)
-
-  -- create comment window and set the comment buffer
-  local reviewthread_position = "main"
-  if reviewthread_position == "main" then
-    api.nvim_set_current_win(main_win)
-  elseif reviewthread_position == "qf" then
-    api.nvim_set_current_win(qf_win)
-  end
-  vim.cmd("rightbelow vsplit %")
-  local comment_win = api.nvim_get_current_win()
-  api.nvim_win_set_option(comment_win, "number", false)
-  api.nvim_win_set_option(comment_win, "relativenumber", false)
-
-  -- jump to main window and select qf entry
-  api.nvim_set_current_win(main_win)
-  api.nvim_win_set_var(main_win, "comment_win", comment_win)
-  --vim.cmd [[cc]]
-
-  -- show comment for first element in qf
-  M.show_reviewthread_qf_entry(repo, number, main_win)
-end
-
-function M.clean_reviewthread_buffers()
-  local tabpage = api.nvim_get_current_tabpage()
-  for _, w in ipairs(api.nvim_tabpage_list_wins(tabpage)) do
-    if api.nvim_win_is_valid(w) then
-      local bufnr = api.nvim_win_get_buf(w)
-      local ft = api.nvim_buf_get_option(bufnr, "filetype")
-      if ft == "octo_reviewthread" then
-        vim.cmd(format("bdelete %d", bufnr))
-      end
-    end
-  end
-end
-
-function M.show_reviewthread_qf_entry(repo, number, main_win)
-
-  -- select qf entry
-  vim.cmd [[cc]]
-
-  local qf = vim.fn.getqflist({context = 0, idx = 0, items = 0, winid = 0})
-
-  local idx = qf.idx or 0
-  local items = qf.items or {}
-  local context = qf.context or {}
-  local path = qf.items[idx].module
-  local commit = context.items[idx].commit
-
-  -- get comment details
-  local selected_item = items[idx]
-  local ids = selected_item.pattern
-  local reviewthread_id = vim.split(ids, "/")[1]
-  local comment_id = vim.split(ids, "/")[2]
-
-  -- get cached thread
-  local threads = api.nvim_win_get_var(main_win, "reviewthreads")
-  local thread
-  for _, t in ipairs(threads) do
-    if reviewthread_id == t.id then
-      thread = t
-    end
-  end
-
-  -- prepare content buffer
-  local content_bufname = format("octo://%s/pull/%d/file/%s/%s", repo, number, thread.diffSide, path)
-  local content_bufnr = vim.fn.bufnr(content_bufname)
-  if content_bufnr == -1 then
-    content_bufnr = api.nvim_create_buf(false, true)
-    api.nvim_buf_set_name(content_bufnr, content_bufname)
-    api.nvim_buf_set_lines(content_bufnr, 0, -1, false, {"Loading ..."})
-  end
-
-  api.nvim_set_current_win(main_win)
-  api.nvim_win_set_buf(main_win, content_bufnr)
-  M.add_reviewthread_qf_mappings(repo, number, main_win)
-
-  util.get_file_contents(repo, commit, path, function(lines)
-    api.nvim_buf_set_option(content_bufnr, "modifiable", true)
-    api.nvim_buf_set_lines(content_bufnr, 0, -1, false, lines)
-    api.nvim_buf_set_option(content_bufnr, "modifiable", false)
-    api.nvim_set_current_win(main_win)
-    vim.cmd [[filetype detect]]
-
-    -- go to comment line
-    local row = (selected_item.lnum) or 1
-    api.nvim_set_current_win(main_win)
-    local ok = pcall(api.nvim_win_set_cursor, main_win, {row, 1})
-    if not ok then
-      api.nvim_err_writeln("Cannot move cursor to line " .. row)
-    else
-      vim.cmd [[normal! zz]]
-    end
-
-    -- highlight commented lines
-    signs.unplace(content_bufnr)
-    M.highlight_lines(content_bufnr, thread.startLine, thread.line)
-
-  end)
-
-  -- prepare comment buffer
-  local comment_win = api.nvim_win_get_var(main_win, "comment_win")
-  -- TODO: this will fail if user closes reviewthread window
-  api.nvim_set_current_win(comment_win)
-
-  local comment_bufname = format("octo://%s/pull/%d/reviewthread/%s/comment/%s", repo, number, reviewthread_id, comment_id)
-  local comment_bufnr = vim.fn.bufnr(comment_bufname)
-  if comment_bufnr > -1 then
-    api.nvim_win_set_buf(comment_win, comment_bufnr)
-  else
-    comment_bufnr = api.nvim_create_buf(false, true)
-    api.nvim_buf_set_var(comment_bufnr, "repo", repo)
-    api.nvim_buf_set_var(comment_bufnr, "number", number)
-    api.nvim_buf_set_option(comment_bufnr, "syntax", "markdown")
-    api.nvim_buf_set_option(comment_bufnr, "filetype", "octo_reviewthread")
-    api.nvim_buf_set_option(comment_bufnr, "buftype", "acwrite")
-    api.nvim_buf_set_name(comment_bufnr, comment_bufname)
-    api.nvim_win_set_buf(comment_win, comment_bufnr)
-
-    -- add mappings to the comment window buffer
-    M.add_reviewthread_qf_mappings(repo, number, main_win)
-    octo.apply_buffer_mappings(comment_bufnr, "reviewthread")
-
-    -- write diff hunk
-    local main_comment = thread.comments.nodes[1]
-    local start_line = thread.originalStartLine ~= vim.NIL and thread.originalStartLine or thread.originalLine
-    local end_line = thread.originalLine
-    writers.write_review_thread_header(comment_bufnr, {
-      path = thread.path,
-      start_line = start_line,
-      end_line = end_line,
-      isOutdated = thread.isOutdated,
-      isResolved = thread.isResolved
-    })
-    writers.write_diff_hunk(comment_bufnr, main_comment.diffHunk)
-
-    -- write thread
-    api.nvim_buf_set_var(comment_bufnr, "comments", {})
-    for _, comment in ipairs(thread.comments.nodes) do
-      writers.write_comment(comment_bufnr, comment, "PullRequestReviewComment")
-    end
-  end
-
-  -- show comment buffer signs
-  signs.render_signcolumn(comment_bufnr)
-
-  -- autocmds
-  vim.cmd [[ augroup octo_reviewthread_autocmds ]]
-  vim.cmd [[ au! * <buffer> ]]
-  vim.cmd [[ au TextChanged <buffer> lua require"octo.signs".render_signcolumn() ]]
-  vim.cmd [[ au TextChangedI <buffer> lua require"octo.signs".render_signcolumn() ]]
-  vim.cmd [[ augroup END ]]
-end
-
-function M.highlight_lines(bufnr, startLine, endLine)
-  if not endLine then return end
-  startLine = startLine or endLine
-  for line = startLine, endLine do
-    signs.place("octo_comment", bufnr, line - 1)
-  end
-end
-
--- MAPPINGS
-function M.add_reviewthread_qf_mappings(repo, number, main_win)
-  vim.cmd(
-    format(
-      "nnoremap <silent><buffer>]q :lua require'octo.reviews'.next_comment('%s', %d, %d)<CR>",
-      repo,
-      number,
-      main_win
-    )
-  )
-  vim.cmd(
-    format(
-      "nnoremap <silent><buffer>[q :lua require'octo.reviews'.prev_comment('%s', %d, %d)<CR>",
-      repo,
-      number,
-      main_win
-    )
-  )
-
-  vim.cmd [[nnoremap <silent><buffer><C-c> :tabclose <BAR> :lua require'octo.reviews'.clean_reviewthread_buffers()<CR>]]
-
-  -- reset quickfix height. Sometimes it messes up after selecting another item
-  vim.cmd(format("%dcopen", qf_height))
-  vim.cmd [[wincmd p]]
-end
-
-function M.next_comment(repo, number, main_win)
-  api.nvim_set_current_win(main_win)
-  local qf = vim.fn.getqflist({idx = 0, size = 0})
-  if qf.idx == qf.size then
-    vim.cmd [[cfirst]]
-  else
-    vim.cmd [[cnext]]
-  end
-  M.show_reviewthread_qf_entry(repo, number, main_win)
-end
-
-function M.prev_comment(repo, number, main_win)
-  api.nvim_set_current_win(main_win)
-  local qf = vim.fn.getqflist({idx = 0})
-  if qf.idx == 1 then
-    vim.cmd [[clast]]
-  else
-    vim.cmd [[cprev]]
-  end
-  M.show_reviewthread_qf_entry(repo, number, main_win)
-end
-
 function M.close_review_tab()
   vim.cmd [[silent! tabclose]]
 end
@@ -762,7 +254,6 @@ function M.add_changes_qf_mappings(bufnr)
   api.nvim_buf_set_keymap(bufnr, "n", "]q", [[<cmd>lua require'octo.reviews'.next_change()<CR>]], mapping_opts)
   api.nvim_buf_set_keymap(bufnr, "n", "[q", [[<cmd>lua require'octo.reviews'.prev_change()<CR>]], mapping_opts)
   api.nvim_buf_set_keymap(bufnr, "n", "<C-c>", [[<cmd>lua require'octo.reviews'.close_review_tab()<CR>]], mapping_opts)
-  api.nvim_buf_set_keymap(bufnr, "n", "<space>ce", [[<cmd>lua require'octo.reviews'.edit_review_comment()<CR>]], mapping_opts)
   vim.cmd [[nnoremap <space>ca :OctoAddReviewComment<CR>]]
   vim.cmd [[vnoremap <space>ca :OctoAddReviewComment<CR>]]
   vim.cmd [[nnoremap <space>sa :OctoAddReviewSuggestion<CR>]]
@@ -793,6 +284,9 @@ function M.prev_change()
   M.diff_changes_qf_entry()
 end
 
+--
+-- REVIEW PROCESS
+--
 function M.start_review()
   local repo, number, pr = util.get_repo_number_pr()
   if not repo then
@@ -817,14 +311,61 @@ function M.start_review()
           _review_id = resp.data.addPullRequestReview.pullRequestReview.id
 
           local threads = resp.data.addPullRequestReview.pullRequestReview.pullRequest.reviewThreads.nodes
-          for _, thread in ipairs(threads) do
-            if thread.startLine == vim.NIL then
-              thread.startLine = thread.line
-              thread.startDiffSide = thread.diffSide
-            end
-            _review_threads[thread.id] = thread
+          M.update_threads(threads)
+          M.initiate_review(repo, number, pr)
+        end
+      end
+    }
+  )
+end
+
+function M.update_threads(threads)
+  _review_threads = {}
+  for _, thread in ipairs(threads) do
+    if thread.startLine == vim.NIL then
+      thread.startLine = thread.line
+      thread.startDiffSide = thread.diffSide
+    end
+    _review_threads[thread.id] = thread
+  end
+end
+
+function M.resume_review()
+  local repo, number, pr = util.get_repo_number_pr()
+  if not repo then
+    return
+  end
+  -- start new review
+  local owner, name = util.split_repo(repo)
+  local query = graphql("pending_review_threads_query", owner, name, number)
+  gh.run(
+    {
+      args = {"api", "graphql", "-f", format("query=%s", query)},
+      cb = function(output, stderr)
+        if stderr and not util.is_blank(stderr) then
+          api.nvim_err_writeln(stderr)
+        elseif output then
+          local resp = json.parse(output)
+          if #resp.data.repository.pullRequest.reviews.nodes == 0 then
+            api.nvim_err_writeln("No pending reviews found")
+            return
           end
 
+          -- There can only be one pending review for a given user
+          for _, review in ipairs(resp.data.repository.pullRequest.reviews.nodes) do
+            if review.viewerDidAuthor then
+              _review_id = review.id
+              break
+            end
+          end
+
+          if not _review_id then
+            api.nvim_err_writeln("No pending reviews found for viewer")
+            return
+          end
+
+          local threads = resp.data.repository.pullRequest.reviewThreads.nodes
+          M.update_threads(threads)
           M.initiate_review(repo, number, pr)
         end
       end
@@ -863,56 +404,6 @@ function M.initiate_review(repo, number, pr)
               headRefOid = pr.headRefOid
             }
           )
-        end
-      end
-    }
-  )
-end
-
-function M.resume_review()
-  local repo, number, pr = util.get_repo_number_pr()
-  if not repo then
-    return
-  end
-  -- start new review
-  local owner, name = util.split_repo(repo)
-  local query = graphql("pending_review_threads_query", owner, name, number)
-  gh.run(
-    {
-      args = {"api", "graphql", "-f", format("query=%s", query)},
-      cb = function(output, stderr)
-        if stderr and not util.is_blank(stderr) then
-          api.nvim_err_writeln(stderr)
-        elseif output then
-          local resp = json.parse(output)
-          if #resp.data.repository.pullRequest.reviews.nodes == 0 then
-            api.nvim_err_writeln("No pending reviews found")
-            return
-          end
-
-          -- There can only be one pending review for a given user
-          for _, review in ipairs(resp.data.repository.pullRequest.reviews.nodes) do
-            if review.viewerDidAuthor then
-              _review_id = review.id
-              break
-            end
-          end
-
-          if not _review_id then
-            api.nvim_err_writeln("No pending reviews found for viewer")
-            return
-          end
-
-          local threads = resp.data.repository.pullRequest.reviewThreads.nodes
-          for _, thread in ipairs(threads) do
-            if thread.startLine == vim.NIL then
-              thread.startLine = thread.line
-              thread.startDiffSide = thread.diffSide
-            end
-            _review_threads[thread.id] = thread
-          end
-
-          M.initiate_review(repo, number, pr)
         end
       end
     }
@@ -959,62 +450,6 @@ function M.discard_review()
       end
     }
   )
-end
-
-function M.delete_pending_review_comment(comment)
-  local query = graphql("delete_pull_request_review_comment_mutation", comment.id)
-  gh.run(
-    {
-      args = {"api", "graphql", "-f", format("query=%s", query)},
-      cb = function(_)
-        for _, thread in ipairs(_review_threads) do
-          for _, c in ipairs(thread.comments.nodes) do
-            if comment.id == c then
-              _review_threads[thread.id] = nil
-              break
-            end
-          end
-        end
-      end
-    }
-  )
-end
-
-function M.jump_to_pending_review_comment(comment)
-  local qf = vim.fn.getqflist({items = 0})
-  local idx
-  for i, item in ipairs(qf.items) do
-    if comment.path == item.module then
-      idx = i
-      break
-    end
-  end
-  if idx then
-    -- select qf item
-    vim.fn.setqflist({}, 'r', {idx = idx })
-    M.diff_changes_qf_entry({
-      diffSide = comment.diffSide,
-      startLine = comment.startLine,
-      line = comment.line,
-    })
-  end
-end
-
-function M.update_pending_review_comment(comment)
-  local qf = vim.fn.getqflist({context = 0})
-  local repo = qf.context.pull_request_repo
-  local number = qf.context.pull_request_number
-  local _, comment_bufnr = window.create_centered_float({
-    header = format("Edit comment for %s (from %d to %d) [%s]", comment.path, comment.startLine, comment.line, comment.diffSide)
-  })
-  local bufname = format("octo://%s/pull/%d/comment/%s/%s:%d.%d", repo, number, comment.diffSide, comment.path, comment.startLine, comment.line)
-  api.nvim_buf_set_name(comment_bufnr, bufname)
-  api.nvim_buf_set_option(comment_bufnr, "syntax", "markdown")
-  api.nvim_buf_set_option(comment_bufnr, "buftype", "acwrite")
-  api.nvim_buf_set_var(comment_bufnr, "OctoDiffProps", {
-    id = comment.id
-  })
-  api.nvim_buf_set_lines(comment_bufnr, 0, -1, false, vim.split(comment.body, "\n"))
 end
 
 function M.submit_review()
@@ -1069,23 +504,44 @@ end
 
 function M.show_pending_comments()
   if _review_id == -1 then
-    api.nvim_err_writeln("No review in progress")
+    api.nvim_err_writeln("[Octo] No review in progress")
     return
   end
   local threads = vim.tbl_values(_review_threads)
-  local filtered_threads = {}
+  local pending_threads = {}
   for _, thread in ipairs(threads) do
-    local first_comment = thread.comments.nodes[1]
-    local review = first_comment.pullRequestReview
-    if review.state == "PENDING" and not util.is_blank(vim.fn.trim(first_comment.body)) then
-      table.insert(filtered_threads, thread)
+    for _, comment in ipairs(thread.comments.nodes) do
+      local review = comment.pullRequestReview
+      if review.state == "PENDING" and not util.is_blank(vim.fn.trim(comment.body)) then
+        table.insert(pending_threads, thread)
+      end
     end
   end
-  if #filtered_threads == 0 then
-    api.nvim_err_writeln("No pending comments found")
+  if #pending_threads == 0 then
+    api.nvim_err_writeln("[Octo] No pending comments found")
     return
   else
-    require"octo.menu".pending_comments(filtered_threads)
+    require"octo.menu".pending_threads(pending_threads)
+  end
+end
+
+function M.jump_to_pending_review_thread(thread)
+  local qf = vim.fn.getqflist({items = 0})
+  local idx
+  for i, item in ipairs(qf.items) do
+    if thread.path == item.module then
+      idx = i
+      break
+    end
+  end
+  if idx then
+    -- select qf item
+    vim.fn.setqflist({}, 'r', {idx = idx })
+    M.diff_changes_qf_entry({
+      diffSide = thread.diffSide,
+      startLine = thread.startLine,
+      line = thread.line,
+    })
   end
 end
 
@@ -1096,12 +552,14 @@ function M.clear_review_threads()
     return
   end
   local diff_bufnr = props.alt_bufnr
-  local current_alt_bufnr = api.nvim_win_get_buf(props.alt_win)
-  if current_alt_bufnr ~= diff_bufnr then
-    api.nvim_win_set_buf(props.alt_win, diff_bufnr)
-    local bufname = api.nvim_buf_get_name(current_alt_bufnr)
-    if vim.startswith(bufname, "octo://thread") then
-      api.nvim_buf_delete(current_alt_bufnr, {force = true})
+  if api.nvim_win_is_valid(props.alt_win) then
+    local current_alt_bufnr = api.nvim_win_get_buf(props.alt_win)
+    if current_alt_bufnr ~= diff_bufnr then
+      api.nvim_win_set_buf(props.alt_win, diff_bufnr)
+      local bufname = api.nvim_buf_get_name(current_alt_bufnr)
+      if string.match(bufname, "octo://.+/pull/%d+/reviewthreads") then
+        api.nvim_buf_delete(current_alt_bufnr, {force = true})
+      end
     end
   end
 end
@@ -1114,9 +572,10 @@ function M.show_review_threads()
   end
   local threads = vim.tbl_values(_review_threads)
   local cursor = api.nvim_win_get_cursor(0)
+  local comment_line = cursor[1]
   local threads_at_cursor = {}
   for _, thread in ipairs(threads) do
-    if util.is_thread_placed_in_buffer(thread, bufnr) and thread.startLine <= cursor[1] and thread.line >= cursor[1] then
+    if util.is_thread_placed_in_buffer(thread, bufnr) and thread.startLine <= comment_line and thread.line >= comment_line then
       table.insert(threads_at_cursor, thread)
     end
   end
@@ -1125,45 +584,39 @@ function M.show_review_threads()
     return
   end
 
-  -- window.create_thread_popup(props.alt_win, thread)
-  local thread_bufnr = api.nvim_create_buf(false, true)
-  local thread_bufname = format("octo://thread")
-  api.nvim_buf_set_name(thread_bufnr, thread_bufname)
-
-  for _, thread in ipairs(threads_at_cursor) do
-    local thread_start, thread_end
-    for _, comment in ipairs(thread.comments.nodes) do
-
-      -- review thread header
-      if comment.replyTo == vim.NIL then
-        local start_line = thread.originalStartLine ~= vim.NIL and thread.originalStartLine or thread.originalLine
-        local end_line = thread.originalLine
-        writers.write_review_thread_header(bufnr, {
-          path = thread.path,
-          start_line = start_line,
-          end_line = end_line,
-          isOutdated = thread.isOutdated,
-          isResolved = thread.isResolved,
-        })
-
-        -- write snippet
-        thread_start, thread_end = writers.write_diff_hunk(thread_bufnr, comment.diffHunk, nil, start_line, end_line, thread.diffSide)
-      end
-
-      api.nvim_buf_set_var(thread_bufnr, "comments", {})
-      local comment_start, comment_end = writers.write_comment(thread_bufnr, comment, "PullRequestReviewComment")
-      thread_end = comment_end
-    end
-  end
-
   if api.nvim_win_is_valid(props.alt_win) then
+    local thread_bufnr = M.create_thread_buffer(props.repo, props.number, comment_line)
+    writers.write_threads(thread_bufnr, threads_at_cursor)
     api.nvim_win_set_buf(props.alt_win, thread_bufnr)
+    octo.configure_octo_buffer(thread_bufnr)
+
+    -- show comment buffer signs
+    signs.render_signcolumn(thread_bufnr)
   else
     api.nvim_err_writeln("[Octo] Cannot find diff window")
   end
 end
 
-function M.place_comment_signs()
+function M.create_thread_buffer(repo, number, line)
+  local thread_bufnr = api.nvim_create_buf(false, true)
+  local thread_bufname = format("octo://%s/pull/%d/reviewthreads/%d", repo, number, line)
+  api.nvim_buf_set_var(thread_bufnr, "repo", repo)
+  api.nvim_buf_set_var(thread_bufnr, "number", number)
+  api.nvim_buf_set_var(thread_bufnr, "review_thread_map", {})
+  -- TODO: get rid of octo_reviewthread ft
+  api.nvim_buf_set_option(thread_bufnr, "filetype", "octo_reviewthread")
+  api.nvim_buf_set_option(thread_bufnr, "buftype", "acwrite")
+  api.nvim_buf_set_name(thread_bufnr, thread_bufname)
+
+  -- add mappings to the thread window buffer
+  octo.apply_buffer_mappings(thread_bufnr, "reviewthread")
+
+  api.nvim_buf_set_var(thread_bufnr, "comments", {})
+
+  return thread_bufnr
+end
+
+function M.place_thread_signs()
   local bufnr = api.nvim_get_current_buf()
   signs.unplace(bufnr)
   local status, props = pcall(api.nvim_buf_get_var, bufnr, "OctoDiffProps")
@@ -1197,6 +650,108 @@ function M.place_comment_signs()
       end
     end
   end
+end
+
+function M.add_review_comment(isSuggestion)
+  -- get visual selected line range
+  local line1, line2
+  if vim.fn.getpos("'<")[2] == vim.fn.getcurpos()[2] then
+    line1 = vim.fn.getpos("'<")[2]
+    line2 = vim.fn.getpos("'>")[2]
+  else
+    line1 = vim.fn.getcurpos()[2]
+    line2 = vim.fn.getcurpos()[2]
+  end
+
+  -- check we are in an octo diff buffer
+  local bufnr = api.nvim_get_current_buf()
+  local status, props = pcall(api.nvim_buf_get_var, bufnr, "OctoDiffProps")
+  if not status or not props then
+    return
+  end
+
+  -- check we are in a valid comment range
+  local diff_hunk
+  for i, range in ipairs(props.comment_ranges) do
+    if range[1] <= line1 and range[2] >= line2 then
+      diff_hunk = props.hunks[i]
+      break
+    end
+  end
+  if not diff_hunk then
+    api.nvim_err_writeln("Cannot place comments outside diff hunks")
+    return
+  end
+  if not vim.startswith(diff_hunk, "@@") then
+    diff_hunk = "@@ "..diff_hunk
+  end
+
+  -- create new fake thread
+  local thread = {
+    originalStartLine = line1,
+    originalLine = line2,
+    path = props.path,
+    isOutdated = false,
+    isResolved = false,
+    diffSide = props.diffSide,
+    isCollapsed = false,
+    id = -1,
+    comments = {
+      nodes = {{
+        id = -1,
+        author = {login = vim.g.octo_viewer},
+        state = "PENDING",
+        replyTo = vim.NIL,
+        diffHunk = diff_hunk,
+        createdAt = vim.fn.strftime("%FT%TZ"),
+        body = " ",
+        viewerCanUpdate = true,
+        viewerCanDelete = true,
+        viewerDidAuthor = true,
+        pullRequestReview = { id = _review_id },
+        reactionGroups = {
+          { content = "THUMBS_UP", users = { totalCount = 0 } },
+          { content = "THUMBS_DOWN", users = { totalCount = 0 } },
+          { content = "LAUGH", users = { totalCount = 0 } },
+          { content = "HOORAY", users = { totalCount = 0 } },
+          { content = "CONFUSED", users = { totalCount = 0 } },
+          { content = "HEART", users = { totalCount = 0 } },
+          { content = "ROCKET", users = { totalCount = 0 } },
+          { content = "EYES", users = { totalCount = 0 } }
+        }
+      }}
+    }
+  }
+
+  local threads = {thread}
+
+  if api.nvim_win_is_valid(props.alt_win) then
+    local thread_bufnr = M.create_thread_buffer(props.repo, props.number, line1)
+    writers.write_threads(thread_bufnr, threads)
+    api.nvim_win_set_buf(props.alt_win, thread_bufnr)
+    octo.configure_octo_buffer(thread_bufnr)
+
+    if isSuggestion then
+      local lines = api.nvim_buf_get_lines(props.content_bufnr, line1-1, line2, false)
+      local suggestion = {"```suggestion"}
+      vim.list_extend(suggestion, lines)
+      table.insert(suggestion, "```")
+      api.nvim_buf_set_lines(thread_bufnr, -3, -2, false, suggestion)
+      api.nvim_buf_set_option(thread_bufnr, "modified", false)
+
+    end
+
+    -- change to insert mode
+    api.nvim_set_current_win(props.alt_win)
+    vim.cmd [[normal Gk]]
+    vim.cmd [[startinsert]]
+
+    -- show comment buffer signs
+    signs.render_signcolumn(thread_bufnr)
+  else
+    api.nvim_err_writeln("[Octo] Cannot find diff window")
+  end
+
 end
 
 return M

--- a/lua/octo/signs.lua
+++ b/lua/octo/signs.lua
@@ -35,7 +35,7 @@ end
 function M.render_signcolumn(bufnr)
   bufnr = bufnr or api.nvim_get_current_buf()
   local ft = api.nvim_buf_get_option(bufnr, "filetype")
-  if not vim.startswith(ft, "octo_") then
+  if ft ~= "octo_issue" and ft ~= "octo_reviewthread" then
     return
   end
 

--- a/lua/octo/signs.lua
+++ b/lua/octo/signs.lua
@@ -34,10 +34,8 @@ end
 
 function M.render_signcolumn(bufnr)
   bufnr = bufnr or api.nvim_get_current_buf()
-  local ft = api.nvim_buf_get_option(bufnr, "filetype")
-  if ft ~= "octo_issue" and ft ~= "octo_reviewthread" then
-    return
-  end
+  local kind = util.get_octo_kind(bufnr)
+  if not kind then return end
 
   local issue_dirty = false
 
@@ -51,7 +49,7 @@ function M.render_signcolumn(bufnr)
   api.nvim_buf_clear_namespace(bufnr, constants.OCTO_EMPTY_MSG_VT_NS, 0, -1)
 
   local start_line, end_line
-  if ft == "octo_issue" then
+  if kind == "issue" or kind == "pull" then
     -- title
     local title = api.nvim_buf_get_var(bufnr, "title")
     if title["dirty"] then

--- a/lua/octo/util.lua
+++ b/lua/octo/util.lua
@@ -304,7 +304,8 @@ end
 
 function M.get_thread_at_cursor(bufnr)
   local cursor = api.nvim_win_get_cursor(0)
-  local thread_map = api.nvim_buf_get_var(bufnr, "review_thread_map")
+  local ok, thread_map = pcall(api.nvim_buf_get_var, bufnr, "review_thread_map")
+  if not thread_map or not ok then return end
   local thread_marks = api.nvim_buf_get_extmarks(bufnr, constants.OCTO_THREAD_NS, 0, -1, {details = true})
   for _, mark in ipairs(thread_marks) do
     local markId = tostring(mark[1])
@@ -320,7 +321,7 @@ function M.get_thread_at_cursor(bufnr)
       end
     end
   end
-  return nil
+  return
 end
 
 function M.update_reactions_at_cursor(bufnr, reaction_groups, reaction_line)

--- a/lua/octo/util.lua
+++ b/lua/octo/util.lua
@@ -703,7 +703,7 @@ function M.get_octo_kind(bufnr)
   bufnr = bufnr or api.nvim_get_current_buf()
   local bufname = api.nvim_buf_get_name(bufnr)
   local kind
-  if string.match(bufname, "octo://.*/reviewthread/.*") then
+  if string.match(bufname, "octo://.*/reviewthreads/.*") then
     kind = "reviewthread"
   elseif string.match(bufname, "octo://.*/pull/.*") then
     kind = "pull"

--- a/lua/octo/util.lua
+++ b/lua/octo/util.lua
@@ -699,4 +699,21 @@ function M.get_sorted_comment_lines(bufnr)
   return lines
 end
 
+function M.is_thread_placed_in_buffer(comment, bufnr)
+  local status, props = pcall(api.nvim_buf_get_var, bufnr, "OctoDiffProps")
+  if not status or not props then
+    return false
+  end
+
+  local bufname = props.bufname
+  local diffSide, path = string.match(bufname, "octo://[^/]+/[^/]+/pull/%d+/file/([^/]+)/(.+)")
+  if not diffSide or not path then
+    return false
+  end
+  if diffSide == comment.diffSide and path == comment.path then
+    return true
+  end
+  return false
+end
+
 return M

--- a/lua/octo/window.lua
+++ b/lua/octo/window.lua
@@ -128,20 +128,21 @@ function M.try_close_wins(...)
   end
 end
 
-function M.create_comment_popup(win, comment)
+function M.create_thread_popup(win, thread)
   local vertical_offset = vim.fn.line(".") - vim.fn.line("w0")
   local win_width = vim.fn.winwidth(win)
   local horizontal_offset = math.floor(win_width / 4) -- 1/4 of win width
-  local header = {format(" %s %s[%s] [%s]", comment.author.login, comment.viewerDidAuthor and "[Author] " or " ", comment.authorAssociation, comment.state)}
+  local first_comment = thread.comments.nodes[1]
+  local header = {format(" %s %s[%s] [%s]", first_comment.author.login, first_comment.viewerDidAuthor and "[Author] " or " ", first_comment.authorAssociation, first_comment.state)}
   local border_width = 1
   local padding = 1
-  local body = vim.list_extend(header, vim.split(comment.body, "\n"))
+  local body = vim.list_extend(header, vim.split(first_comment.body, "\n"))
   local height = math.min(2*border_width + #body, vim.fn.winheight(win))
 
   local preview_bufnr = api.nvim_create_buf(false, true)
   api.nvim_buf_set_lines(preview_bufnr, 0, -1, false, body)
   local preview_width = win_width - 2*border_width - 2*padding - horizontal_offset
-  local preview_col = comment.diffSide == "LEFT" and (padding + border_width) or (padding + border_width + horizontal_offset)
+  local preview_col = thread.diffSide == "LEFT" and (padding + border_width) or (padding + border_width + horizontal_offset)
   local preview_winid = api.nvim_open_win(preview_bufnr, false, {
     relative = "win",
     win = win,
@@ -159,7 +160,7 @@ function M.create_comment_popup(win, comment)
   local border = {}
   local borderwin_width = win_width - horizontal_offset
   local line_fill = string.rep("─", borderwin_width-2*border_width)
-  local border_col = comment.diffSide == "LEFT" and 0 or horizontal_offset
+  local border_col = thread.diffSide == "LEFT" and 0 or horizontal_offset
   table.insert(border, format("┌%s┐", line_fill))
   for _=1, height-2 do
     table.insert(border, format("│%s│", string.rep(" ", borderwin_width-2*border_width)))

--- a/lua/octo/window.lua
+++ b/lua/octo/window.lua
@@ -128,61 +128,6 @@ function M.try_close_wins(...)
   end
 end
 
-function M.create_thread_popup(win, thread)
-  local vertical_offset = vim.fn.line(".") - vim.fn.line("w0")
-  local win_width = vim.fn.winwidth(win)
-  local horizontal_offset = math.floor(win_width / 4) -- 1/4 of win width
-  local first_comment = thread.comments.nodes[1]
-  local header = {format(" %s %s[%s] [%s]", first_comment.author.login, first_comment.viewerDidAuthor and "[Author] " or " ", first_comment.authorAssociation, first_comment.state)}
-  local border_width = 1
-  local padding = 1
-  local body = vim.list_extend(header, vim.split(first_comment.body, "\n"))
-  local height = math.min(2*border_width + #body, vim.fn.winheight(win))
-
-  local preview_bufnr = api.nvim_create_buf(false, true)
-  api.nvim_buf_set_lines(preview_bufnr, 0, -1, false, body)
-  local preview_width = win_width - 2*border_width - 2*padding - horizontal_offset
-  local preview_col = thread.diffSide == "LEFT" and (padding + border_width) or (padding + border_width + horizontal_offset)
-  local preview_winid = api.nvim_open_win(preview_bufnr, false, {
-    relative = "win",
-    win = win,
-    row = vertical_offset + padding,
-    col = preview_col,
-    width = preview_width,
-    height = height - 2*border_width
-  })
-  api.nvim_win_set_option(preview_winid, "foldcolumn", "0")
-  api.nvim_win_set_option(preview_winid, "signcolumn", "no")
-  api.nvim_win_set_option(preview_winid, "number", false)
-  api.nvim_win_set_option(preview_winid, "relativenumber", false)
-  vim.lsp.util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "WinLeave"}, preview_winid)
-
-  local border = {}
-  local borderwin_width = win_width - horizontal_offset
-  local line_fill = string.rep("─", borderwin_width-2*border_width)
-  local border_col = thread.diffSide == "LEFT" and 0 or horizontal_offset
-  table.insert(border, format("┌%s┐", line_fill))
-  for _=1, height-2 do
-    table.insert(border, format("│%s│", string.rep(" ", borderwin_width-2*border_width)))
-  end
-  table.insert(border, format("└%s┘", line_fill))
-  local border_bufnr = api.nvim_create_buf(false, true)
-  api.nvim_buf_set_lines(border_bufnr, 0, -1, false, border)
-  local border_winid = api.nvim_open_win(border_bufnr, false, {
-    relative = "win",
-    win = win,
-    row = vertical_offset,
-    col = border_col,
-    width = borderwin_width,
-    height = height
-  })
-  api.nvim_win_set_option(border_winid, "foldcolumn", "0")
-  api.nvim_win_set_option(border_winid, "signcolumn", "no")
-  api.nvim_win_set_option(border_winid, "number", false)
-  api.nvim_win_set_option(border_winid, "relativenumber", false)
-  vim.lsp.util.close_preview_autocmd({"CursorMoved", "CursorMovedI", "WinLeave"}, border_winid)
-end
-
 function M.create_popup(opts)
   opts = opts or {}
   if not opts.width then

--- a/lua/octo/writers.lua
+++ b/lua/octo/writers.lua
@@ -1094,6 +1094,7 @@ function M.write_threads(bufnr, threads)
           isResolved = thread.isResolved,
         })
 
+        M.write_block(bufnr, {""}, line)
         -- write snippet
         thread_start, thread_end = M.write_thread_snippet(bufnr, comment.diffHunk, nil, start_line, end_line, thread.diffSide)
       end
@@ -1102,7 +1103,7 @@ function M.write_threads(bufnr, threads)
       folds.create(bufnr, comment_start+1, comment_end, true)
       thread_end = comment_end
     end
-    folds.create(bufnr, thread_start - 1, thread_end - 1, not thread.isCollapsed)
+    folds.create(bufnr, thread_start-1, thread_end - 1, not thread.isCollapsed)
 
     -- mark the thread region
     local thread_mark_id = api.nvim_buf_set_extmark(

--- a/lua/octo/writers.lua
+++ b/lua/octo/writers.lua
@@ -584,7 +584,8 @@ function M.write_thread_snippet(bufnr, diffhunk, start_line, comment_start, comm
   local max_lnum = math.max(strlen(tostring(right_offset + #diffhunk_lines)), strlen(tostring(left_offset + #diffhunk_lines)))
 
   -- calculate diffhunk subrange to show
-  local snippet_start, snippet_end
+  local snippet_start = start_line
+  local snippet_end = start_line
   if comment_side and comment_start ~= comment_end then
     -- for multiline comments, discard calculated values
     -- write just those lines

--- a/lua/octo/writers.lua
+++ b/lua/octo/writers.lua
@@ -631,7 +631,7 @@ function M.write_thread_snippet(bufnr, diffhunk, start_line, comment_start, comm
       max_length = strlen(line)
     end
   end
-  max_length = math.max(max_length, vim.fn.winwidth(0) - 10 - vim.wo.foldcolumn)
+  max_length = math.max(max_length, vim.fn.winwidth(0) - 10)
 
   -- write empty lines to hold virtual text
   local empty_lines = {}

--- a/plugin/octo.vim
+++ b/plugin/octo.vim
@@ -95,7 +95,7 @@ highlight default link OctoNvimPullModifications OctoNvimBlue
 highlight default link OctoNvimStateOpen OctoNvimGreen
 highlight default link OctoNvimStateClosed OctoNvimRed
 highlight default link OctoNvimStateMerged OctoNvimPurple
-highlight default link OctoNvimStatePending OctoNvimBubbleYellow
+highlight default link OctoNvimStatePending OctoNvimYellow
 highlight default link OctoNvimStateApproved OctoNvimStateOpen
 highlight default link OctoNvimStateChangesRequested OctoNvimStateClosed
 highlight default link OctoNvimStateCommented Normal

--- a/plugin/octo.vim
+++ b/plugin/octo.vim
@@ -56,13 +56,20 @@ au!
 au BufEnter octo://* call s:configure_octo_buffer()
 au BufReadCmd octo://* lua require'octo'.load_buffer()
 au BufWriteCmd octo://* lua require'octo'.save_buffer()
-au CursorHold octo://* lua require'octo.reviews'.show_comment()
+au CursorHold octo://* lua require'octo.reviews'.show_review_threads()
 au CursorHold octo://* lua require'octo'.on_cursor_hold()
 augroup END
 
 " sign definitions
-sign define octo_comment text=❯ texthl=OctoNvimCommentSign linehl=OctoNvimCommentLine 
-sign define octo_comment_range text=│ texthl=OctoNvimCommentRangeLine
+          
+sign define octo_thread text= texthl=OctoNvimBlue
+sign define octo_thread_resolved text=  texthl=OctoNvimGreen
+sign define octo_thread_outdated text=  texthl=OctoNvimRed
+sign define octo_thread_pending text= texthl=OctoNvimYellow
+sign define octo_thread_resolved_pending text= texthl=OctoNvimYellow
+sign define octo_thread_outdated_pending text= texthl=OctoNvimYellow
+
+sign define octo_comment_range numhl=OctoNvimGreen
 sign define octo_clean_block_start text=┌ linehl=OctoNvimEditable
 sign define octo_clean_block_end text=└ linehl=OctoNvimEditable
 sign define octo_dirty_block_start text=┌ texthl=OctoNvimDirty linehl=OctoNvimEditable
@@ -94,9 +101,6 @@ highlight default link OctoNvimDate Comment
 highlight default link OctoNvimDetailsLabel Title 
 highlight default link OctoNvimDetailsValue Identifier
 highlight default link OctoNvimMissingDetails Comment
-highlight default link OctoNvimCommentLine Visual
-highlight default link OctoNvimCommentSign OctoNvimYellow
-highlight default link OctoNvimCommentRangeLine OctoNvimYellow
 highlight default link OctoNvimEditable NormalFloat
 highlight default link OctoNvimBubble NormalFloat
 highlight default link OctoNvimUser OctoNvimBubble

--- a/plugin/octo.vim
+++ b/plugin/octo.vim
@@ -56,8 +56,9 @@ au!
 au BufEnter octo://* call s:configure_octo_buffer()
 au BufReadCmd octo://* lua require'octo'.load_buffer()
 au BufWriteCmd octo://* lua require'octo'.save_buffer()
-au CursorHold octo://* lua require'octo.reviews'.show_review_threads()
 au CursorHold octo://* lua require'octo'.on_cursor_hold()
+au CursorHold octo://* lua require'octo.reviews'.show_review_threads()
+au CursorMoved octo://* lua require'octo.reviews'.clear_review_threads()
 augroup END
 
 " sign definitions

--- a/plugin/octo.vim
+++ b/plugin/octo.vim
@@ -86,7 +86,7 @@ highlight default OctoNvimBubbleRed guifg=#ffffff guibg=#da3633
 highlight default OctoNvimBubblePurple guifg=#ffffff guibg=#ad7cfd
 highlight default OctoNvimBubbleYellow guifg=#ffffff guibg=#d3c846
 highlight default OctoNvimBubbleBlue guifg=#ffffff guibg=#58A6FF
-highlight default OctoNvimGreen guifg=#2ea043
+highlight default OctoNvimGreen guifg=#238636
 highlight default OctoNvimRed guifg=#da3633
 highlight default OctoNvimPurple guifg=#ad7cfd
 highlight default OctoNvimYellow guifg=#d3c846

--- a/plugin/octo.vim
+++ b/plugin/octo.vim
@@ -2,10 +2,6 @@ if exists('g:loaded_octo')
   finish
 endif
 
-function! s:command_complete(...)
-  return luaeval('require("octo.commands").command_complete(_A)', a:000)
-endfunction
-
 " commands
 if executable('gh')
   command! -complete=customlist,s:command_complete -nargs=* Octo lua require"octo.commands".octo(<f-args>)
@@ -29,31 +25,15 @@ function! octo#issue_complete(findstart, base) abort
   return luaeval("require'octo.completion'.issue_complete(_A[1], _A[2])", [a:findstart, a:base])
 endfunction
 
-" autocommands
-function s:configure_octo_buffer() abort
-  " issue/pr/comment buffers
-  if match(bufname(), "octo://.\\+/.\\+/pull/\\d\\+/file/") == -1
-    setlocal omnifunc=octo#issue_complete
-    setlocal nonumber norelativenumber nocursorline wrap
-    setlocal foldcolumn=3
-    setlocal signcolumn=yes
-    setlocal fillchars=fold:⠀,foldopen:⠀,foldclose:⠀,foldsep:⠀
-    setlocal foldtext=v:lua.OctoFoldText()
-    setlocal foldmethod=manual
-    setlocal foldenable
-    setlocal foldcolumn=3
-    setlocal foldlevelstart=99
-    setlocal conceallevel=2
-    setlocal syntax=markdown
-  " file diff buffers
-  else
-    lua require"octo.reviews".place_comment_signs()
-  end
+function! s:command_complete(...)
+  return luaeval('require("octo.commands").command_complete(_A)', a:000)
 endfunction
 
+
+" autocommands
 augroup octo_autocmds
 au!
-au BufEnter octo://* call s:configure_octo_buffer()
+au BufEnter octo://* lua require'octo'.configure_octo_buffer()
 au BufReadCmd octo://* lua require'octo'.load_buffer()
 au BufWriteCmd octo://* lua require'octo'.save_buffer()
 au CursorHold octo://* lua require'octo'.on_cursor_hold()
@@ -62,7 +42,6 @@ au CursorMoved octo://* lua require'octo.reviews'.clear_review_threads()
 augroup END
 
 " sign definitions
-          
 sign define octo_thread text= texthl=OctoNvimBlue
 sign define octo_thread_resolved text=  texthl=OctoNvimGreen
 sign define octo_thread_outdated text=  texthl=OctoNvimRed
@@ -81,11 +60,11 @@ sign define octo_clean_line text=[ linehl=OctoNvimEditable
 sign define octo_dirty_line text=[ texthl=OctoNvimDirty linehl=OctoNvimEditable
 
 highlight default OctoNvimViewer guifg=#000000 guibg=#58A6FF
-highlight default OctoNvimBubbleGreen guifg=#ffffff guibg=#238636
-highlight default OctoNvimBubbleRed guifg=#ffffff guibg=#da3633
-highlight default OctoNvimBubblePurple guifg=#ffffff guibg=#ad7cfd
-highlight default OctoNvimBubbleYellow guifg=#ffffff guibg=#d3c846
-highlight default OctoNvimBubbleBlue guifg=#ffffff guibg=#58A6FF
+highlight default OctoNvimBubbleGreen guibg=#238636 guifg=#acf2bd
+highlight default OctoNvimBubbleRed guibg=#da3633 guifg=#fdb8c0
+highlight default OctoNvimBubblePurple guifg=#ffffff guibg=#6f42c1
+highlight default OctoNvimBubbleYellow guibg=#735c0f guifg=#d3c846 
+highlight default OctoNvimBubbleBlue guifg=#eaf5ff guibg=#0366d6
 highlight default OctoNvimGreen guifg=#238636
 highlight default OctoNvimRed guifg=#da3633
 highlight default OctoNvimPurple guifg=#ad7cfd
@@ -116,11 +95,12 @@ highlight default link OctoNvimPullModifications OctoNvimBlue
 highlight default link OctoNvimStateOpen OctoNvimGreen
 highlight default link OctoNvimStateClosed OctoNvimRed
 highlight default link OctoNvimStateMerged OctoNvimPurple
-highlight default link OctoNvimStatePending OctoNvimYellow
+highlight default link OctoNvimStatePending OctoNvimBubbleYellow
 highlight default link OctoNvimStateApproved OctoNvimStateOpen
 highlight default link OctoNvimStateChangesRequested OctoNvimStateClosed
 highlight default link OctoNvimStateCommented Normal
 highlight default link OctoNvimStateDismissed OctoNvimStateClosed
+highlight default link OctoNvimStateSubmitted OctoNvimBubbleGreen
 
 " folds
 lua require'octo.folds'


### PR DESCRIPTION
### Describe what this PR does / why we need it
This PR unifies the UX regarding PR reviews. We move away from using popups to enter comments and instead use the same kind of issue/pr buffer the user is used to.
We also unified `Octo review start|resume` and `Octo review threads`. The later is removed and all threads are now shown in the review diff buffers.
This allow users to see other people review comments while doing their own reviews. It also enables users to add review comments to other people threads 