### PR TITLE
Update vim.fn.trim for nightly neovim

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -664,7 +664,7 @@ function M.create_issue(repo)
   )
   if choice == 1 then
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
-    body = utils.escape_char(vim.trim(table.concat(lines, "\n")))
+    body = utils.escape_char(utils.trim(table.concat(lines, "\n")))
   else
     body = constants.NO_BODY_MSG
   end

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -664,7 +664,7 @@ function M.create_issue(repo)
   )
   if choice == 1 then
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
-    body = utils.escape_char(vim.fn.trim(table.concat(lines, "\n")))
+    body = utils.escape_char(vim.trim(table.concat(lines, "\n")))
   else
     body = constants.NO_BODY_MSG
   end

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -407,7 +407,7 @@ function OctoBuffer:do_add_issue_comment(comment_metadata)
         local resp = vim.fn.json_decode(output)
         local respBody = resp.data.addComment.commentEdge.node.body
         local respId = resp.data.addComment.commentEdge.node.id
-        if vim.fn.trim(comment_metadata.body) == vim.fn.trim(respBody) then
+        if vim.trim(comment_metadata.body) == vim.trim(respBody) then
           local comments = self.commentsMetadata
           for i, c in ipairs(comments) do
             if tonumber(c.id) == -1 then
@@ -442,7 +442,7 @@ function OctoBuffer:do_add_thread_comment(comment_metadata)
         local resp = vim.fn.json_decode(output)
         local resp_comment = resp.data.addPullRequestReviewComment.comment
         local comment_end
-        if vim.fn.trim(comment_metadata.body) == vim.fn.trim(resp_comment.body) then
+        if vim.trim(comment_metadata.body) == vim.trim(resp_comment.body) then
           local comments = self.commentsMetadata
           for i, c in ipairs(comments) do
             if tonumber(c.id) == -1 then
@@ -550,7 +550,7 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
           local resp = vim.fn.json_decode(output).data.addPullRequestReviewThread
           if not utils.is_blank(resp.thread) then
             local new_comment = resp.thread.comments.nodes[1]
-            if vim.fn.trim(comment_metadata.body) == vim.fn.trim(new_comment.body) then
+            if vim.trim(comment_metadata.body) == vim.trim(new_comment.body) then
               local comments = self.commentsMetadata
               for i, c in ipairs(comments) do
                 if tonumber(c.id) == -1 then
@@ -647,7 +647,7 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
             local r = vim.fn.json_decode(output)
             local resp = r.data.addPullRequestReviewComment
             if not utils.is_blank(resp.comment) then
-              if vim.fn.trim(comment_metadata.body) == vim.fn.trim(resp.comment.body) then
+              if vim.trim(comment_metadata.body) == vim.trim(resp.comment.body) then
                 local comments = self.commentsMetadata
                 for i, c in ipairs(comments) do
                   if tonumber(c.id) == -1 then
@@ -699,7 +699,7 @@ function OctoBuffer:do_add_pull_request_comment(comment_metadata)
       elseif output then
         local resp = vim.fn.json_decode(output)
         if not utils.is_blank(resp) then
-          if vim.fn.trim(comment_metadata.body) == vim.fn.trim(resp.body) then
+          if vim.trim(comment_metadata.body) == vim.trim(resp.body) then
             local comments = self.commentsMetadata
             for i, c in ipairs(comments) do
               if tonumber(c.id) == -1 then
@@ -752,7 +752,7 @@ function OctoBuffer:do_update_comment(comment_metadata)
         elseif comment_metadata.kind == "PullRequestReview" then
           resp_comment = resp.data.updatePullRequestReview.pullRequestReview
         end
-        if resp_comment and vim.fn.trim(comment_metadata.body) == vim.fn.trim(resp_comment.body) then
+        if resp_comment and vim.trim(comment_metadata.body) == vim.trim(resp_comment.body) then
           local comments = self.commentsMetadata
           for i, c in ipairs(comments) do
             if c.id == comment_metadata.id then
@@ -793,7 +793,7 @@ function OctoBuffer:update_metadata()
     metadata.body = text
     metadata.startLine = start_line
     metadata.endLine = end_line
-    metadata.dirty = vim.fn.trim(metadata.body) ~= vim.fn.trim(metadata.savedBody) and true or false
+    metadata.dirty = vim.trim(metadata.body) ~= vim.trim(metadata.savedBody) and true or false
   end
 end
 

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -744,7 +744,7 @@ function OctoBuffer:do_update_comment(comment_metadata)
         elseif comment_metadata.kind == "PullRequestReviewComment" then
           resp_comment = resp.data.updatePullRequestReviewComment.pullRequestReviewComment
           local threads =
-          resp.data.updatePullRequestReviewComment.pullRequestReviewComment.pullRequest.reviewThreads.nodes
+            resp.data.updatePullRequestReviewComment.pullRequestReviewComment.pullRequest.reviewThreads.nodes
           local review = require("octo.reviews").get_current_review()
           if review then
             review:update_threads(threads)

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -407,7 +407,7 @@ function OctoBuffer:do_add_issue_comment(comment_metadata)
         local resp = vim.fn.json_decode(output)
         local respBody = resp.data.addComment.commentEdge.node.body
         local respId = resp.data.addComment.commentEdge.node.id
-        if vim.trim(comment_metadata.body) == vim.trim(respBody) then
+        if utils.trim(comment_metadata.body) == utils.trim(respBody) then
           local comments = self.commentsMetadata
           for i, c in ipairs(comments) do
             if tonumber(c.id) == -1 then
@@ -442,7 +442,7 @@ function OctoBuffer:do_add_thread_comment(comment_metadata)
         local resp = vim.fn.json_decode(output)
         local resp_comment = resp.data.addPullRequestReviewComment.comment
         local comment_end
-        if vim.trim(comment_metadata.body) == vim.trim(resp_comment.body) then
+        if utils.trim(comment_metadata.body) == utils.trim(resp_comment.body) then
           local comments = self.commentsMetadata
           for i, c in ipairs(comments) do
             if tonumber(c.id) == -1 then
@@ -550,7 +550,7 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
           local resp = vim.fn.json_decode(output).data.addPullRequestReviewThread
           if not utils.is_blank(resp.thread) then
             local new_comment = resp.thread.comments.nodes[1]
-            if vim.trim(comment_metadata.body) == vim.trim(new_comment.body) then
+            if utils.trim(comment_metadata.body) == utils.trim(new_comment.body) then
               local comments = self.commentsMetadata
               for i, c in ipairs(comments) do
                 if tonumber(c.id) == -1 then
@@ -647,7 +647,7 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
             local r = vim.fn.json_decode(output)
             local resp = r.data.addPullRequestReviewComment
             if not utils.is_blank(resp.comment) then
-              if vim.trim(comment_metadata.body) == vim.trim(resp.comment.body) then
+              if utils.trim(comment_metadata.body) == utils.trim(resp.comment.body) then
                 local comments = self.commentsMetadata
                 for i, c in ipairs(comments) do
                   if tonumber(c.id) == -1 then
@@ -699,7 +699,7 @@ function OctoBuffer:do_add_pull_request_comment(comment_metadata)
       elseif output then
         local resp = vim.fn.json_decode(output)
         if not utils.is_blank(resp) then
-          if vim.trim(comment_metadata.body) == vim.trim(resp.body) then
+          if utils.trim(comment_metadata.body) == utils.trim(resp.body) then
             local comments = self.commentsMetadata
             for i, c in ipairs(comments) do
               if tonumber(c.id) == -1 then
@@ -744,7 +744,7 @@ function OctoBuffer:do_update_comment(comment_metadata)
         elseif comment_metadata.kind == "PullRequestReviewComment" then
           resp_comment = resp.data.updatePullRequestReviewComment.pullRequestReviewComment
           local threads =
-            resp.data.updatePullRequestReviewComment.pullRequestReviewComment.pullRequest.reviewThreads.nodes
+          resp.data.updatePullRequestReviewComment.pullRequestReviewComment.pullRequest.reviewThreads.nodes
           local review = require("octo.reviews").get_current_review()
           if review then
             review:update_threads(threads)
@@ -752,7 +752,7 @@ function OctoBuffer:do_update_comment(comment_metadata)
         elseif comment_metadata.kind == "PullRequestReview" then
           resp_comment = resp.data.updatePullRequestReview.pullRequestReview
         end
-        if resp_comment and vim.trim(comment_metadata.body) == vim.trim(resp_comment.body) then
+        if resp_comment and utils.trim(comment_metadata.body) == utils.trim(resp_comment.body) then
           local comments = self.commentsMetadata
           for i, c in ipairs(comments) do
             if c.id == comment_metadata.id then
@@ -793,7 +793,7 @@ function OctoBuffer:update_metadata()
     metadata.body = text
     metadata.startLine = start_line
     metadata.endLine = end_line
-    metadata.dirty = vim.trim(metadata.body) ~= vim.trim(metadata.savedBody) and true or false
+    metadata.dirty = utils.trim(metadata.body) ~= utils.trim(metadata.savedBody) and true or false
   end
 end
 

--- a/lua/octo/reviews/file-panel.lua
+++ b/lua/octo/reviews/file-panel.lua
@@ -439,7 +439,7 @@ function M.thread_counts(path)
     end
     for _, comment in ipairs(thread.comments.nodes) do
       local review = comment.pullRequestReview
-      if not utils.is_blank(review) and review.state == "PENDING" and not utils.is_blank(vim.fn.trim(comment.body)) then
+      if not utils.is_blank(review) and review.state == "PENDING" and not utils.is_blank(vim.trim(comment.body)) then
         pending = pending + 1
       end
     end

--- a/lua/octo/reviews/file-panel.lua
+++ b/lua/octo/reviews/file-panel.lua
@@ -439,7 +439,7 @@ function M.thread_counts(path)
     end
     for _, comment in ipairs(thread.comments.nodes) do
       local review = comment.pullRequestReview
-      if not utils.is_blank(review) and review.state == "PENDING" and not utils.is_blank(vim.trim(comment.body)) then
+      if not utils.is_blank(review) and review.state == "PENDING" and not utils.is_blank(utils.trim(comment.body)) then
         pending = pending + 1
       end
     end

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -411,8 +411,9 @@ end
 
 function Review:get_level()
   local review_level = "COMMIT"
-  if self.layout.left.commit == self.pull_request.left.commit
-      and self.layout.right.commit == self.pull_request.right.commit
+  if
+    self.layout.left.commit == self.pull_request.left.commit
+    and self.layout.right.commit == self.pull_request.right.commit
   then
     review_level = "PR"
   end

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -244,7 +244,7 @@ function Review:submit(event)
   local bufnr = vim.api.nvim_get_current_buf()
   local winid = vim.api.nvim_get_current_win()
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  local body = utils.escape_char(vim.fn.trim(table.concat(lines, "\n")))
+  local body = utils.escape_char(vim.trim(table.concat(lines, "\n")))
   local query = graphql("submit_pull_request_review_mutation", self.id, event, body, { escape = false })
   gh.run {
     args = { "api", "graphql", "-f", string.format("query=%s", query) },
@@ -264,7 +264,7 @@ function Review:show_pending_comments()
   local pending_threads = {}
   for _, thread in ipairs(vim.tbl_values(self.threads)) do
     for _, comment in ipairs(thread.comments.nodes) do
-      if comment.pullRequestReview.state == "PENDING" and not utils.is_blank(vim.fn.trim(comment.body)) then
+      if comment.pullRequestReview.state == "PENDING" and not utils.is_blank(vim.trim(comment.body)) then
         table.insert(pending_threads, thread)
       end
     end

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -244,7 +244,7 @@ function Review:submit(event)
   local bufnr = vim.api.nvim_get_current_buf()
   local winid = vim.api.nvim_get_current_win()
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  local body = utils.escape_char(vim.trim(table.concat(lines, "\n")))
+  local body = utils.escape_char(utils.trim(table.concat(lines, "\n")))
   local query = graphql("submit_pull_request_review_mutation", self.id, event, body, { escape = false })
   gh.run {
     args = { "api", "graphql", "-f", string.format("query=%s", query) },
@@ -264,7 +264,7 @@ function Review:show_pending_comments()
   local pending_threads = {}
   for _, thread in ipairs(vim.tbl_values(self.threads)) do
     for _, comment in ipairs(thread.comments.nodes) do
-      if comment.pullRequestReview.state == "PENDING" and not utils.is_blank(vim.trim(comment.body)) then
+      if comment.pullRequestReview.state == "PENDING" and not utils.is_blank(utils.trim(comment.body)) then
         table.insert(pending_threads, thread)
       end
     end
@@ -411,9 +411,8 @@ end
 
 function Review:get_level()
   local review_level = "COMMIT"
-  if
-    self.layout.left.commit == self.pull_request.left.commit
-    and self.layout.right.commit == self.pull_request.right.commit
+  if self.layout.left.commit == self.pull_request.left.commit
+      and self.layout.right.commit == self.pull_request.right.commit
   then
     review_level = "PR"
   end

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -1296,7 +1296,7 @@ function M.write_threads(bufnr, threads)
       -- review thread header
       if utils.is_blank(comment.replyTo) then
         local start_line = not utils.is_blank(thread.originalStartLine) and thread.originalStartLine
-            or thread.originalLine
+          or thread.originalLine
         local end_line = thread.originalLine
         comment.start_line = start_line
         comment.end_line = end_line

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -199,7 +199,7 @@ function M.write_state(bufnr, state, number)
 end
 
 function M.write_body(bufnr, issue, line)
-  local body = vim.fn.trim(issue.body)
+  local body = vim.trim(issue.body)
   if vim.startswith(body, constants.NO_BODY_MSG) or utils.is_blank(body) then
     body = " "
   end
@@ -544,7 +544,7 @@ function M.write_comment(bufnr, comment, kind, line)
 
   -- body
   line = line + 2
-  local comment_body = vim.fn.trim(string.gsub(comment.body, "\r\n", "\n"))
+  local comment_body = vim.trim(string.gsub(comment.body, "\r\n", "\n"))
   if vim.startswith(comment_body, constants.NO_BODY_MSG) or utils.is_blank(comment_body) then
     comment_body = " "
   end

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -199,7 +199,7 @@ function M.write_state(bufnr, state, number)
 end
 
 function M.write_body(bufnr, issue, line)
-  local body = vim.trim(issue.body)
+  local body = utils.trim(issue.body)
   if vim.startswith(body, constants.NO_BODY_MSG) or utils.is_blank(body) then
     body = " "
   end
@@ -544,7 +544,7 @@ function M.write_comment(bufnr, comment, kind, line)
 
   -- body
   line = line + 2
-  local comment_body = vim.trim(string.gsub(comment.body, "\r\n", "\n"))
+  local comment_body = utils.trim(string.gsub(comment.body, "\r\n", "\n"))
   if vim.startswith(comment_body, constants.NO_BODY_MSG) or utils.is_blank(comment_body) then
     comment_body = " "
   end
@@ -1296,7 +1296,7 @@ function M.write_threads(bufnr, threads)
       -- review thread header
       if utils.is_blank(comment.replyTo) then
         local start_line = not utils.is_blank(thread.originalStartLine) and thread.originalStartLine
-          or thread.originalLine
+            or thread.originalLine
         local end_line = thread.originalLine
         comment.start_line = start_line
         comment.end_line = end_line

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -129,11 +129,11 @@ end
 
 function M.is_blank(s)
   return (
-      s == nil
-          or s == vim.NIL
-          or (type(s) == "string" and string.match(s, "%S") == nil)
-          or (type(s) == "table" and next(s) == nil)
-      )
+    s == nil
+    or s == vim.NIL
+    or (type(s) == "string" and string.match(s, "%S") == nil)
+    or (type(s) == "table" and next(s) == nil)
+  )
 end
 
 function M.parse_remote_url(url, aliases)
@@ -202,19 +202,19 @@ function M.commit_exists(commit, cb)
     return
   end
   Job
-      :new({
-        enable_recording = true,
-        command = "git",
-        args = { "cat-file", "-t", commit },
-        on_exit = vim.schedule_wrap(function(j_self, _, _)
-          if "commit" == M.trim(table.concat(j_self:result(), "\n")) then
-            cb(true)
-          else
-            cb(false)
-          end
-        end),
-      })
-      :start()
+    :new({
+      enable_recording = true,
+      command = "git",
+      args = { "cat-file", "-t", commit },
+      on_exit = vim.schedule_wrap(function(j_self, _, _)
+        if "commit" == M.trim(table.concat(j_self:result(), "\n")) then
+          cb(true)
+        else
+          cb(false)
+        end
+      end),
+    })
+    :start()
 end
 
 function M.get_file_at_commit(path, commit, cb)
@@ -297,16 +297,16 @@ function M.checkout_pr(pr_number)
     return
   end
   Job
-      :new({
-        enable_recording = true,
-        command = "gh",
-        args = { "pr", "checkout", pr_number },
-        on_exit = vim.schedule_wrap(function()
-          local output = vim.fn.system "git branch --show-current"
-          vim.notify("Switched to " .. output)
-        end),
-      })
-      :start()
+    :new({
+      enable_recording = true,
+      command = "gh",
+      args = { "pr", "checkout", pr_number },
+      on_exit = vim.schedule_wrap(function()
+        local output = vim.fn.system "git branch --show-current"
+        vim.notify("Switched to " .. output)
+      end),
+    })
+    :start()
 end
 
 ---Formats a string as a date
@@ -997,7 +997,7 @@ function M.close_preview_autocmd(events, winnr, bufnrs)
       autocmd!
       autocmd BufEnter * lua vim.lsp.util._close_preview_window(%d, {%s})
     augroup end
-  ]] ,
+  ]],
     augroup,
     winnr,
     table.concat(bufnrs, ",")
@@ -1009,7 +1009,7 @@ function M.close_preview_autocmd(events, winnr, bufnrs)
       augroup %s
         autocmd %s <buffer> lua vim.lsp.util._close_preview_window(%d)
       augroup end
-    ]] ,
+    ]],
       augroup,
       table.concat(events, ","),
       winnr
@@ -1125,10 +1125,11 @@ function M.apply_mappings(kind, bufnr)
   local mappings = require "octo.mappings"
   local conf = config.get_config()
   for action, value in pairs(conf.mappings[kind]) do
-    if not M.is_blank(value)
-        and not M.is_blank(action)
-        and not M.is_blank(value.lhs)
-        and not M.is_blank(mappings[action])
+    if
+      not M.is_blank(value)
+      and not M.is_blank(action)
+      and not M.is_blank(value.lhs)
+      and not M.is_blank(mappings[action])
     then
       if M.is_blank(value.desc) then
         value.desc = ""

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -68,6 +68,16 @@ M.file_status_map = {
   renamed = "R",
 }
 
+function M.trim(str)
+  if type(vim.fn.trim) == "function" then
+    return vim.fn.trim(str)
+  elseif type(vim.trim) == "function" then
+    return vim.trim(str)
+  else
+    return str:gsub("^%s*(.-)%s*$", "%1")
+  end
+end
+
 function M.calculate_strongest_review_state(states)
   if vim.tbl_contains(states, "APPROVED") then
     return "APPROVED"
@@ -119,11 +129,11 @@ end
 
 function M.is_blank(s)
   return (
-    s == nil
-    or s == vim.NIL
-    or (type(s) == "string" and string.match(s, "%S") == nil)
-    or (type(s) == "table" and next(s) == nil)
-  )
+      s == nil
+          or s == vim.NIL
+          or (type(s) == "string" and string.match(s, "%S") == nil)
+          or (type(s) == "table" and next(s) == nil)
+      )
 end
 
 function M.parse_remote_url(url, aliases)
@@ -192,19 +202,19 @@ function M.commit_exists(commit, cb)
     return
   end
   Job
-    :new({
-      enable_recording = true,
-      command = "git",
-      args = { "cat-file", "-t", commit },
-      on_exit = vim.schedule_wrap(function(j_self, _, _)
-        if "commit" == vim.trim(table.concat(j_self:result(), "\n")) then
-          cb(true)
-        else
-          cb(false)
-        end
-      end),
-    })
-    :start()
+      :new({
+        enable_recording = true,
+        command = "git",
+        args = { "cat-file", "-t", commit },
+        on_exit = vim.schedule_wrap(function(j_self, _, _)
+          if "commit" == M.trim(table.concat(j_self:result(), "\n")) then
+            cb(true)
+          else
+            cb(false)
+          end
+        end),
+      })
+      :start()
 end
 
 function M.get_file_at_commit(path, commit, cb)
@@ -287,16 +297,16 @@ function M.checkout_pr(pr_number)
     return
   end
   Job
-    :new({
-      enable_recording = true,
-      command = "gh",
-      args = { "pr", "checkout", pr_number },
-      on_exit = vim.schedule_wrap(function()
-        local output = vim.fn.system "git branch --show-current"
-        vim.notify("Switched to " .. output)
-      end),
-    })
-    :start()
+      :new({
+        enable_recording = true,
+        command = "gh",
+        args = { "pr", "checkout", pr_number },
+        on_exit = vim.schedule_wrap(function()
+          local output = vim.fn.system "git branch --show-current"
+          vim.notify("Switched to " .. output)
+        end),
+      })
+      :start()
 end
 
 ---Formats a string as a date
@@ -987,7 +997,7 @@ function M.close_preview_autocmd(events, winnr, bufnrs)
       autocmd!
       autocmd BufEnter * lua vim.lsp.util._close_preview_window(%d, {%s})
     augroup end
-  ]],
+  ]] ,
     augroup,
     winnr,
     table.concat(bufnrs, ",")
@@ -999,7 +1009,7 @@ function M.close_preview_autocmd(events, winnr, bufnrs)
       augroup %s
         autocmd %s <buffer> lua vim.lsp.util._close_preview_window(%d)
       augroup end
-    ]],
+    ]] ,
       augroup,
       table.concat(events, ","),
       winnr
@@ -1115,11 +1125,10 @@ function M.apply_mappings(kind, bufnr)
   local mappings = require "octo.mappings"
   local conf = config.get_config()
   for action, value in pairs(conf.mappings[kind]) do
-    if
-      not M.is_blank(value)
-      and not M.is_blank(action)
-      and not M.is_blank(value.lhs)
-      and not M.is_blank(mappings[action])
+    if not M.is_blank(value)
+        and not M.is_blank(action)
+        and not M.is_blank(value.lhs)
+        and not M.is_blank(mappings[action])
     then
       if M.is_blank(value.desc) then
         value.desc = ""

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -197,7 +197,7 @@ function M.commit_exists(commit, cb)
       command = "git",
       args = { "cat-file", "-t", commit },
       on_exit = vim.schedule_wrap(function(j_self, _, _)
-        if "commit" == vim.fn.trim(table.concat(j_self:result(), "\n")) then
+        if "commit" == vim.trim(table.concat(j_self:result(), "\n")) then
           cb(true)
         else
           cb(false)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

I updated my neovim to the `nightly` branch and broke `octo.nvim` when opening a PR.
Apparently `vim.fn.trim` is renamed to `vim.trim`.

### Describe how you did it

Replace all occurences of `vim.fn.trim` to `vim.trim`

### Describe how to verify it

Open a PR with octo.nvim

### Special notes for reviews

I'm not sure if this PR should be merged for now since this is a fix for a nightly version of Neovim.
