### PR TITLE
Ensure all files from PR are loaded

### DIFF
--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -135,7 +135,7 @@ function Review:initiate()
 
   local url = string.format("repos/%s/pulls/%d/files", pr.repo, pr.number)
   gh.run {
-    args = { 'api', '--paginate', url, '--jq', '.' },
+    args = { "api",  "--paginate", url, "--jq",  "." },
     cb = function(output, stderr)
       if stderr and not utils.is_blank(stderr) then
         utils.notify(stderr, 2)

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -135,7 +135,7 @@ function Review:initiate()
 
   local url = string.format("repos/%s/pulls/%d/files", pr.repo, pr.number)
   gh.run {
-    args = { "api", "--paginate", url, "--jq",  "." },
+    args = { "api", "--paginate", url, "--jq", "." },
     cb = function(output, stderr)
       if stderr and not utils.is_blank(stderr) then
         utils.notify(stderr, 2)
@@ -146,9 +146,8 @@ function Review:initiate()
           deleted = "D",
           renamed = "R",
         }
-
         local results = {}
-        local page_outputs = vim.split(output, '\n')
+        local page_outputs = vim.split(output, "\n")
         for _, text in ipairs(page_outputs) do
           local page_result = vim.fn.json_decode(text)
           for _, result in ipairs(page_result) do

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -135,7 +135,7 @@ function Review:initiate()
 
   local url = string.format("repos/%s/pulls/%d/files", pr.repo, pr.number)
   gh.run {
-    args = { "api",  "--paginate", url, "--jq",  "." },
+    args = { "api", "--paginate", url, "--jq",  "." },
     cb = function(output, stderr)
       if stderr and not utils.is_blank(stderr) then
         utils.notify(stderr, 2)

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -147,7 +147,7 @@ function Review:initiate()
           renamed = "R",
         }
 
-        local results = utils.get_pages(output)
+        local results = utils.get_flatten_pages(output)
         local files = {}
         for _, result in ipairs(results) do
           local entry = FileEntry:new {

--- a/lua/octo/reviews.lua
+++ b/lua/octo/reviews.lua
@@ -146,15 +146,8 @@ function Review:initiate()
           deleted = "D",
           renamed = "R",
         }
-        local results = {}
-        local page_outputs = vim.split(output, "\n")
-        for _, text in ipairs(page_outputs) do
-          local page_result = vim.fn.json_decode(text)
-          for _, result in ipairs(page_result) do
-            table.insert(results, result)
-          end
-        end
 
+        local results = utils.get_pages(output)
         local files = {}
         for _, result in ipairs(results) do
           local entry = FileEntry:new {

--- a/lua/octo/reviews/file-panel.lua
+++ b/lua/octo/reviews/file-panel.lua
@@ -303,6 +303,9 @@ function FilePanel:render()
     offset = #s
 
     -- viewer viewed state
+    if not file.viewed_state then
+      file.viewed_state = "UNVIEWED"
+    end
     local viewerViewedStateIcon = utils.viewed_state_map[file.viewed_state].icon
     local viewerViewedStateHl = utils.viewed_state_map[file.viewed_state].hl
     s = s .. " " .. viewerViewedStateIcon

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -488,6 +488,18 @@ function M.get_pages(text)
   return results
 end
 
+function M.get_flatten_pages(text)
+  local results = {}
+  local page_outputs = vim.split(text, "\n")
+  for _, page in ipairs(page_outputs) do
+    local decoded_page = vim.fn.json_decode(page)
+    for _, result in ipairs(decoded_page) do
+      table.insert(results, result)
+    end
+  end
+  return results
+end
+
 function M.aggregate_pages(text, aggregation_key)
   -- aggregation key can be at any level (eg: comments)
   -- take the first response and extend it with elements from the


### PR DESCRIPTION
### Describe what this PR does / why we need it

When `gh` returns multiple pages, the plugins break cause the output is not a JSON file but the concatenation of multiple JSON files.

### Does this pull request fix one issue?

NONE

### Describe how you did it

One way to break it down is to use the `--jq` argument that will return each JSON content on a different page.
 We can then split the returned content and populate the results object with all the PR files

### Describe how to verify it

I guess one could create a repo with a PR that generates multiple diffs to enforce the pagination.
For me it breaks with the following stack trace:

```
Error executing vim.schedule lua callback: Vim:E474: Trailing characters: ... stack traceback:
        [C]: in function 'json_decode'
        .../.config/nvim/plugged/octo.nvim/lua/octo/reviews.lua:149: in function 'cb'
        .../.config/nvim/plugged/octo.nvim/lua/octo/gh.lua:83: in function 'cb'
```

### Special notes for reviews

After applying this patch, It looks like the plugin can also break as it tries to load too many files. (it throws a   pid = "EMFILE: too many open files"). I haven't had time to investigate this part, but it might require follow-up work.