### PR TITLE
Fix create_thread_buffer

### DIFF
--- a/lua/octo/reviews/thread-panel.lua
+++ b/lua/octo/reviews/thread-panel.lua
@@ -95,7 +95,7 @@ function M.create_thread_buffer(threads, repo, number, side, path)
   if not vim.startswith(path, "/") then
     path = "/" .. path
   end
-  local line = threads[1].originalStartLine
+  local line = threads[1].originalStartLine ~= vim.NIL and threads[1].originalStartLine or threads[1].originalLine
   local bufname = string.format("octo://%s/review/%s/threads/%s%s:%d", repo, current_review.id, side, path, line)
   local bufnr = vim.fn.bufnr(bufname)
   local buffer


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Fixes creating thread buffers for existing comments.

When a comment is first created but before it's submitted, the `thread` object in `Review:add_comment` is stubbed with a valid value given for `originalStartLine`. `ThreadPanel:create_thread_buffer` then uses this to correctly render the thread.

But after submitting the comment, the response from the GH API doesn't include a value for `originalStartLine` for single-line comments, [as mentioned here.](https://docs.github.com/en/graphql/reference/objects#pullrequestreviewthread) This breaks the rendering in `create_thread_buffer`.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #314 

### Describe how you did it
The fix was to fall back to `thread.originalLine` if `thread.originalStartLine` is set to `vim.NIL`.

### Describe how to verify it
1. Create and submit a new comment.
2. Move the cursor over the comment.

### Special notes for reviews

