### PR TITLE
Fix the floating window size calculation

### DIFF
--- a/lua/octo/ui/window.lua
+++ b/lua/octo/ui/window.lua
@@ -95,6 +95,9 @@ function M.create_centered_float(opts)
     else
       opts.height = math.min(vim_height, 2 * opts.border_width + #opts.content) + 1
     end
+
+    opts.width = math.floor(opts.width)
+    opts.height = math.floor(opts.height)
   else
     opts.width = math.floor(vim_width * opts.x_percent)
     opts.height = math.floor(vim_height * opts.y_percent)


### PR DESCRIPTION
If the number of max lines >= 1, it calculates a float number. It could apply to `vim.api.nvim_open_win`. Add the converting action to make sure the final result type is int.

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Pass the size with correct type to create floating window.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it

The result of the value may not be an integer, add the convert to make sure it's integer type.

### Describe how to verify it

I verify in my local environment with `:Octo pr checks`

### Special notes for reviews

