### PR TITLE
fix: Use cwd's origin url on `Octo repo view` when no argument is passed

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -138,7 +138,14 @@ function M.setup()
         picker.repos { login = login }
       end,
       view = function(repo)
-        utils.get_repo(nil, repo)
+        if repo == nil and utils.cwd_is_git() then
+          repo = utils.get_git_origin_repo()
+          utils.get_repo(nil, repo)
+        elseif repo == nil then
+          utils.error "Argument for repo name is required"
+        else
+          utils.get_repo(nil, repo)
+        end
       end,
       fork = function()
         utils.fork_repo()

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -378,6 +378,23 @@ function M.get_repo_id(repo)
   end
 end
 
+-- Checks if the current cwd is in a git repo
+function M.cwd_is_git()
+  local cmd = "git rev-parse --is-inside-work-tree"
+  local out = vim.fn.system(cmd)
+  out = out:gsub("%s+", "")
+  return out == "true"
+end
+
+-- Gets the origin url and returns the repo name
+function M.get_git_origin_repo()
+  local cmd = "git remote get-url origin"
+  local repo = string.gsub(vim.fn.system(cmd), ".*:", "")
+  repo = repo:gsub(".git", "")
+  repo = repo:gsub("%s+", "")
+  return repo
+end
+
 ---Gets repo info
 function M.get_repo_info(repo)
   if repo_info_cache[repo] then


### PR DESCRIPTION
### Describe what this PR does / why we need it
This commit changes the `repo view` command to fetch the cwd git remote-origin when no repository argument is provided. If its not in a git folder then it will just log an error instead.

### Does this pull request fix one issue?

Fixes #413 

### Describe how you did it

Check cwd is a git folder -> Attempt to fetch origin url -> Pull repository name and pass to edit octo buffer

### Describe how to verify it
Run `Octo repo view` in a folder that has a remote-origin set

### Special notes for reviews

