### PR TITLE
Support toggling changed file viewed state

### DIFF
--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -104,6 +104,7 @@ M.defaults = {
       next_thread = "]t",
       prev_thread = "[t",
       close_review_tab = "<C-c>",
+      toggle_viewed = "<leader><space>",
     },
     submit_win = {
       close_review_win = "<C-c>",
@@ -121,6 +122,7 @@ M.defaults = {
       focus_files = "<leader>e",
       toggle_files = "<leader>b",
       close_review_tab = "<C-c>",
+      toggle_viewed = "<leader><space>",
     }
   }
 }

--- a/lua/octo/graphql.lua
+++ b/lua/octo/graphql.lua
@@ -213,6 +213,40 @@ M.start_review_mutation =
   }
 ]]
 
+-- https://docs.github.com/en/graphql/reference/mutations#markfileasviewed
+M.mark_file_as_viewed_mutation =
+  [[
+  mutation {
+    markFileAsViewed(input: {path: "%s", pullRequestId: "%s"}) {
+      pullRequest {
+        files(first:100){
+          nodes {
+            path
+            viewerViewedState
+          }
+        }
+      }
+    }
+  }
+]]
+
+-- https://docs.github.com/en/graphql/reference/mutations#unmarkfileasviewed
+M.unmark_file_as_viewed_mutation =
+  [[
+  mutation {
+    unmarkFileAsViewed(input: {path: "%s", pullRequestId: "%s"}) {
+      pullRequest {
+        files(first:100){
+          nodes {
+            path
+            viewerViewedState
+          }
+        }
+      }
+    }
+  }
+]]
+
 -- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreview
 M.submit_pull_request_review_mutation =
   [[
@@ -977,6 +1011,12 @@ M.update_pull_request_state_mutation =
         closedAt
         updatedAt
         url
+        files(first:100) {
+          nodes {
+            path
+            viewerViewedState 
+          } 
+        }
         merged
         mergedBy {
           login
@@ -1375,6 +1415,12 @@ query($endCursor: String) {
       closedAt
       updatedAt
       url
+      files(first:100) {
+        nodes {
+          path
+          viewerViewedState 
+        } 
+      }
       merged
       mergedBy {
         ... on Organization { name }

--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -170,6 +170,12 @@ M.keypress_event_cbs = {
     local current_review = require"octo.reviews".get_current_review()
     current_review:submit('REQUEST_CHANGES')
   end,
+  toggle_viewed = function()
+    local layout = M.get_current_layout()
+    if layout then
+      layout.file_panel:get_file_at_cursor():toggle_viewed()
+    end
+  end,
 }
 
 function M.get_current_layout()

--- a/lua/octo/model/pull-request.lua
+++ b/lua/octo/model/pull-request.lua
@@ -8,6 +8,7 @@ local M = {}
 ---@field id string
 ---@field left Rev
 ---@field right Rev
+---@field files table
 local PullRequest = {}
 PullRequest.__index = PullRequest
 
@@ -19,8 +20,12 @@ function PullRequest:new(opts)
     number = opts.number,
     id = opts.id,
     left = opts.left,
-    right = opts.right
+    right = opts.right,
   }
+  this.files = {}
+  for _, file in ipairs(opts.files) do
+    this.files[file.path] = file.viewerViewedState
+  end
   this.owner, this.name = util.split_repo(this.repo)
   setmetatable(this, self)
   return this

--- a/lua/octo/reviews/file-panel.lua
+++ b/lua/octo/reviews/file-panel.lua
@@ -222,6 +222,7 @@ function FilePanel:render()
     self.render_data:add_hl(...)
   end
 
+  local current_review = require"octo.reviews".get_current_review()
   local conf = config.get_config()
   local strlen = vim.fn.strlen
   local s = "Files changed"
@@ -270,9 +271,16 @@ function FilePanel:render()
       end
     end
 
-    -- stastus
+    -- status
     add_hl(renderer.get_git_hl(file.status), line_idx, offset + 1, offset + 2)
-    s = s .. " " .. file.status .. " "
+    s = s .. " " .. file.status
+    offset = #s
+
+    -- viewer viewed state
+    local viewerViewedStateIcon = utils.viewed_state_map[file.viewed_state].icon
+    local viewerViewedStateHl = utils.viewed_state_map[file.viewed_state].hl
+    s = s .. " " .. viewerViewedStateIcon
+    add_hl(viewerViewedStateHl, line_idx, offset + 1, offset + 4)
     offset = #s
 
     -- icon
@@ -312,7 +320,6 @@ function FilePanel:render()
     line_idx = line_idx + 1
   end
 
-  local current_review = require"octo.reviews".get_current_review()
   local right = current_review.layout.right
   local left = current_review.layout.left
   local extra_info = { left:abbrev() .. ".." .. right:abbrev() }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Adds support for toggling viewed state on PR changed files

### Does this pull request fix one issue?

Fixes https://github.com/pwntester/octo.nvim/issues/147

### Describe how you did it
viewed state is collected as part of the PR load
on the review file panel, it is used to show an icon indicating if the file has been marked as viewed or not
A new mapping (`<leader><space>`) sends a GraphQL API mutation to change the viewed state and redraws the file panel


