### PR TITLE
Use git remote get-url

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -146,9 +146,9 @@ function M.get_remote_name()
   local conf = config.get_config()
   local candidates = conf.default_remote
   for _, candidate in ipairs(candidates) do
-    local cmd = string.format("git config --get remote.%s.url", candidate)
+    local cmd = string.format("git remote get-url %s", candidate)
     local url = string.gsub(vim.fn.system(cmd), "%s+", "")
-    if not M.is_blank(url) then
+    if not string.find(url, "error") then
       local owner, name
       if #vim.split(url, "://") == 2 then
         owner = vim.split(url, "/")[#vim.split(url, "/") - 1]


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR changes the git command on `Utils.get_remote_name()` function to use the `git remote --get-url candidate`. It allows custom rewritten URLs in git config to work properly. See more: https://github.com/pwntester/octo.nvim/issues/228

### Does this pull request fix one issue?

Fixes #228 

### Describe how you did it

It's a two-line code change. The first one substitutes the `git config --get remote.%s.url` command for `git remote get-url %s`. Since the new command returns an error message, the second line ignores every candidate with an error instead of verifying a nullability.

### Describe how to verify it

`Octo pr list` should work for all the git clone options bellow:

`git clone git@github.com:nandofarias/octo.nvim.git && cd octo.nvim && nvim +"Octo pr list"`
`git clone https://github.com/nandofarias/octo.nvim.git && cd octo.nvim && nvim +"Octo pr list"`
`git config --global url."git@github.com:".insteadOf "github:" && git clone github:nandofarias/octo.nvim.git && cd octo.nvim && nvim +"Octo pr list"`


### Special notes for reviews

Let me know if I can help with anything else 😀
