### PR TITLE
Add option to select base repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ use {
 ```lua
 require"octo".setup({
   default_remote = {"upstream", "origin"}; -- order to try remotes
+  always_select_remote = "false"	   -- always give prompt to select base remote repo when creating PRs
   ssh_aliases = {},                        -- SSH aliases. e.g. `ssh_aliases = {["github.com-work"] = "github.com"}`
   reaction_viewer_hint_icon = "";         -- marker for user reactions
   user_icon = " ";                        -- user icon

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -7,6 +7,7 @@ local reviews = require "octo.reviews"
 local window = require "octo.ui.window"
 local writers = require "octo.ui.writers"
 local utils = require "octo.utils"
+local config = require "octo.config"
 
 local M = {}
 
@@ -712,11 +713,30 @@ end
 
 function M.create_pr(is_draft)
   is_draft = "draft" == is_draft and true or false
-  local repo = utils.get_remote_name()
-  if not repo then
-    utils.notify("Cant find repo name", 1)
-    return
+  local conf = config.get_config()
+  local select = conf.always_select_remote or false
+
+  local repo
+  if select then
+    local remotes = utils.get_all_remotes()
+    local remote_entries = {"Select base repo,",}
+    for idx, remote in ipairs(remotes) do
+        table.insert(remote_entries, idx .. ". " .. remote.repo)
+    end
+    local remote_idx = vim.fn.inputlist(remote_entries)
+    if remote_idx < 1 then
+        utils.notify("Something went wrong", 1)
+        return
+    end
+    repo = remotes[remote_idx].repo
+  else
+      repo = utils.get_remote_name()
+      if not repo then
+        utils.notify("Cant find repo name", 1)
+        return
+      end
   end
+
 
   -- get repo info
   local info = utils.get_repo_info(repo)

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -721,20 +721,23 @@ function M.create_pr(is_draft)
     local remotes = utils.get_all_remotes()
     local remote_entries = {"Select base repo,",}
     for idx, remote in ipairs(remotes) do
-        table.insert(remote_entries, idx .. ". " .. remote.repo)
+      table.insert(remote_entries, idx .. ". " .. remote.repo)
     end
     local remote_idx = vim.fn.inputlist(remote_entries)
     if remote_idx < 1 then
-        utils.notify("Something went wrong", 1)
-        return
+      utils.notify("Aborting PR creation", 2)
+      return
+    elseif remote_idx > #remotes then
+      utils.notify("Invaild index.", 2)
+      return
     end
     repo = remotes[remote_idx].repo
   else
-      repo = utils.get_remote_name()
-      if not repo then
-        utils.notify("Cant find repo name", 1)
-        return
-      end
+    repo = utils.get_remote_name()
+    if not repo then
+      utils.notify("Cant find repo name", 1)
+      return
+    end
   end
 
 

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -15,6 +15,7 @@ M.defaults = {
   left_bubble_delimiter = "",
   github_hostname = "",
   snippet_context_lines = 4,
+  always_select_remote = false,
   file_panel = {
     size = 10,
     use_icons = true,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Adds config option `always_select_remote` that gives select prompt for base repo when creating a PR.

### Does this pull request fix one issue?
Fixes #334

<!--If that, add \"Fixes #xxxx\" below in the next line. For example, Fixes #15. Otherwise, add \"NONE\" -->

### Describe how you did it
I added function to get all configured remotes in the current repo, then I parse it and display it in `inputlist` and use it as base repo. This only happens if `always_select_remote` is set to `true`. Otherwise the behaviour is same as before.


### Describe how to verify it
Set `always_select_remote` to `true`
`:Octo pr create`
Prompt with remotes should be displayed
Select a repo from the list
Selected repo should be used as base repo for the PR

### Special notes for reviews
My lua skills are pretty basic, so feel free to suggest/make any improvements