### PR TITLE
Pass in proxy variables to plenary job

### DIFF
--- a/lua/octo/gh.lua
+++ b/lua/octo/gh.lua
@@ -20,6 +20,8 @@ local env_vars = {
   LocalAppData = vim.env["LocalAppData"],
   HOME = vim.env["HOME"],
   NO_COLOR = 1,
+  http_proxy = vim.env["http_proxy"],
+  https_proxy = vim.env['https_proxy'],
 }
 
 -- uses GH to get the name of the authenticated user


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
The error below is shown when we try to reach a GHE instance under a corporate proxy:
```
> :Octo issue list

Fetching issues (this may take a while) ...
git.mycompay.com
  X git.mycompay.com: authentication failed
  - The git.mycompay.com token in /Users/waltermaldonadojr/.config/gh/hosts.yml is no longer valid.
  - To re-authenticate, run: gh auth login -h git.mycompay.com
  - To forget about this host, run: gh auth logout -h git.mycompay.com
```

But it turns out authentication is working ok. What happens is that the gh client cannot reach the server under a corporate proxy. Passing in the env variables to the plenary job seems to fix the issue.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
Added the variables in plenary job initialization, grabbing them from vim.env

### Describe how to verify it
You'll need to setup a proxy and configure your pc to only work sending your web requests through the proxy. This way outbound connections from your pc will be blocked and the Octo client will not be able to reach internet without the proxy vars set up.

### Special notes for reviews
Great project, hope it helps!
