### PR TITLE
Use unmapped commands when excuting normal mode commands

### DIFF
--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -401,7 +401,7 @@ function Review:add_comment(isSuggestion)
       end
       thread_buffer:configure()
       vim.cmd [[diffoff!]]
-      vim.cmd [[normal vvGk]]
+      vim.cmd [[normal! vvGk]]
       vim.cmd [[startinsert]]
     end
   else


### PR DESCRIPTION

### Describe what this PR does / why we need it
I had `vv` mapped to `v']` to select whatever was pasted last. This seems to not play well with the command `vvGk` in `Review:add_comment`. I kept getting the following error:
```
E5108: Error executing lua: .../.vim_run/plugged/octo.nvim/lua/octo/reviews/init.lua:404: Vim(normal):E20: Mark not set
stack traceback:
        [C]: in function 'cmd'
        .../.vim_run/plugged/octo.nvim/lua/octo/reviews/init.lua:404: in function 'add_comment'
        .../.vim_run/plugged/octo.nvim/lua/octo/reviews/init.lua:431: in function 'add_review_comment'
        .../.vim_run/plugged/octo.nvim/lua/octo/mappings.lua:112: in function <.../.vim_run/plugged/octo.nvim/lua/octo/mappings.lua:111>
```

### Does this pull request fix one issue?

No.

### Describe how you did it

Use `normal!` (with the `!` at the end) to use unmapped commands and avoid conflicts with user mappings

### Describe how to verify it

Map `vv` to `v']` in your `.init.vim`/`.vimrc`, start review mode and try adding a comment on a change.

### Special notes for reviews

