### PR TITLE
Improve background color

### DIFF
--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -177,13 +177,9 @@ end
 function M.get_background_color_of_highlight_group(highlight_group_name)
   local highlight_group = vim.api.nvim_get_hl_by_name(highlight_group_name, true)
   local highlight_group_normal = vim.api.nvim_get_hl_by_name("Normal", true)
-  local background_color = highlight_group.background
-      or highlight_group_normal.background
-      or highlight_group_normal.foreground
+  local background_color = highlight_group.background or highlight_group_normal.background
   if background_color then
     return string.format("#%06x", background_color)
-  else
-    return "#000000"
   end
 end
 


### PR DESCRIPTION
Closes #424 

Adjusting the `get_background_color_of_highlight_group` function to support cleared highlight groups.

- Falling back to `highlight_group_normal.foreground` is both confusing and makes it impossible to overwrite the default background value to a null value. So I've removed it.
- Removed the fallback else if background color isn't defined. In my case, I don't want there to be a background color so I'm clearing the `OctoEditable` highlight but the previous logic would still add a color back.

### Does this pull request fix one issue?

Resolves https://github.com/pwntester/octo.nvim/discussions/424

### Special notes for reviews

Please let me know if the black background was intentional. And if so, what I would need to do to allow the `get_background_color_of_highlight_group` to return a cleared value so I can get a transparent UI.

