### PR TITLE
fix: require 'octo' for telescope previewer

### DIFF
--- a/lua/octo/telescope/previewers.lua
+++ b/lua/octo/telescope/previewers.lua
@@ -1,3 +1,4 @@
+require "octo"
 local OctoBuffer = require("octo.model.octo-buffer").OctoBuffer
 local previewers = require "telescope.previewers"
 local utils = require "octo.utils"


### PR DESCRIPTION
### Describe what this PR does / why we need it

'octo/writers.lua' uses the global 'octo_buffers', which 'octo.lua'
initializes. However, if a user calls a function that uses the telescope
previewer (e.g. 'Octo pr list') then there's a chance that
'octo/writers.lua' executes before the initialization of 'octo_buffers'.
This results in an attempt to index a nil global.

### Does this pull request fix one issue?

Fixes #207

### Describe how you did it

To fix this, import  the 'octo' module so 'octo_buffers' has guaranteed
initialization.

### Describe how to verify it

1. Launch nvim in repo with open pull requests
2. Execute `Octo pr list`
3. No error message should appear.

### Special notes for reviews

