### PR TITLE
Enable `gf` on thread blocks

### DIFF
--- a/lua/octo.lua
+++ b/lua/octo.lua
@@ -3,7 +3,6 @@ local gh = require "octo.gh"
 local signs = require "octo.signs"
 local constants = require "octo.constants"
 local config = require "octo.config"
-local colors = require'octo.colors'
 local utils = require "octo.utils"
 local graphql = require "octo.graphql"
 local writers = require "octo.writers"
@@ -17,32 +16,9 @@ local M = {}
 _G.octo_repo_issues = {}
 _G.octo_buffers = {}
 
-local function check_login()
-  gh.run(
-    {
-      args = {"auth", "status"},
-      cb = function(_, stderr)
-        if stderr and not utils.is_blank(stderr) then
-          local name = string.match(stderr, "Logged in to [^%s]+ as ([^%s]+)")
-          if name then
-            vim.g.octo_viewer = name
-          else
-            vim.notify(stderr, 2)
-          end
-        end
-      end
-    }
-  )
-end
-
-function M.init()
-  colors.setup()
-end
-
 function M.setup(user_config)
   signs.setup()
   config.setup(user_config or {})
-  check_login()
 end
 
 function M.configure_octo_buffer(bufnr)

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -297,7 +297,7 @@ function M.add_comment()
   local _thread = utils.get_thread_at_cursor(bufnr)
   local thread_id = _thread.threadId
   local replyTo = _thread.replyTo
-  local thread_end_line = _thread.endLine
+  local thread_end_line = _thread.bufferEndLine
   if thread_id and not buffer:isReviewThread() then
     vim.notify("[Octo] Start a new review to reply to a thread", 2)
     return
@@ -350,7 +350,9 @@ function M.delete_comment()
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
   if not buffer then return end
-  local comment, start_line, end_line = utils.get_comment_at_cursor(bufnr)
+  local comment = utils.get_comment_at_cursor(bufnr)
+  local start_line = comment.bufferStartLine
+  local end_line = comment.bufferEndLine
   if not comment then
     vim.notify("[Octo] The cursor does not seem to be located at any comment", 1)
     return
@@ -458,7 +460,7 @@ function M.resolve_thread()
   if not buffer then return end
   local _thread = utils.get_thread_at_cursor(bufnr)
   local thread_id = _thread.threadId
-  local thread_line = _thread.startLine
+  local thread_line = _thread.bufferStartLine
   local query = graphql("resolve_review_thread_mutation", thread_id)
   gh.run(
     {
@@ -498,7 +500,7 @@ function M.unresolve_thread()
   if not buffer then return end
   local _thread = utils.get_thread_at_cursor(bufnr)
   local thread_id = _thread.threadId
-  local thread_line = _thread.startLine
+  local thread_line = _thread.bufferStartLine
   local query = graphql("unresolve_review_thread_mutation", thread_id)
   gh.run(
     {

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -294,10 +294,14 @@ function M.add_comment()
     comment_kind = "IssueComment"
   end
 
+  local replyTo, thread_id, thread_end_line
   local _thread = utils.get_thread_at_cursor(bufnr)
-  local thread_id = _thread.threadId
-  local replyTo = _thread.replyTo
-  local thread_end_line = _thread.bufferEndLine
+  if _thread then
+    thread_id = _thread.threadId
+    replyTo = _thread.replyTo
+    thread_end_line = _thread.bufferEndLine
+  end
+
   if thread_id and not buffer:isReviewThread() then
     vim.notify("[Octo] Start a new review to reply to a thread", 2)
     return
@@ -459,6 +463,7 @@ function M.resolve_thread()
   local buffer = octo_buffers[bufnr]
   if not buffer then return end
   local _thread = utils.get_thread_at_cursor(bufnr)
+  if not _thread then return end
   local thread_id = _thread.threadId
   local thread_line = _thread.bufferStartLine
   local query = graphql("resolve_review_thread_mutation", thread_id)
@@ -499,6 +504,7 @@ function M.unresolve_thread()
   local buffer = octo_buffers[bufnr]
   if not buffer then return end
   local _thread = utils.get_thread_at_cursor(bufnr)
+  if not _thread then return end
   local thread_id = _thread.threadId
   local thread_line = _thread.bufferStartLine
   local query = graphql("unresolve_review_thread_mutation", thread_id)

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -255,10 +255,6 @@ function M.octo(object, action, ...)
     vim.notify("[Octo] Missing arguments", 1)
     return
   end
-  if not vim.g.octo_viewer then
-    vim.notify("[Octo] You are not logged into any GitHub hosts. Run `gh auth login` to authenticate.", 2)
-    return
-  end
   local o = M.commands[object]
   if not o then
     local repo, number, kind = utils.parse_url(object)

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -294,7 +294,10 @@ function M.add_comment()
     comment_kind = "IssueComment"
   end
 
-  local thread_id, _, thread_end_line, replyTo = utils.get_thread_at_cursor(bufnr)
+  local _thread = utils.get_thread_at_cursor(bufnr)
+  local thread_id = _thread.threadId
+  local replyTo = _thread.replyTo
+  local thread_end_line = _thread.endLine
   if thread_id and not buffer:isReviewThread() then
     vim.notify("[Octo] Start a new review to reply to a thread", 2)
     return
@@ -357,7 +360,8 @@ function M.delete_comment()
     query = graphql("delete_issue_comment_mutation", comment.id)
   elseif comment.kind == "PullRequestReviewComment" then
     query = graphql("delete_pull_request_review_comment_mutation", comment.id)
-    threadId = utils.get_thread_at_cursor(bufnr)
+    local _thread = utils.get_thread_at_cursor(bufnr)
+    threadId = _thread.threadId
   elseif comment.kind == "PullRequestReview" then
     -- Review top level comments cannot be deleted here
     return
@@ -452,7 +456,9 @@ function M.resolve_thread()
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
   if not buffer then return end
-  local thread_id, thread_line = utils.get_thread_at_cursor(bufnr)
+  local _thread = utils.get_thread_at_cursor(bufnr)
+  local thread_id = _thread.threadId
+  local thread_line = _thread.startLine
   local query = graphql("resolve_review_thread_mutation", thread_id)
   gh.run(
     {
@@ -490,7 +496,9 @@ function M.unresolve_thread()
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
   if not buffer then return end
-  local thread_id, thread_line = utils.get_thread_at_cursor(bufnr)
+  local _thread = utils.get_thread_at_cursor(bufnr)
+  local thread_id = _thread.threadId
+  local thread_line = _thread.startLine
   local query = graphql("unresolve_review_thread_mutation", thread_id)
   gh.run(
     {

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -59,6 +59,7 @@ M.defaults = {
       reload = "<C-r>",
       open_in_browser = "<C-b>",
       copy_url = "<C-y>",
+      goto_file = "gf",
       add_assignee = "<space>aa",
       remove_assignee = "<space>ad",
       create_label = "<space>lc",

--- a/lua/octo/gh.lua
+++ b/lua/octo/gh.lua
@@ -22,6 +22,25 @@ local env_vars = {
 
 local function run(opts)
   if not Job then return end
+
+  -- Lazy load viewer name on the first gh command
+  if not vim.g.octo_viewer then
+    local job = Job:new( {
+      enable_recording = true,
+      command = "gh",
+      args = {"auth", "status"},
+      env = env_vars
+    })
+    job:sync()
+    local stderr = table.concat(job:stderr_result(), "\n")
+    local name = string.match(stderr, "Logged in to [^%s]+ as ([^%s]+)")
+    if name then
+      vim.g.octo_viewer = name
+    else
+      vim.notify(stderr, 2)
+    end
+  end
+
   opts = opts or {}
   local conf = config.get_config()
   local mode = opts.mode or "async"

--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -71,6 +71,9 @@ M.keypress_event_cbs = {
   goto_issue = function()
     require"octo.navigation".go_to_issue()
   end,
+  goto_file = function()
+    require"octo.navigation".go_to_file()
+  end,
   next_comment = function()
     require"octo.navigation".next_comment()
   end,

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -212,12 +212,9 @@ function OctoBuffer:render_issue()
     end
     ::continue::
   end
-  -- if prev_is_event then
-  --   writers.write_block(self.bufnr, {""})
-  -- end
-
-  -- show signs
-  --self:render_signcolumn()
+  if prev_is_event then
+    writers.write_block(self.bufnr, {""})
+  end
 
   -- drop undo history
   utils.clear_history()

--- a/lua/octo/model/thread-metadata.lua
+++ b/lua/octo/model/thread-metadata.lua
@@ -4,6 +4,8 @@ local M = {}
 ---@field threadId string
 ---@field replyTo string
 ---@field reviewId string
+---@field path string
+---@field line number
 local ThreadMetadata = {}
 ThreadMetadata.__index = ThreadMetadata
 
@@ -13,7 +15,9 @@ function ThreadMetadata:new(opts)
   local this = {
     threadId = opts.threadId,
     replyTo = opts.replyTo,
-    reviewId = opts.reviewId
+    reviewId = opts.reviewId,
+    path = opts.path,
+    line = opts.line
   }
   setmetatable(this, self)
   return this

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -27,8 +27,22 @@ function M.open_in_browser(kind, repo, number)
       cmd = string.format("gh repo view --web %s", repo)
     end
   end
-  print(cmd)
   pcall(vim.cmd, "silent !"..cmd)
+end
+
+function M.go_to_file()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local buffer = octo_buffers[bufnr]
+  if not buffer then return end
+  if not buffer:isPullRequest() then return end
+  local _thread = utils.get_thread_at_cursor(bufnr)
+  local stat = vim.loop.fs_stat(utils.path_join({vim.fn.getcwd(), _thread.path}))
+  if stat and stat.type then
+    vim.cmd("e ".._thread.path)
+    vim.api.nvim_win_set_cursor(0, {_thread.line, 0})
+  else
+    vim.notify("[Octo] Cannot find file in CWD", 2)
+  end
 end
 
 function M.go_to_issue()

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -283,10 +283,11 @@ function M.get_comment_at_line(bufnr, line)
     local start_line = mark[1] + 1
     local end_line = mark[3]["end_row"] + 1
     if start_line +1 <= line and end_line - 2 >= line then
-      return comment, start_line, end_line
+      comment.bufferStartLine = start_line
+      comment.bufferEndLine = end_line
+      return comment
     end
   end
-  return nil
 end
 
 function M.get_body_at_cursor(bufnr)
@@ -317,8 +318,8 @@ function M.get_thread_at_line(bufnr, line)
       local startLine = mark[2] - 1
       local endLine = mark[4].end_row
       if startLine <= line and endLine >= line then
-        thread.startLine = startLine
-        thread.endLine = endLine
+        thread.bufferStartLine = startLine
+        thread.bufferEndLine = endLine
         return thread
       end
     end

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -314,10 +314,12 @@ function M.get_thread_at_line(bufnr, line)
   for _, mark in ipairs(thread_marks) do
     local thread = buffer.threadsMetadata[tostring(mark[1])]
     if thread then
-      local startLine = mark[2]
+      local startLine = mark[2] - 1
       local endLine = mark[4].end_row
       if startLine <= line and endLine >= line then
-        return thread.threadId, startLine, endLine, thread.replyTo, thread.reviewId
+        thread.startLine = startLine
+        thread.endLine = endLine
+        return thread
       end
     end
   end

--- a/lua/octo/writers.lua
+++ b/lua/octo/writers.lua
@@ -1337,7 +1337,9 @@ function M.write_threads(bufnr, threads)
     buffer.threadsMetadata[tostring(thread_mark_id)] = ThreadMetadata:new({
       threadId = thread.id,
       replyTo = thread.comments.nodes[1].id,
-      reviewId = thread.comments.nodes[1].pullRequestReview.id
+      reviewId = thread.comments.nodes[1].pullRequestReview.id,
+      path = thread.path,
+      line = thread.originalLine
     })
   end
 

--- a/lua/octo/writers.lua
+++ b/lua/octo/writers.lua
@@ -1339,7 +1339,7 @@ function M.write_threads(bufnr, threads)
       replyTo = thread.comments.nodes[1].id,
       reviewId = thread.comments.nodes[1].pullRequestReview.id,
       path = thread.path,
-      line = thread.originalLine
+      line = thread.originalStartLine ~= vim.NIL and thread.originalStartLine or thread.originalLine
     })
   end
 

--- a/plugin/octo.vim
+++ b/plugin/octo.vim
@@ -19,6 +19,6 @@ augroup octo_autocmds
   au WinLeave * lua require'octo.reviews'.on_win_leave()
 augroup END
 
-lua require"octo".init()
+lua require'octo.colors'.setup()
 
 let g:loaded_octo = 1


### PR DESCRIPTION
Enable a new navigation `goto_file` mapped to `gf` by default which navigates 
to the location of a thread if the file is available under the CWD
This new navigation is only enabled on PR buffers within a Thread block

- Refactor get_thread_at_cursor to return just a single object
- Add new `goto_file` config and default mapping `gf`
- Refactor get_comment_at_cursor to return a single obj
- Adjust thread start line
