### PR TITLE
fix: specify hostname if remote is not github.com

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -37,10 +37,7 @@ M.commands = {
     end,
     search = function(repo, ...)
       local opts = M.process_varargs(repo, ...)
-      if not opts.repo or opts.repo == vim.NIL then
-        opts.repo = utils.get_remote_name()
-      end
-      if not opts.repo then
+      if utils.is_blank(opts.repo) then
         utils.notify("Cannot find repo", 2)
         return
       end
@@ -105,11 +102,7 @@ M.commands = {
     end,
     search = function(repo, ...)
       local opts = M.process_varargs(repo, ...)
-
-      if not opts.repo or opts.repo == vim.NIL then
-        opts.repo = utils.get_remote_name()
-      end
-      if not opts.repo then
+      if utils.is_blank(opts.repo) then
         utils.notify("Cannot find repo", 2)
         return
       end
@@ -274,7 +267,7 @@ M.commands = {
 
 function M.process_varargs(repo, ...)
   local args = table.pack(...)
-  if not repo then
+  if utils.is_blank(repo) then
     repo = utils.get_remote_name()
   elseif #vim.split(repo, "/") ~= 2 then
     table.insert(args, repo)

--- a/lua/octo/gh.lua
+++ b/lua/octo/gh.lua
@@ -56,12 +56,21 @@ function M.run(opts)
   opts = opts or {}
   local conf = config.get_config()
   local mode = opts.mode or "async"
+  local hostname = ""
+  local remote_hostname = require("octo.utils").get_remote_host()
   if opts.args[1] == "api" then
     table.insert(opts.args, "-H")
     table.insert(opts.args, "Accept: " .. table.concat(headers, ";"))
-    if not require("octo.utils").is_blank(conf.github_hostname) then
+    if not require("octo.utils").is_blank(opts.hostname) then
+      hostname = opts.hostname
+    elseif not require("octo.utils").is_blank(conf.github_hostname) then
+      hostname = conf.github_hostname
+    elseif not require("octo.utils").is_blank(remote_hostname) then
+      hostname = remote_hostname
+    end
+    if not require("octo.utils").is_blank(hostname) and hostname ~= "github.com" then
       table.insert(opts.args, "--hostname")
-      table.insert(opts.args, conf.github_hostname)
+      table.insert(opts.args, hostname)
     end
   end
 

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -124,7 +124,7 @@ function M.issues(opts)
   end
   local filter = get_filter(opts, "issue")
 
-  if not opts.repo or opts.repo == vim.NIL then
+  if not require("octo.utils").is_blank(opts.repo) then
     opts.repo = utils.get_remote_name()
   end
   if not opts.repo then

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -182,7 +182,7 @@ function M.get_remote()
         goto continue
       end
       return {
-        host = host,
+        host = vim.split(host, "@")[#vim.split(host, "@")],
         repo = string.gsub(repo, ".git$", ""),
       }
     end

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -141,9 +141,13 @@ function M.is_blank(s)
   return not (s ~= nil and s ~= vim.NIL and string.match(s, "%S") ~= nil)
 end
 
-function M.get_remote_name()
+function M.get_remote()
   local conf = config.get_config()
   local candidates = conf.default_remote
+  local default_remote = {
+    host = "github.com",
+    repo = "",
+  }
   for _, candidate in ipairs(candidates) do
     local job = Job:new {
       command = "git",
@@ -155,7 +159,10 @@ function M.get_remote_name()
     local url = table.concat(job:result(), "\n")
     local stderr = table.concat(job:stderr_result(), "\n")
 
-    if M.is_blank(stderr) then
+    if not M.is_blank(stderr) then
+      goto continue
+    else
+      local host
       local repo
       -- https://github.com/pwntester/octo.nvim.git
       -- ssh://git@github.com/pwntester/octo.nvim.git
@@ -163,18 +170,34 @@ function M.get_remote_name()
           vim.startswith(url, "https://") or
           vim.startswith(url, "ssh://") then
         local chunks = vim.split(url, "/")
+        host = chunks[3]
         repo = chunks[4] .. "/" .. chunks[5]
         -- git@github.com:pwntester/octo.nvim.git
       elseif vim.startswith(url, "git@") then
         local parts = vim.split(url, ":")
-        local chunks = vim.split(parts[2], "/")
-        repo = chunks[1] .. "/" .. chunks[2]
+        host = vim.split(parts[1], "@")[2]
+        local repo_chunks = vim.split(parts[2], "/")
+        repo = repo_chunks[1] .. "/" .. repo_chunks[2]
       else
-        return
+        goto continue
       end
-      return string.gsub(repo, ".git$", "")
+      return {
+        host = host,
+        repo = string.gsub(repo, ".git$", ""),
+      }
     end
+    ::continue::
   end
+  require("octo.utils").notify("Unable to parse a git remote.", 2)
+  return default_remote
+end
+
+function M.get_remote_name()
+  return M.get_remote().repo
+end
+
+function M.get_remote_host()
+  return M.get_remote().host
 end
 
 function M.commit_exists(commit, cb)


### PR DESCRIPTION
`gh api` gets confused if auth for a github.com host is configured, but
the repository remote uses an enterprise github host. We avoid this by
finding the host from the remotes and specify it via flag.

Fixes: https://github.com/pwntester/octo.nvim/issues/276
