### PR TITLE
fix: add space after the viewed icon

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -15,7 +15,7 @@ local path_sep = package.config:sub(1, 1)
 
 M.viewed_state_map = {
   DISMISSED = { icon = "󰀨 ", hl = "OctoRed" },
-  VIEWED = { icon = "󰗠", hl = "OctoGreen" },
+  VIEWED = { icon = "󰗠 ", hl = "OctoGreen" },
   UNVIEWED = { icon = "󰄰 ", hl = "OctoBlue" },
 }
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

It fixes missing space in file panel.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Added the missing space.

### Describe how to verify it

1. Start a review
2. Mark a file as viewed
3. Check the mark looks good