### PR TITLE
Fix PR checkout from telescope list

### DIFF
--- a/lua/octo/telescope/menu.lua
+++ b/lua/octo/telescope/menu.lua
@@ -261,11 +261,7 @@ local function checkout_pull_request(repo)
   return function(prompt_bufnr)
     local selection = action_state.get_selected_entry(prompt_bufnr)
     actions.close(prompt_bufnr)
-    local tmp_table = vim.split(selection.value, "\t")
-    if vim.tbl_isempty(tmp_table) then
-      return
-    end
-    local number = tmp_table[1]
+    local number = selection.value
     local args = {"pr", "checkout", number, "-R", repo}
     if repo == "" then
       args = {"pr", "checkout", number}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Checking out PR from `Octo pr list` does not work. The telescope entry is being interpreted incorrectly, `selection.value` is the PR number rather than a table.


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Use the correct number when attempting to checkout a PR

### Describe how to verify it
Tested the change locally

### Special notes for reviews

