### PR TITLE
Add missing commands to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 | | fork | Fork repo |
 | | browser | Open current repo in the browser|
 | | url | Copies the URL of the current repo to the system clipboard|
+| | view | Open a repo by path ({organization}/{name})|
 | gist | list [repo] [key=value] (4) | List user gists |
 | comment | add | Add a new comment |
 | | delete | Delete a comment |
@@ -277,7 +278,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 | label | add [label] | Add a label from available label menu |
 | | remove [label] | Remove a label |
 | | create [label] | Create a new label |
-| assignees| add [login] | Assign a user |
+| assignee| add [login] | Assign a user |
 | | remove [login] | Unassign a user |
 | reviewer | add [login] | Assign a PR reviewer |
 | reaction | `thumbs_up` \| `+1` | Add 👍 reaction|
@@ -297,6 +298,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 | | discard| Deletes a pending review for current PR if any |
 | | comments| View pending review comments |
 | | commit | Pick a specific commit to review |
+| | close | Close the review window and return to the PR |
 | actions |  | Lists all available Octo actions|
 | search | <query> | Search GitHub for issues and PRs matching the [query](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) |
 

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -82,7 +82,7 @@ See |octo-command-examples| for examples.
 
   list                  Lists repos the user owns, contributes, or belongs to.
   fork                  Fork repo.
-  browser               Open current PR in the browser.
+  browser               Open current repo in the browser.
   url                   Copies the URL of the current repo to the system 
                         clipboard.
 
@@ -114,7 +114,7 @@ See |octo-command-examples| for examples.
   create [label]        Create a new label.
 
 
-:Octo assignees [action]                        *octo-commands-assignees*
+:Octo assignee [action]                         *octo-commands-assignee*
 
   add [login]           Assign a user.
   remove [login]        Unassign a user

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -85,6 +85,7 @@ See |octo-command-examples| for examples.
   browser               Open current repo in the browser.
   url                   Copies the URL of the current repo to the system 
                         clipboard.
+  view                  Open a repo by path ({organization}/{name}).
 
 
 :Octo gist [action]                             *octo-commands-gist*
@@ -152,6 +153,7 @@ See |octo-command-examples| for examples.
   discard               Deletes a pending review for the current PR, if any.
   comments              View pending review comments.
   commit                Pick a specific commit to review.
+  close                 Close the review window and return to the PR.
 
 :Octo actions                                   *octo-commands-actions*
 

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -271,6 +271,9 @@ function M.setup()
       rocket = function()
         M.reaction_action "ROCKET"
       end,
+      heart = function()
+        M.reaction_action "HEART"
+      end,
     },
     card = {
       add = function()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Add repo-review and review-close commands to the docs. Fixed a couple of typos while I
was at it.

Also added the heart reaction command, because I noticed it was missing, even though all
the docs referred to it as if it worked.

### Does this pull request fix one issue?
No

### Describe how you did it
Updated doc/octo.txt and README to add the missing commands

### Describe how to verify it
N/A

### Special notes for reviews