### PR TITLE
Rename "PR review" to "PR reviews"

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Octo issue list neovim/neovim labels=bug,help\ wanted states=OPEN
 Octo search assignee:pwntester is:pr
 ```
 
-## 📋 PR review
+## 📋 PR reviews
 
 - Open the PR (eg: `Octo <PR url>` or `Octo pr list` or `Octo pr edit <PR number>`)
 - Start a review with `Octo review start` or resume a pending review with `Octo review resume`


### PR DESCRIPTION
### Describe what this PR does / why we need it
Rename "PR review" to "PR reviews" to be consistent with the table of contents.  The link to the section in the table of contents now works.

### Does this pull request fix one issue?
Fixes #402.

### Describe how you did it
The link was broken because it did not match the section title.  It now does.

### Describe how to verify it
1. Open the link to the README in the fixed version: https://github.com/jcharum/octo.nvim/blob/5b223ddfc2e47711194bb121e3a99cfc887c7ba5/README.md .
2. Scroll to the Table of Contents.
3. Click on the `PR reviews` link.
4. Verify that it takes you to the `PR reviews` section.

### Special notes for reviews
None.