### PR TITLE
Improve goto_issue & on_cursor_hold

### DIFF
--- a/lua/octo/constants.lua
+++ b/lua/octo/constants.lua
@@ -19,7 +19,8 @@ M.OCTO_EVENT_VT_NS = vim.api.nvim_create_namespace "octo_event_vt"
 M.NO_BODY_MSG = "No description provided."
 
 M.LONG_ISSUE_PATTERN = "([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(%d+)"
-M.SHORT_ISSUE_PATTERN = "()(%s*)#(%d+)"
+M.SHORT_ISSUE_PATTERN = "[^%w%d]+#(%d+)"
+M.SHORT_ISSUE_LINE_BEGGINING_PATTERN = "^#(%d+)"
 M.URL_ISSUE_PATTERN = "[htps]+://[^/]+/([^/]+/[^/]+)/([pulisue]+)/(%d+)"
 
 M.USER_PATTERN = "@([%w-]+)"

--- a/lua/octo/constants.lua
+++ b/lua/octo/constants.lua
@@ -19,7 +19,7 @@ M.OCTO_EVENT_VT_NS = vim.api.nvim_create_namespace "octo_event_vt"
 M.NO_BODY_MSG = "No description provided."
 
 M.LONG_ISSUE_PATTERN = "([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(%d+)"
-M.SHORT_ISSUE_PATTERN = "%s#(%d+)"
+M.SHORT_ISSUE_PATTERN = "()(%s*)#(%d+)"
 M.URL_ISSUE_PATTERN = "[htps]+://[^/]+/([^/]+/[^/]+)/([pulisue]+)/(%d+)"
 
 M.USER_PATTERN = "@([%w-]+)"

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -190,14 +190,7 @@ function M.on_cursor_hold()
   end
 
   -- link popup
-  local repo, number = utils.extract_pattern_at_cursor(constants.LONG_ISSUE_PATTERN)
-  if not repo or not number then
-    repo = buffer.repo
-    number = utils.extract_pattern_at_cursor(constants.SHORT_ISSUE_PATTERN)
-  end
-  if not repo or not number then
-    repo, _, number = utils.extract_pattern_at_cursor(constants.URL_ISSUE_PATTERN)
-  end
+  local repo, number = utils.extract_issue_at_cursor(buffer.repo)
   if not repo or not number then
     return
   end

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -70,7 +70,10 @@ function M.go_to_issue()
 
   if not repo or not number then
     repo = current_repo
-    number = utils.extract_pattern_at_cursor(constants.SHORT_ISSUE_PATTERN)
+    local start_col, maybe_space, n = utils.extract_pattern_at_cursor(constants.SHORT_ISSUE_PATTERN)
+    if n and (start_col == 1 or #maybe_space > 0) then
+      number = n
+    end
   end
 
   if not repo or not number then

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -1,4 +1,3 @@
-local constants = require "octo.constants"
 local gh = require "octo.gh"
 local graphql = require "octo.gh.graphql"
 local utils = require "octo.utils"
@@ -64,59 +63,28 @@ function M.go_to_issue()
   if not buffer then
     return
   end
-  local current_repo = buffer.repo
-
-  local function multi_match(pattern, line, offset)
-    line = line or vim.api.nvim_get_current_line()
-    offset = offset or 0
-    local res = table.pack(line:find(pattern))
-    if #res == 0 then
-      return
-    end
-    local start_col = res[1] + offset
-    local end_col = res[2] + offset
-    if utils.cursor_in_col_range(start_col, end_col) then
-      return unpack(utils.tbl_slice(res, 3, #res))
-    elseif end_col == #line then
-      return
-    end
-    return multi_match(pattern, line:sub(end_col + 1), offset + end_col)
-  end
-
-  local repo, number = multi_match(constants.LONG_ISSUE_PATTERN)
-
+  local repo, number = utils.extract_issue_at_cursor(buffer.repo)
   if not repo or not number then
-    repo = current_repo
-    local start_col, maybe_space, n = multi_match(constants.SHORT_ISSUE_PATTERN)
-    if n and (start_col == 1 or #maybe_space > 0) then
-      number = n
-    end
+    return
   end
-
-  if not repo or not number then
-    repo, _, number = multi_match(constants.URL_ISSUE_PATTERN)
-  end
-
-  if repo and number then
-    local owner, name = utils.split_repo(repo)
-    local query = graphql("issue_kind_query", owner, name, number)
-    gh.run {
-      args = { "api", "graphql", "-f", string.format("query=%s", query) },
-      cb = function(output, stderr)
-        if stderr and not utils.is_blank(stderr) then
-          vim.api.nvim_err_writeln(stderr)
-        elseif output then
-          local resp = vim.fn.json_decode(output)
-          local kind = resp.data.repository.issueOrPullRequest.__typename
-          if kind == "Issue" then
-            utils.get_issue(repo, number)
-          elseif kind == "PullRequest" then
-            utils.get_pull_request(repo, number)
-          end
+  local owner, name = utils.split_repo(repo)
+  local query = graphql("issue_kind_query", owner, name, number)
+  gh.run {
+    args = { "api", "graphql", "-f", string.format("query=%s", query) },
+    cb = function(output, stderr)
+      if stderr and not utils.is_blank(stderr) then
+        vim.api.nvim_err_writeln(stderr)
+      elseif output then
+        local resp = vim.fn.json_decode(output)
+        local kind = resp.data.repository.issueOrPullRequest.__typename
+        if kind == "Issue" then
+          utils.get_issue(repo, number)
+        elseif kind == "PullRequest" then
+          utils.get_pull_request(repo, number)
         end
-      end,
-    }
-  end
+      end
+    end,
+  }
 end
 
 function M.next_comment()

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -647,9 +647,9 @@ function M.extract_pattern_at_cursor(pattern, line, offset)
   if #res == 0 then
     return
   end
-  local start_col = res[1] + offset
-  local end_col = res[2] + offset
-  if M.cursor_in_col_range(start_col, end_col) then
+  local start_col = res[1]
+  local end_col = res[2]
+  if M.cursor_in_col_range(offset + start_col, offset + end_col) then
     return unpack(M.tbl_slice(res, 3, #res))
   elseif end_col == #line then
     return

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -643,6 +643,9 @@ end
 function M.extract_pattern_at_cursor(pattern, line, offset)
   line = line or vim.api.nvim_get_current_line()
   offset = offset or 0
+  if offset > 0 and pattern:sub(1, 1) == "^" then
+    return
+  end
   local res = table.pack(line:find(pattern))
   if #res == 0 then
     return
@@ -660,9 +663,14 @@ end
 function M.extract_issue_at_cursor(current_repo)
   local repo, number = M.extract_pattern_at_cursor(constants.LONG_ISSUE_PATTERN)
   if not repo or not number then
-    local start_col, maybe_space, n = M.extract_pattern_at_cursor(constants.SHORT_ISSUE_PATTERN)
-    if n and (start_col == 1 or #maybe_space > 0) then
-      number = n
+    number = M.extract_pattern_at_cursor(constants.SHORT_ISSUE_PATTERN)
+    if number then
+      repo = current_repo
+    end
+  end
+  if not repo or not number then
+    number = M.extract_pattern_at_cursor(constants.SHORT_ISSUE_LINE_BEGGINING_PATTERN)
+    if number then
       repo = current_repo
     end
   end

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -625,8 +625,9 @@ end
 
 function M.cursor_in_col_range(start_col, end_col)
   local cursor = vim.api.nvim_win_get_cursor(0)
+  local col = cursor[2] + 1
   if start_col and end_col then
-    if start_col <= cursor[2] and cursor[2] <= end_col then
+    if start_col <= col and col <= end_col then
       return true
     end
   end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

I noticed both `goto_issue` and `on_cursor_hold` do not work with the latter issue when multi issues on one line.

```
# With such line below, `#12` can work, but no with `#13`.
See #12, #13
```

This PR solves this and slight bugs below.

* 4e68143 Now it can work with short issue style on the begging of the line.
   - It did not work with `#12` on the begging.
* e1b9417 It had a mistake to calculate columns.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it

Run `goto_issue` and `on_cursor_hold` for each line and each issue/PR.

Short issue pattern: #393, #394, #395
Long issue pattern: pwntester/octo.nvim#393, pwntester/octo.nvim#394, pwntester/octo.nvim#395
URL issue pattern: https://github.com/pwntester/octo.nvim/pull/393, https://github.com/pwntester/octo.nvim/pull/394, https://github.com/pwntester/octo.nvim/pull/395

### Special notes for reviews

