### PR TITLE
Add gh token to env vars passed to gh to allow for token auth

### DIFF
--- a/lua/octo/gh.lua
+++ b/lua/octo/gh.lua
@@ -13,6 +13,7 @@ local headers = {
 local env_vars = {
   PATH = vim.env["PATH"],
   GH_CONFIG_DIR = vim.env["GH_CONFIG_DIR"],
+  GITHUB_TOKEN = vim.env["GITHUB_TOKEN"],
   XDG_CONFIG_HOME = vim.env["XDG_CONFIG_HOME"],
   XDG_DATA_HOME = vim.env["XDG_DATA_HOME"],
   XDG_STATE_HOME = vim.env["XDG_STATE_HOME"],


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Allows the `GITHUB_TOKEN` env var to be sent through to `gh` when making calls out to it. This allows octo to work out of the box in environments where `GITHUB_TOKEN` is automatically set (Codespaces, for example).

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes https://github.com/pwntester/octo.nvim/issues/235

### Describe how you did it

I added `GITHUB_TOKEN` to list of environment variables that gets passed to the job that calls out to `gh`

### Describe how to verify it

I ran my version of octo in a codespace where `GITHUB_TOKEN` was set and it worked.

### Special notes for reviews

