### PR TITLE
feature: Show builtin actions when no action is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ use {
 ```lua
 require"octo".setup({
   use_local_fs = false,                    -- use local files on right side of reviews
+  enable_builtin = false,                  -- shows a list of builtin actions when no action is provided
   default_remote = {"upstream", "origin"}; -- order to try remotes
   ssh_aliases = {},                        -- SSH aliases. e.g. `ssh_aliases = {["github.com-work"] = "github.com"}`
   reaction_viewer_hint_icon = "";         -- marker for user reactions

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -324,7 +324,11 @@ end
 
 function M.octo(object, action, ...)
   if not object then
-    utils.error "Missing arguments"
+    if config.get_config().enable_builtin then
+      M.commands.actions()
+    else
+      utils.error "Missing arguments"
+    end
     return
   end
   local o = M.commands[object]

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -15,6 +15,7 @@ M.defaults = {
   left_bubble_delimiter = "",
   github_hostname = "",
   use_local_fs = false,
+  enable_builtin = false,
   snippet_context_lines = 4,
   gh_env = {},
   timeout = 5000,


### PR DESCRIPTION
### Describe what this PR does / why we need it
Provides a QOL feature to show the list of builtin actions when no action is provided.

### Does this pull request fix one issue?
Fixes #377 

### Describe how you did it
Added the config option `enable_builtin` which when enabled runs `Octo actions` when the user runs the default `Octo` command.

### Describe how to verify it
When turned off the behavior of `Octo` should be the same. When enabled it should run `Octo actions`

### Special notes for reviews
I've set the default behavior of it to be off but maybe it should just be on by default and just remove the error message when no action is provided? 🤔 
