### PR TITLE
make signcolumn configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ require"octo".setup({
   gh_env = {},                             -- extra environment variables to pass on to GitHub CLI, can be a table or function returning a table
   ui = {
     use_signcolumn = true,                 -- show "modified" marks on the sign column
-    use_foldcolumn = true,                 -- enable folding
   },
   issues = {
     order_by = {                           -- criteria to sort results of `Octo issue list`

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ require"octo".setup({
   github_hostname = "";                    -- GitHub Enterprise host
   snippet_context_lines = 4;               -- number or lines around commented lines
   gh_env = {},                             -- extra environment variables to pass on to GitHub CLI, can be a table or function returning a table
+  ui = {
+    use_signcolumn = true,                 -- show "modified" marks on the sign column
+    use_foldcolumn = true,                 -- enable folding
+  },
   issues = {
     order_by = {                           -- criteria to sort results of `Octo issue list`
       field = "CREATED_AT",                -- either COMMENTS, CREATED_AT or UPDATED_AT (https://docs.github.com/en/graphql/reference/enums#issueorderfield)

--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -65,7 +65,7 @@ function M.setup()
   })
 end
 
-function M.octo_buffer(bufnr)
+function M.update_signcolumn(bufnr)
   define({ "TextChanged", "TextChangedI" }, {
     group = "octobuffer_autocmds",
     buffer = bufnr,

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -16,6 +16,10 @@ M.defaults = {
   github_hostname = "",
   snippet_context_lines = 4,
   gh_env = {},
+  ui = {
+    use_signcolumn = true,
+    use_foldcolumn = true,
+  },
   issues = {
     order_by = {
       field = "CREATED_AT",

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -18,7 +18,6 @@ M.defaults = {
   gh_env = {},
   ui = {
     use_signcolumn = true,
-    use_foldcolumn = true,
   },
   issues = {
     order_by = {

--- a/lua/octo/folds.lua
+++ b/lua/octo/folds.lua
@@ -1,12 +1,6 @@
 local M = {}
 
 function M.setup()
-  function _G.octo_foldtext()
-    --print(vim.line(vim.v.foldstart - 1))
-    --print(vim.v.foldstart, vim.api.nvim_get_current_buf())
-    --print(vim.v.foldstart, util.get_comment_at_line(vim.v.foldstart))
-    return "  ..."
-  end
 end
 
 function M.create(bufnr, start_line, end_line, is_opened)

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -229,18 +229,11 @@ function OctoBuffer:configure()
   -- configure buffer
   vim.api.nvim_buf_call(self.bufnr, function()
     local use_signcolumn = config.get_config().ui.use_signcolumn
-    --options
     vim.cmd [[setlocal filetype=octo]]
     vim.cmd [[setlocal buftype=acwrite]]
     vim.cmd [[setlocal omnifunc=v:lua.octo_omnifunc]]
     vim.cmd [[setlocal conceallevel=2]]
     vim.cmd [[setlocal nonumber norelativenumber nocursorline wrap]]
-    vim.cmd [[setlocal foldenable]]
-    vim.cmd [[setlocal foldtext=v:lua.octo_foldtext()]]
-    vim.cmd [[setlocal foldmethod=manual]]
-    vim.cmd [[setlocal foldcolumn=3]]
-    vim.cmd [[setlocal foldlevelstart=99]]
-    vim.cmd [[setlocal fillchars=fold:⠀,foldopen:⠀,foldclose:⠀,foldsep:⠀]]
     if use_signcolumn then
       vim.cmd [[setlocal signcolumn=yes]]
       autocmds.update_signcolumn(self.bufnr)

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -229,24 +229,21 @@ function OctoBuffer:configure()
   -- configure buffer
   vim.api.nvim_buf_call(self.bufnr, function()
     local use_signcolumn = config.get_config().ui.use_signcolumn
-    local use_foldcolumn = config.get_config().ui.use_foldcolumn
     --options
     vim.cmd [[setlocal filetype=octo]]
     vim.cmd [[setlocal buftype=acwrite]]
     vim.cmd [[setlocal omnifunc=v:lua.octo_omnifunc]]
     vim.cmd [[setlocal conceallevel=2]]
     vim.cmd [[setlocal nonumber norelativenumber nocursorline wrap]]
+    vim.cmd [[setlocal foldenable]]
+    vim.cmd [[setlocal foldtext=v:lua.octo_foldtext()]]
+    vim.cmd [[setlocal foldmethod=manual]]
+    vim.cmd [[setlocal foldcolumn=3]]
+    vim.cmd [[setlocal foldlevelstart=99]]
+    vim.cmd [[setlocal fillchars=fold:⠀,foldopen:⠀,foldclose:⠀,foldsep:⠀]]
     if use_signcolumn then
       vim.cmd [[setlocal signcolumn=yes]]
       autocmds.update_signcolumn(self.bufnr)
-    end
-    if use_foldcolumn then
-      vim.cmd [[setlocal foldenable]]
-      vim.cmd [[setlocal foldtext=v:lua.octo_foldtext()]]
-      vim.cmd [[setlocal foldmethod=manual]]
-      vim.cmd [[setlocal foldcolumn=3]]
-      vim.cmd [[setlocal foldlevelstart=99]]
-      vim.cmd [[setlocal fillchars=fold:⠀,foldopen:⠀,foldclose:⠀,foldsep:⠀]]
     end
   end)
 
@@ -749,7 +746,7 @@ function OctoBuffer:do_update_comment(comment_metadata)
         elseif comment_metadata.kind == "PullRequestReviewComment" then
           resp_comment = resp.data.updatePullRequestReviewComment.pullRequestReviewComment
           local threads =
-            resp.data.updatePullRequestReviewComment.pullRequestReviewComment.pullRequest.reviewThreads.nodes
+          resp.data.updatePullRequestReviewComment.pullRequestReviewComment.pullRequest.reviewThreads.nodes
           local review = require("octo.reviews").get_current_review()
           if review then
             review:update_threads(threads)
@@ -789,7 +786,7 @@ function OctoBuffer:update_metadata()
 
   for _, metadata in ipairs(metadata_objs) do
     local mark =
-      vim.api.nvim_buf_get_extmark_by_id(self.bufnr, constants.OCTO_COMMENT_NS, metadata.extmark, { details = true })
+    vim.api.nvim_buf_get_extmark_by_id(self.bufnr, constants.OCTO_COMMENT_NS, metadata.extmark, { details = true })
     local start_line, end_line, text = utils.get_extmark_region(self.bufnr, mark)
     metadata.body = text
     metadata.startLine = start_line
@@ -918,7 +915,7 @@ end
 function OctoBuffer:get_comment_at_line(line)
   for _, comment in ipairs(self.commentsMetadata) do
     local mark =
-      vim.api.nvim_buf_get_extmark_by_id(self.bufnr, constants.OCTO_COMMENT_NS, comment.extmark, { details = true })
+    vim.api.nvim_buf_get_extmark_by_id(self.bufnr, constants.OCTO_COMMENT_NS, comment.extmark, { details = true })
     local start_line = mark[1] + 1
     local end_line = mark[3]["end_row"] + 1
     if start_line + 1 <= line and end_line - 2 >= line then
@@ -934,7 +931,7 @@ function OctoBuffer:get_body_at_cursor()
   local cursor = vim.api.nvim_win_get_cursor(0)
   local metadata = self.bodyMetadata
   local mark =
-    vim.api.nvim_buf_get_extmark_by_id(self.bufnr, constants.OCTO_COMMENT_NS, metadata.extmark, { details = true })
+  vim.api.nvim_buf_get_extmark_by_id(self.bufnr, constants.OCTO_COMMENT_NS, metadata.extmark, { details = true })
   local start_line = mark[1] + 1
   local end_line = mark[3]["end_row"] + 1
   if start_line + 1 <= cursor[1] and end_line - 2 >= cursor[1] then
@@ -996,7 +993,7 @@ function OctoBuffer:update_reactions_at_cursor(reaction_groups, reaction_line)
   local comments = self.commentsMetadata
   for i, comment in ipairs(comments) do
     local mark =
-      vim.api.nvim_buf_get_extmark_by_id(self.bufnr, constants.OCTO_COMMENT_NS, comment.extmark, { details = true })
+    vim.api.nvim_buf_get_extmark_by_id(self.bufnr, constants.OCTO_COMMENT_NS, comment.extmark, { details = true })
     local start_line = mark[1] + 1
     local end_line = mark[3].end_row + 1
     if start_line <= cursor[1] and end_line >= cursor[1] then


### PR DESCRIPTION
This PR adds to options to disable/enable the modified marks on the sign column.
The reason for this is to enable users to not use the signcolumn for marking modified comments/body/title so that they can use the statuscolumn instead.
Status column will be more customizable and does not suffer from https://github.com/pwntester/octo.nvim/issues/80

An an example you can disable the signcolumn using:

```lua
ui = {
    use_signcolumn = false
}
```
 
and add the following to your statuscolumn configuration

```lua
local function mk_hl(group, sym)
  return table.concat({ "%#", group, "#", sym, "%*" })
end

_G.get_statuscol_octo = function(bufnum, lnum)
  if vim.api.nvim_buf_get_option(bufnum, "filetype") == "octo" then
    if type(octo_buffers) == "table" then
      local buffer = octo_buffers[bufnum]
      if buffer then
        buffer:update_metadata()
        local hl = "OctoSignColumn"
        local metadatas = {buffer.titleMetadata, buffer.bodyMetadata}
        for _, comment_metadata in ipairs(buffer.commentsMetadata) do
          table.insert(metadatas, comment_metadata)
        end
        for _, metadata in ipairs(metadatas) do
          if metadata and metadata.startLine and metadata.endLine then
            if metadata.dirty then
              hl = "OctoDirty"
            else
              hl = "OctoSignColumn"
            end
            if lnum - 1 == metadata.startLine and lnum - 1 == metadata.endLine then
              return mk_hl(hl, "[ ")
            elseif lnum - 1 == metadata.startLine then
              return mk_hl(hl, "┌ ")
            elseif lnum - 1 == metadata.endLine then
              return mk_hl(hl, "└ ")
            elseif metadata.startLine < lnum - 1 and lnum - 1 < metadata.endLine then
              return mk_hl(hl, "│ ")
            end
          end
        end
      end
    end
  end
  return "  "
end

vim.opt.statuscolumn = "%{%v:lua.get_statuscol_octo(bufnr(), v:lnum)%}"

```
