### PR TITLE
Fix error recognition for `git remote` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Edit and review GitHub issues and pull requests from the comfort of your favorit
 ## ⚡️Requirements
 
 - Install [GitHub CLI](https://cli.github.com/)
+- Install [plenary.nvim](https://github.com/nvim-lua/plenary.nvim)
 - Install [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
 - Install [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons)
 
@@ -68,16 +69,23 @@ Edit and review GitHub issues and pull requests from the comfort of your favorit
 Use your favourite plugin manager to install it. eg:
 
 ```lua
-use {'pwntester/octo.nvim', config=function()
-  require"octo".setup()
-end}
+use {
+  'pwntester/octo.nvim',
+  requires = {
+    'nvim-lua/plenary.nvim',
+    'nvim-telescope/telescope.nvim',
+    'kyazdani42/nvim-web-devicons',
+  },
+  config = function ()
+    require"octo".setup()
+  end
+}
 ```
 
 ## ⚙️ Configuration
 
 ```lua
-use {'pwntester/octo.nvim', config=function()
-  require"octo".setup({
+require"octo".setup({
   default_remote = {"upstream", "origin"}; -- order to try remotes
   reaction_viewer_hint_icon = "";         -- marker for user reactions
   user_icon = " ";                        -- user icon
@@ -202,7 +210,6 @@ use {'pwntester/octo.nvim', config=function()
     }
   }
 })
-end}
 ```
 
 ## 🚀 Usage

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -146,9 +146,9 @@ function M.get_remote_name()
   local conf = config.get_config()
   local candidates = conf.default_remote
   for _, candidate in ipairs(candidates) do
-    local cmd = string.format("git remote get-url %s", candidate)
+    local cmd = string.format("git remote get-url %s 2>/dev/null", candidate)
     local url = string.gsub(vim.fn.system(cmd), "%s+", "")
-    if not string.find(url, "error") then
+    if not M.is_blank(url) then
       local owner, name
       if #vim.split(url, "://") == 2 then
         owner = vim.split(url, "/")[#vim.split(url, "/") - 1]

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -146,9 +146,16 @@ function M.get_remote_name()
   local conf = config.get_config()
   local candidates = conf.default_remote
   for _, candidate in ipairs(candidates) do
-    local cmd = string.format("git remote get-url %s 2>/dev/null", candidate)
-    local url = string.gsub(vim.fn.system(cmd), "%s+", "")
-    if not M.is_blank(url) then
+    local job = Job:new {
+      command = "git",
+      args = { "remote", "get-url", candidate },
+    }
+    job:sync()
+
+    local url = table.concat(job:result(), "\n")
+    local stderr = table.concat(job:stderr_result(), "\n")
+
+    if M.is_blank(stderr) then
       local owner, name
       if #vim.split(url, "://") == 2 then
         owner = vim.split(url, "/")[#vim.split(url, "/") - 1]


### PR DESCRIPTION
Fixes #230 

Checking for the string "error" can be problematic: 

- Firstly, errors can return other strings like "fatal", which will not be caught
- A repository url could contain error (e.g. my-error-checker.git or similar), and this will lead to false errors being caught

Using `/dev/null`, we can check for an empty string ignoring error messages.

I've tested it locally and it works for me.

Caveat: this obviously won't work with Windows machines, but not sure if we're supporting them anyway.