### PR TITLE
Fix display offset values for empty diff directives

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1164,6 +1164,12 @@ function M.generate_position2line_map(diffhunk)
       left_side_line = left_side_line + 1
     end
   end
+  if left_offset == nil then
+    left_offset = 0
+  end
+  if right_offset == nil then
+    right_offset = 0
+  end
   return {
     left_side_lines = left_side_lines,
     right_side_lines = right_side_lines,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Assigns 0 to offset values that were returned as `nil` from `string.match()` i.e. no `diff_directive` was found or was empty string.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #382 

### Describe how you did it
Set `right_offset` and `left_offset` to `0` if values are equal to `nil`

### Describe how to verify it
Tested on a personal repo

### Special notes for reviews

