### PR TITLE
Allow users to change the submit_win mappings

### DIFF
--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -166,6 +166,7 @@ function M.setup(user_config)
     M._config.mappings.review_thread = (user_config.mappings.review_thread or M._config.mappings.review_thread)
     M._config.mappings.review = (user_config.mappings.review or M._config.mappings.review)
     M._config.mappings.file_panel = (user_config.mappings.file_panel or M._config.mappings.file_panel)
+    M._config.mappings.submit_win = (user_config.mappings.submit_win or M._config.mappings.submit_win)
   end
 end
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
To allow users to provide their own submit_win keymaps

### Does this pull request fix one issue?

Fixes #270 

### Describe how you did it
Added the missing user mapping override

### Describe how to verify it
Provide a custom submit_win mapping to the configuration and expect it to be used in the submit window

### Special notes for reviews

