### PR TITLE
let browser cmd open current PR if not specified

### DIFF
--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -11,6 +11,11 @@ function M.open_in_browser(kind, repo, number)
     local bufnr = vim.api.nvim_get_current_buf()
     local buffer = octo_buffers[bufnr]
     if not buffer then
+      utils.get_pull_request_for_current_branch(function(pr)
+        if pr ~= nil then
+          M.open_in_browser("pr", pr.repo, pr.number)
+        end
+      end)
       return
     end
     if buffer:isPullRequest() then


### PR DESCRIPTION
### Describe what this PR does / why we need it

Not sure if this is the best way to achieve this, but this would be a useful feature for me 
I can just open vim and type `:Octo pr browser` and it takes me to the current PR associated to my branch

### Does this pull request fix one issue?

NONE

### Describe how you did it

👇 

### Describe how to verify it

use `:Octo pr browser` after opening vim to navigate to PR

### Special notes for reviews

Since this is async it would be nice to print some kind of loading message first while we are waiting for gh to return
