### PR TITLE
refactor(README):rename org

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Edit and review GitHub issues and pull requests from the comfort of your favorit
 - Install [GitHub CLI](https://cli.github.com/)
 - Install [plenary.nvim](https://github.com/nvim-lua/plenary.nvim)
 - Install [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
-- Install [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons)
+- Install [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)
 
 ## 📦 Installation
 
@@ -75,7 +75,7 @@ use {
   requires = {
     'nvim-lua/plenary.nvim',
     'nvim-telescope/telescope.nvim',
-    'kyazdani42/nvim-web-devicons',
+    'nvim-tree/nvim-web-devicons',
   },
   config = function ()
     require"octo".setup()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
nvim-web-devicons's organization `kyazdani42` is renamed to `nvim-tree`.
GitHub can resolve names even with old Org names, but some nvim plugin managers (e.g., lazy.nvim) issue warnings when both old and new names are included in the import. Therefore, I would like to standardize to the new name

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
"NONE"

### Describe how you did it

rename nvim-web-devicons's URL.

### Describe how to verify it
We can access new URL https://github.com/nvim-tree/nvim-web-devicons and display new URL at GitHub.

### Special notes for reviews

