### PR TITLE
feat: provide entry filename for better integration with nvim

### DIFF
--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -48,8 +48,16 @@ function M.gen_from_issue(max_number, print_repo)
     if not obj or vim.tbl_isempty(obj) then
       return nil
     end
+    local kind = obj.__typename == "Issue" and "issue" or "pull_request"
+    local filename
+    if kind == "issue" then
+      filename = utils.get_issue_uri(obj.repository.nameWithOwner, obj.number)
+    else
+      filename = utils.get_pull_request_uri(obj.repository.nameWithOwner, obj.number)
+    end
     return {
-      kind = obj.__typename == "Issue" and "issue" or "pull_request",
+      filename = filename,
+      kind = kind,
       value = obj.number,
       ordinal = obj.number .. " " .. obj.title,
       display = make_display,
@@ -426,6 +434,7 @@ function M.gen_from_repo(max_nameWithOwner, max_forkCount, max_stargazerCount)
     end
 
     return {
+      filename = utils.get_repo_uri(_, repo),
       kind = "repo",
       value = repo.nameWithOwner,
       ordinal = repo.nameWithOwner .. " " .. repo.description,

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -550,18 +550,33 @@ function M.get_repo_number_from_varargs(...)
   return repo, number
 end
 
+--- Get the URI for a repository
+function M.get_repo_uri(_, repo)
+  return string.format("octo://%s/repo", repo)
+end
+
+--- Get the URI for an issue
+function M.get_issue_uri(...)
+  local repo, number = M.get_repo_number_from_varargs(...)
+  return string.format("octo://%s/issue/%s", repo, number)
+end
+
+--- Get the URI for an pull request
+function M.get_pull_request_uri(...)
+  local repo, number = M.get_repo_number_from_varargs(...)
+  return string.format("octo://%s/pull/%s", repo, number)
+end
+
 function M.get_repo(_, repo)
-  vim.cmd(string.format("edit octo://%s/repo", repo))
+  vim.cmd("edit " .. M.get_repo_uri(_, repo))
 end
 
 function M.get_issue(...)
-  local repo, number = M.get_repo_number_from_varargs(...)
-  vim.cmd(string.format("edit octo://%s/issue/%s", repo, number))
+  vim.cmd("edit " .. M.get_issue_uri(...))
 end
 
 function M.get_pull_request(...)
-  local repo, number = M.get_repo_number_from_varargs(...)
-  vim.cmd(string.format("edit octo://%s/pull/%s", repo, number))
+  vim.cmd("edit " .. M.get_pull_request_uri(...))
 end
 
 function M.parse_url(url)

--- a/lua/octo/writers.lua
+++ b/lua/octo/writers.lua
@@ -476,7 +476,10 @@ function M.write_comment(bufnr, comment, kind, line)
     table.insert(header_vt, { conf.timeline_marker .. " ", "OctoTimelineMarker" })
     table.insert(header_vt, { "REVIEW: ", "OctoTimelineItemHeading" })
     --vim.list_extend(header_vt, author_bubble)
-    table.insert(header_vt, { comment.author.login .. " ", comment.viewerDidAuthor and "OctoUserViewer" or "OctoUser" })
+    table.insert(header_vt, {
+      comment.author.login .. " ",
+      comment.viewerDidAuthor and "OctoUserViewer" or "OctoUser",
+    })
     vim.list_extend(header_vt, state_bubble)
     table.insert(header_vt, { " " .. utils.format_date(comment.createdAt), "OctoDate" })
     if not comment.viewerCanUpdate then


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

By providing the filename as part of the entry, now a user can load multiple
entries from Telescope to the quickfix/loclist and actually move through them
and making Octo fill the buffers by triggering the BufReadCmd.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
I don't see one, but I think this is an actual bug. Before this code if you tried filling the quickfix list you wouldn't get anything useful.

### Describe how you did it

Break up editing function into uri generation and editing the uri.

### Describe how to verify it

1. `Octo issue list`
2. Select multiple with telescope
3. Use send to quickfix/loclist action.
4. Now navigation of the quickfix list has the buffer names, and Octo fills them.

### Special notes for reviews

I tested pull requests and issues, but not the repo one. Can't seem to make octo show me the repositores I own. Or perhaps I made a mistake?