### PR TITLE
Use hostname flag to get user name

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -42,11 +42,11 @@ local function get_env()
 end
 
 -- uses GH to get the name of the authenticated user
-function M.get_user_name()
+function M.get_user_name(remote_hostname)
   local job = Job:new {
     enable_recording = true,
     command = "gh",
-    args = { "auth", "status" },
+    args = { "auth", "status" , "--hostname", remote_hostname },
     env = get_env(),
   }
   job:sync()
@@ -63,17 +63,17 @@ function M.run(opts)
   if not Job then
     return
   end
+  local remote_hostname = require("octo.utils").get_remote_host()
 
   -- Lazy load viewer name on the first gh command
   if not vim.g.octo_viewer then
-    vim.g.octo_viewer = M.get_user_name()
+    vim.g.octo_viewer = M.get_user_name(remote_hostname)
   end
 
   opts = opts or {}
   local conf = config.get_config()
   local mode = opts.mode or "async"
   local hostname = ""
-  local remote_hostname = require("octo.utils").get_remote_host()
   if opts.args[1] == "api" then
     table.insert(opts.args, "-H")
     table.insert(opts.args, "Accept: " .. table.concat(headers, ";"))


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

With this pr the local repo hostname is used to determine the Username for eg comments and other operations that need this username.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #388 

### Describe how you did it

To determine the Username `gh auth status` is used, which also takes the flag `--hostname`. I added this flag to the `gh auth status` command with the remote host i get from the `get_remote_host` function from `octo.utils`.

If you have 2 hosts configured in ~/.config/gh/hosts.yml like github.com and a GHE instance, the current implementation only takes the first  output in consideration to determine the username, which in my test is always github.com even if this is the second host configured in ~/.config/gh/hosts.yml.

With adding the `--hostname` flag we only consider the local repos remote for determine the username.

### Describe how to verify it

You have 2 host configured in ~/.config/gh/hosts.yml and while create a comment on an issue the username on the host the repo is hosted on (github.com or GHE instance) is used in the comment.

### Special notes for reviews

