### PR TITLE
allow web devicons to be an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ require"octo".setup({
   snippet_context_lines = 4;               -- number or lines around commented lines
   file_panel = {
     size = 10,                             -- changed files panel rows
-    use_icons = true                       -- use web-devicons in file panel
+    use_icons = true                       -- use web-devicons in file panel (if false, nvim-web-devicons does not need to be installed)
   },
   mappings = {
     issue = {

--- a/lua/octo/reviews/renderer.lua
+++ b/lua/octo/reviews/renderer.lua
@@ -3,6 +3,7 @@
 --
 local M = {}
 local web_devicons
+local config = require "octo.config"
 
 ---@class HlData
 ---@field group string
@@ -82,7 +83,11 @@ function M.get_git_hl(status)
 end
 
 function M.get_file_icon(name, ext, render_data, line_idx, offset)
-  --if not config.get_config().file_panel.use_icons then return " " end
+  local use_icons = config.get_config().file_panel.use_icons
+  if not use_icons then
+    return " "
+  end
+
   if not web_devicons then
     web_devicons = require "nvim-web-devicons"
   end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

In the README, it looks like the `file_picker.use_icons` field could be set to false to make the web devicons an optional dependency, but the line that reads from this config property was commented out.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Just uncommented the relevant line out.

### Describe how to verify it

Uninstall the nvim-web-devicons package from the nvim runtime, and open the file picker. It should still work without a lua `require` stack trace appearing in the messages pane, provided that the `file_picker.use_icons` config property is set to `false`.

### Special notes for reviews

