### PR TITLE
feature: review_diff go to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ Contributions are always welcome!
 
 See [`CONTRIBUTING`](/CONTRIBUTING.md) for ways to get started.
 
-Please adhere to this project's [`CODE_OF_CONDUCT`](/CODE_OF_CONDUCT).
+Please adhere to this project's [`CODE_OF_CONDUCT`](/CODE_OF_CONDUCT.md).
 
 ## 🌟 Credits
 The PR review panel is heavily inspired in [diffview.nvim](https://github.com/sindrets/diffview.nvim)

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -145,6 +145,7 @@ M.defaults = {
       select_prev_entry = { lhs = "[q", desc = "move to next changed file" },
       close_review_tab = { lhs = "<C-c>", desc = "close review tab" },
       toggle_viewed = { lhs = "<leader><space>", desc = "toggle viewer viewed state" },
+      goto_file = { lhs = "gf", desc = "go to file" },
     },
     file_panel = {
       next_entry = { lhs = "j", desc = "move to next changed file" },


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This PR adds support for `go_to_file` in `review_diff`. 

Often during the review I want to harness the power of lsp and see some type info, or go to definition. Currently lsp in not attached to buffers during review. But I want to be able to go_to_file to be able to use it.

Also found this comment while browsing thought the project.
https://github.com/antosha417/octo.nvim/blob/92b982d7e2271597accfb3a6157a9f5efc185b24/lua/octo/reviews/file-entry.lua#L394-L400

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes https://github.com/pwntester/octo.nvim/issues/371

### Describe how to verify it
with default config press `gf` while in `review_diff`

### Special notes for reviews
Thank you a lot for maintaining this plugin and doing neovim community better ❤️ 
