### PR TITLE
fix: correct function checkout_pr points to

### DIFF
--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -24,7 +24,7 @@ M.keypress_event_cbs = {
     if repo then require"octo.telescope.menu".issues(repo) end
   end,
   checkout_pr = function()
-    require"octo.commands".checkout_pr()
+    require"octo.commands".commands.pr.checkout()
   end,
   list_commits = function()
     require"octo.telescope.menu".commits()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Checking out a PR got refactored in #184 and now the mapping points to a non-existing function in `commands.lua`.

### Does this pull request fix one issue?

No issue exists but happy to add one post-hoc if desired.

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Changing what command `checkout_pr` in `mappings.lua` points to, namely `commands.pr.checkout`

### Describe how to verify it

Try checking out as is and you'll run into an error. This PR is a simple fix for that :)

### Special notes for reviews

