### PR TITLE
Fix state highlighting

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -186,7 +186,7 @@ function M.write_state(bufnr, state, number)
   -- title virtual text
   local title_vt = {
     { tostring(number), "OctoIssueId" },
-    { string.format(" [%s] ", state), utils.state_hl_map[state] .. "Float" },
+    { string.format(" [%s] ", state), utils.state_hl_map[state] },
   }
 
   -- PR virtual text


### PR DESCRIPTION
The state colors were not being loaded because of this string concatenation.

Because it is not documented this way, I took the initial approach of simply removing the concatenation, however in order to not break existing configurations which have figured this out, perhaps we should add `Float` to the names here instead, and update the documentation accordingly:

https://github.com/pwntester/octo.nvim/blob/2d2769ff80a82a0da24dcf636ae146f3ed5d7ae5/lua/octo/ui/colors.lua#L113-L121

WDYT?

fixes #405