### PR TITLE
Add action to list all available Octo actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 | | resume| Edit a pending review for current PR |
 | | discard| Deletes a pending review for current PR if any |
 | | comments| View pending review comments |
+| octo | actions | Lists all available Octo actions|
 
 0. `[repo]`: If repo is not provided, it will be derived from `<cwd>/.git/config`.
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 | | resume| Edit a pending review for current PR |
 | | discard| Deletes a pending review for current PR if any |
 | | comments| View pending review comments |
-| octo | actions | Lists all available Octo actions|
+| actions |  | Lists all available Octo actions|
 
 0. `[repo]`: If repo is not provided, it will be derived from `<cwd>/.git/config`.
 

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -12,6 +12,9 @@ local M = {}
 
 -- supported commands
 M.commands = {
+  commands = function()
+    M.octo_commands()
+  end,
   issue = {
     create = function(repo)
       M.create_issue(repo)
@@ -279,6 +282,11 @@ function M.octo(object, action, ...)
       return
     end
   else
+    if type(o) == "function" then
+      o(...)
+      return
+    end
+
     local a = o[action]
     if not a then
       utils.notify("Incorrect action, valid actions are:" .. vim.inspect(vim.tbl_keys(o)), 1)
@@ -1417,6 +1425,27 @@ function M.copy_url()
   local url = buffer.node.url
   vim.fn.setreg("+", url, "c")
   utils.notify("Copied URL '" .. url .. "' to the system clipboard (+ register)", 1)
+end
+
+function M.octo_commands()
+  local flattened_commands = {}
+
+  for object, commands in pairs(M.commands) do
+    if (object ~= "commands") then
+      for name, fun in pairs(commands) do
+        table.insert(
+          flattened_commands,
+          {
+            object = object,
+            name = name,
+            fun = fun
+          }
+        )
+      end
+    end
+  end
+
+  picker.commands(flattened_commands)
 end
 
 return M

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -12,9 +12,11 @@ local M = {}
 
 -- supported commands
 M.commands = {
-  commands = function()
-    M.octo_commands()
-  end,
+  octo = {
+    actions = function()
+      M.octo_actions()
+    end,
+  },
   issue = {
     create = function(repo)
       M.create_issue(repo)
@@ -282,11 +284,6 @@ function M.octo(object, action, ...)
       return
     end
   else
-    if type(o) == "function" then
-      o(...)
-      return
-    end
-
     local a = o[action]
     if not a then
       utils.notify("Incorrect action, valid actions are:" .. vim.inspect(vim.tbl_keys(o)), 1)
@@ -1427,25 +1424,23 @@ function M.copy_url()
   utils.notify("Copied URL '" .. url .. "' to the system clipboard (+ register)", 1)
 end
 
-function M.octo_commands()
-  local flattened_commands = {}
+function M.octo_actions()
+  local flattened_actions = {}
 
   for object, commands in pairs(M.commands) do
-    if (object ~= "commands") then
-      for name, fun in pairs(commands) do
-        table.insert(
-          flattened_commands,
-          {
-            object = object,
-            name = name,
-            fun = fun
-          }
-        )
-      end
+    for name, fun in pairs(commands) do
+      table.insert(
+        flattened_actions,
+        {
+          object = object,
+          name = name,
+          fun = fun
+        }
+      )
     end
   end
 
-  picker.commands(flattened_commands)
+  picker.octo_actions(flattened_actions)
 end
 
 return M

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1431,16 +1431,13 @@ function M.octo_actions()
   local flattened_actions = {}
 
   for object, commands in pairs(M.commands) do
-    if object ~= 'actions' then
+    if object ~= "actions" then
       for name, fun in pairs(commands) do
-        table.insert(
-          flattened_actions,
-          {
-            object = object,
-            name = name,
-            fun = fun
-          }
-        )
+        table.insert(flattened_actions, {
+          object = object,
+          name = name,
+          fun = fun,
+        })
       end
     end
   end

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -12,11 +12,9 @@ local M = {}
 
 -- supported commands
 M.commands = {
-  octo = {
-    actions = function()
-      M.octo_actions()
-    end,
-  },
+  actions = function()
+    M.octo_actions()
+  end,
   issue = {
     create = function(repo)
       M.create_issue(repo)
@@ -284,6 +282,11 @@ function M.octo(object, action, ...)
       return
     end
   else
+    if type(o) == "function" then
+      o(...)
+      return
+    end
+
     local a = o[action]
     if not a then
       utils.notify("Incorrect action, valid actions are:" .. vim.inspect(vim.tbl_keys(o)), 1)
@@ -1428,15 +1431,17 @@ function M.octo_actions()
   local flattened_actions = {}
 
   for object, commands in pairs(M.commands) do
-    for name, fun in pairs(commands) do
-      table.insert(
-        flattened_actions,
-        {
-          object = object,
-          name = name,
-          fun = fun
-        }
-      )
+    if object ~= 'actions' then
+      for name, fun in pairs(commands) do
+        table.insert(
+          flattened_actions,
+          {
+            object = object,
+            name = name,
+            fun = fun
+          }
+        )
+      end
     end
   end
 

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -508,4 +508,40 @@ function M.gen_from_gist()
   end
 end
 
+function M.gen_from_octo_commands(commands)
+  local make_display = function(entry)
+    if not entry then
+      return nil
+    end
+
+    local columns = {
+      {entry.value.object, "TelescopeResultsNumber"},
+      {entry.value.name}
+    }
+
+    local displayer =
+      entry_display.create {
+      separator = "",
+      items = {
+        {width = 12},
+        {remaining = true}
+      }
+    }
+
+    return displayer(columns)
+  end
+
+  return function(command)
+    if not command or vim.tbl_isempty(command) then
+      return nil
+    end
+
+    return {
+      value = command,
+      ordinal = command.object .. " " .. command.name,
+      display = make_display
+    }
+  end
+end
+
 return M

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -515,17 +515,16 @@ function M.gen_from_octo_actions()
     end
 
     local columns = {
-      {entry.action.object, "TelescopeResultsNumber"},
-      {entry.action.name}
+      { entry.action.object, "TelescopeResultsNumber" },
+      { entry.action.name },
     }
 
-    local displayer =
-      entry_display.create {
+    local displayer = entry_display.create {
       separator = "",
       items = {
-        {width = 12},
-        {remaining = true}
-      }
+        { width = 12 },
+        { remaining = true },
+      },
     }
 
     return displayer(columns)
@@ -540,7 +539,7 @@ function M.gen_from_octo_actions()
       value = action.name,
       ordinal = action.object .. " " .. action.name,
       display = make_display,
-      action = action
+      action = action,
     }
   end
 end

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -508,15 +508,15 @@ function M.gen_from_gist()
   end
 end
 
-function M.gen_from_octo_commands(commands)
+function M.gen_from_octo_actions()
   local make_display = function(entry)
     if not entry then
       return nil
     end
 
     local columns = {
-      {entry.value.object, "TelescopeResultsNumber"},
-      {entry.value.name}
+      {entry.action.object, "TelescopeResultsNumber"},
+      {entry.action.name}
     }
 
     local displayer =
@@ -531,15 +531,16 @@ function M.gen_from_octo_commands(commands)
     return displayer(columns)
   end
 
-  return function(command)
-    if not command or vim.tbl_isempty(command) then
+  return function(action)
+    if not action or vim.tbl_isempty(action) then
       return nil
     end
 
     return {
-      value = command,
-      ordinal = command.object .. " " .. command.name,
-      display = make_display
+      value = action.name,
+      ordinal = action.object .. " " .. action.name,
+      display = make_display,
+      action = action
     }
   end
 end

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -921,9 +921,9 @@ function M.repos(opts)
 end
 
 --
--- OCTO COMMANDS
+-- OCTO
 --
-function M.commands(commands)
+function M.octo_actions(flattened_actions)
   local opts = {
     preview_title = "",
     prompt_title = "",
@@ -934,8 +934,8 @@ function M.commands(commands)
     opts,
     {
       finder = finders.new_table {
-        results = commands,
-        entry_maker = entry_maker.gen_from_octo_commands(commands)
+        results = flattened_actions,
+        entry_maker = entry_maker.gen_from_octo_actions()
       },
       sorter = conf.generic_sorter(opts),
       attach_mappings = function()
@@ -943,7 +943,7 @@ function M.commands(commands)
           function(prompt_bufnr)
             local selected_command = action_state.get_selected_entry(prompt_bufnr)
             actions.close(prompt_bufnr)
-            selected_command.value.fun()
+            selected_command.action.fun()
           end
         )
         return true
@@ -968,7 +968,7 @@ M.picker = {
   repos = M.repos,
   live_issues = M.issue_search,
   live_prs = M.pull_request_search,
-  commands = M.commands
+  octo_actions = M.octo_actions
 }
 
 return M

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -927,29 +927,24 @@ function M.octo_actions(flattened_actions)
   local opts = {
     preview_title = "",
     prompt_title = "",
-    results_title = ""
+    results_title = "",
   }
 
-  pickers.new(
-    opts,
-    {
-      finder = finders.new_table {
-        results = flattened_actions,
-        entry_maker = entry_maker.gen_from_octo_actions()
-      },
-      sorter = conf.generic_sorter(opts),
-      attach_mappings = function()
-        actions.select_default:replace(
-          function(prompt_bufnr)
-            local selected_command = action_state.get_selected_entry(prompt_bufnr)
-            actions.close(prompt_bufnr)
-            selected_command.action.fun()
-          end
-        )
-        return true
-      end
-    }
-  ):find()
+  pickers.new(opts, {
+    finder = finders.new_table {
+      results = flattened_actions,
+      entry_maker = entry_maker.gen_from_octo_actions(),
+    },
+    sorter = conf.generic_sorter(opts),
+    attach_mappings = function()
+      actions.select_default:replace(function(prompt_bufnr)
+        local selected_command = action_state.get_selected_entry(prompt_bufnr)
+        actions.close(prompt_bufnr)
+        selected_command.action.fun()
+      end)
+      return true
+    end,
+  }):find()
 end
 
 M.picker = {
@@ -968,7 +963,7 @@ M.picker = {
   repos = M.repos,
   live_issues = M.issue_search,
   live_prs = M.pull_request_search,
-  octo_actions = M.octo_actions
+  octo_actions = M.octo_actions,
 }
 
 return M

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -920,6 +920,38 @@ function M.repos(opts)
   }
 end
 
+--
+-- OCTO COMMANDS
+--
+function M.commands(commands)
+  local opts = {
+    preview_title = "",
+    prompt_title = "",
+    results_title = ""
+  }
+
+  pickers.new(
+    opts,
+    {
+      finder = finders.new_table {
+        results = commands,
+        entry_maker = entry_maker.gen_from_octo_commands(commands)
+      },
+      sorter = conf.generic_sorter(opts),
+      attach_mappings = function()
+        actions.select_default:replace(
+          function(prompt_bufnr)
+            local selected_command = action_state.get_selected_entry(prompt_bufnr)
+            actions.close(prompt_bufnr)
+            selected_command.value.fun()
+          end
+        )
+        return true
+      end
+    }
+  ):find()
+end
+
 M.picker = {
   issues = M.issues,
   prs = M.pull_requests,
@@ -936,6 +968,7 @@ M.picker = {
   repos = M.repos,
   live_issues = M.issue_search,
   live_prs = M.pull_request_search,
+  commands = M.commands
 }
 
 return M


### PR DESCRIPTION
### Describe what this PR does / why we need it
Adds an action that lists all available Octo actions and runs them when selected.


### Does this pull request fix one issue?
Fixes #163. 

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. Added a new top-level `Octo actions` action. This required adding support for actions without an object.
2. This iterates through each object in `commands.lua` and flattens them into an array that's then passed to the provider.
3. The provider renders each action with two columns: `object action`, e.g. `pr list`.


### Describe how to verify it
Run `Octo actions`.


### Special notes for reviews
This currently doesn't handle actions that require arguments like `issue create`. I see two options for that:
1. When building the `flattened_actions` array, we inspect the given action to determine if it requires an argument and then prompt the user for each argument.
2. Adjust existing actions that require arguments so they can be called without the argument, and then prompt the user if the args aren't given.

@pwntester what do you think?
