### PR TITLE
fix: Use default title for fzf-lua actions picker

### DIFF
--- a/lua/octo/pickers/fzf-lua/pickers/actions.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/actions.lua
@@ -17,7 +17,7 @@ return function(flattened_actions)
   table.sort(titles)
 
   fzf.fzf_exec(titles, {
-    prompt = picker_utils.get_prompt(opts.prompt_title),
+    prompt = picker_utils.get_prompt "Actions",
     fzf_opts = {
       ["--no-multi"] = "",
     },


### PR DESCRIPTION
### Describe what this PR does / why we need it
This commit fixes a bug where the fzf-lua actions picker references an unknown opt table and uses a default `Action` string as the picker title.

### Does this pull request fix one issue?

Fixes #415 

### Describe how you did it
Removed an uninitialized opt table reference

### Describe how to verify it
Switch to fzf-lua as a picker and run `Octo actions`

### Special notes for reviews

