### PR TITLE
Update docs to correct deprecated treesitter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Just add the following lines to your TreeSitter config:
 
 ```lua
 local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
-parser_config.markdown.used_by = "octo"
+parser_config.markdown.filetype_to_parsername = "octo"
 ```
 
 ## ✋ Contributing

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -289,7 +289,7 @@ Can I use treesitter markdown parser with octo buffers?~
   Just add the following lines to your TreeSitter config:
 >
   local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
-  parser_config.markdown.used_by = "octo"
+  parser_config.markdown.filetype_to_parsername = "octo"
 <
 
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Updates the documentation to resolve a deprecation message from a recent treesitter change: https://github.com/nvim-treesitter/nvim-treesitter/commit/58a4897e6d5f21a9178ae0f802d47af26d67a219

```
used_by is deprecated, please use 'filetype_to_parsername'
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #258 

### Describe how you did it
Updated docs and README to use the new syntax `parser_config.markdown.filetype_to_parsername = "octo"`

### Describe how to verify it
Changed my neovim config locally to use `parser_config.markdown.filetype_to_parsername = "octo"` and the deprecated message vanished 

### Special notes for reviews

