### PR TITLE
Fix broken remote detection

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -166,7 +166,9 @@ function M.get_remote_name()
       else
         return
       end
-      return string.gsub(vim.split(url, sep)[2], ".git$", "")
+      return table.concat({
+        unpack(vim.split(string.gsub(vim.split(url, sep)[2], ".git$", ""), "/"), 2)
+      }, "/")
     end
   end
 end


### PR DESCRIPTION
### Describe what this PR does / why we need it

The current implementation of `utils.get_remote_name`, introduced via https://github.com/pwntester/octo.nvim/commit/cd8bdcbfca4dd57b38fe25ba570a2e3f51b1f77b, returns a wrong value containing a domain name, e.g. `github.com/pwntester/octo.nvim` ,  which subsequently makes many commands not able to function properly, including `Octo issue list` , `Octo pr list` etc. 

### Does this pull request fix one issue?

None

### Describe how you did it

Strip domain name before returning the value.

e.g. "github.com/pwntester/octo.nvim" to "pwntester/octo.nvim"

### Describe how to verify it


### Special notes for reviews

I'm not sure what kind of URL is expected in the  ":/" or ":" separator case. Please tell me if this PR does not work properly for those cases.
