### PR TITLE
Fix wrong argument in load buffer function

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -394,14 +394,14 @@ function M.add_comment()
     viewerCanDelete = true,
     viewerDidAuthor = true,
     reactionGroups = {
-      { content = "THUMBS_UP",   users = { totalCount = 0 } },
+      { content = "THUMBS_UP", users = { totalCount = 0 } },
       { content = "THUMBS_DOWN", users = { totalCount = 0 } },
-      { content = "LAUGH",       users = { totalCount = 0 } },
-      { content = "HOORAY",      users = { totalCount = 0 } },
-      { content = "CONFUSED",    users = { totalCount = 0 } },
-      { content = "HEART",       users = { totalCount = 0 } },
-      { content = "ROCKET",      users = { totalCount = 0 } },
-      { content = "EYES",        users = { totalCount = 0 } },
+      { content = "LAUGH", users = { totalCount = 0 } },
+      { content = "HOORAY", users = { totalCount = 0 } },
+      { content = "CONFUSED", users = { totalCount = 0 } },
+      { content = "HEART", users = { totalCount = 0 } },
+      { content = "ROCKET", users = { totalCount = 0 } },
+      { content = "EYES", users = { totalCount = 0 } },
     },
   }
 
@@ -804,12 +804,12 @@ function M.create_pr(is_draft)
 
   -- get remote branches
   if
-      info == nil
-      or info.refs == nil
-      or info.refs.nodes == nil
-      or info == vim.NIL
-      or info.refs == vim.NIL
-      or info.refs.nodes == vim.NIL
+    info == nil
+    or info.refs == nil
+    or info.refs.nodes == nil
+    or info == vim.NIL
+    or info.refs == vim.NIL
+    or info.refs.nodes == vim.NIL
   then
     utils.error "Cannot grab remote branches"
     return
@@ -825,7 +825,7 @@ function M.create_pr(is_draft)
   local remote_branch = local_branch
   if not remote_branch_exists then
     local choice =
-        vim.fn.confirm("Remote branch '" .. local_branch .. "' does not exist. Push local one?", "&Yes\n&No\n&Cancel", 2)
+      vim.fn.confirm("Remote branch '" .. local_branch .. "' does not exist. Push local one?", "&Yes\n&No\n&Cancel", 2)
     if choice == 1 then
       local remote = "origin"
       remote_branch = vim.fn.input {
@@ -1275,12 +1275,7 @@ function M.move_project_card()
 end
 
 function M.reload(bufnr)
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
-  local buffer = octo_buffers[bufnr]
-  if not buffer then
-    return
-  end
-  require("octo").load_buffer(buffer.repo, buffer.kind, buffer.number)
+  require("octo").load_buffer(bufnr)
 end
 
 function M.create_label(label)

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -26,8 +26,8 @@ function M.open_in_browser(kind, repo, number)
   local cmd
   local remote = utils.get_remote_host()
   if not remote then
-     utils.error "Cannot find repo remote host"
-     return
+    utils.error "Cannot find repo remote host"
+    return
   end
   if not kind and not repo then
     local bufnr = vim.api.nvim_get_current_buf()

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -158,23 +158,23 @@ function M.issues(opts)
         opts.prompt_title = opts.prompt_title or ""
         opts.results_title = opts.results_title or ""
         pickers
-            .new(opts, {
-              finder = finders.new_table {
-                results = issues,
-                entry_maker = entry_maker.gen_from_issue(max_number),
-              },
-              sorter = conf.generic_sorter(opts),
-              previewer = previewers.issue.new(opts),
-              attach_mappings = function(_, map)
-                action_set.select:replace(function(prompt_bufnr, type)
-                  open(type)(prompt_bufnr)
-                end)
-                map("i", "<c-b>", open_in_browser())
-                map("i", "<c-y>", copy_url())
-                return true
-              end,
-            })
-            :find()
+          .new(opts, {
+            finder = finders.new_table {
+              results = issues,
+              entry_maker = entry_maker.gen_from_issue(max_number),
+            },
+            sorter = conf.generic_sorter(opts),
+            previewer = previewers.issue.new(opts),
+            attach_mappings = function(_, map)
+              action_set.select:replace(function(prompt_bufnr, type)
+                open(type)(prompt_bufnr)
+              end)
+              map("i", "<c-b>", open_in_browser())
+              map("i", "<c-y>", copy_url())
+              return true
+            end,
+          })
+          :find()
       end
     end,
   }
@@ -224,19 +224,19 @@ function M.gists(opts)
         opts.prompt_title = opts.prompt_title or ""
         opts.results_title = opts.results_title or ""
         pickers
-            .new(opts, {
-              finder = finders.new_table {
-                results = gists,
-                entry_maker = entry_maker.gen_from_gist(),
-              },
-              previewer = previewers.gist.new(opts),
-              sorter = conf.generic_sorter(opts),
-              attach_mappings = function(_, map)
-                map("i", "<CR>", open_gist)
-                return true
-              end,
-            })
-            :find()
+          .new(opts, {
+            finder = finders.new_table {
+              results = gists,
+              entry_maker = entry_maker.gen_from_gist(),
+            },
+            previewer = previewers.gist.new(opts),
+            sorter = conf.generic_sorter(opts),
+            attach_mappings = function(_, map)
+              map("i", "<CR>", open_gist)
+              return true
+            end,
+          })
+          :find()
       end
     end,
   }
@@ -280,7 +280,7 @@ function M.pull_requests(opts)
   local cfg = octo_config.get_config()
   local order_by = cfg.pull_requests.order_by
   local query =
-      graphql("pull_requests_query", owner, name, filter, order_by.field, order_by.direction, { escape = false })
+    graphql("pull_requests_query", owner, name, filter, order_by.field, order_by.direction, { escape = false })
   utils.info "Fetching pull requests (this may take a while) ..."
   gh.run {
     args = { "api", "graphql", "--paginate", "--jq", ".", "-f", string.format("query=%s", query) },
@@ -304,25 +304,25 @@ function M.pull_requests(opts)
         opts.prompt_title = opts.prompt_title or ""
         opts.results_title = opts.results_title or ""
         pickers
-            .new(opts, {
-              finder = finders.new_table {
-                results = pull_requests,
-                entry_maker = entry_maker.gen_from_issue(max_number),
-              },
-              sorter = conf.generic_sorter(opts),
-              previewer = previewers.issue.new(opts),
-              attach_mappings = function(_, map)
-                action_set.select:replace(function(prompt_bufnr, type)
-                  open(type)(prompt_bufnr)
-                end)
-                map("i", "<c-o>", checkout_pull_request())
-                map("i", "<c-b>", open_in_browser())
-                map("i", "<c-y>", copy_url())
-                map("i", "<c-r>", merge_pull_request())
-                return true
-              end,
-            })
-            :find()
+          .new(opts, {
+            finder = finders.new_table {
+              results = pull_requests,
+              entry_maker = entry_maker.gen_from_issue(max_number),
+            },
+            sorter = conf.generic_sorter(opts),
+            previewer = previewers.issue.new(opts),
+            attach_mappings = function(_, map)
+              action_set.select:replace(function(prompt_bufnr, type)
+                open(type)(prompt_bufnr)
+              end)
+              map("i", "<c-o>", checkout_pull_request())
+              map("i", "<c-b>", open_in_browser())
+              map("i", "<c-y>", copy_url())
+              map("i", "<c-r>", merge_pull_request())
+              return true
+            end,
+          })
+          :find()
       end
     end,
   }
@@ -347,24 +347,24 @@ function M.commits()
       elseif output then
         local results = vim.fn.json_decode(output)
         pickers
-            .new({}, {
-              prompt_title = false,
-              results_title = false,
-              preview_title = false,
-              finder = finders.new_table {
-                results = results,
-                entry_maker = entry_maker.gen_from_git_commits(),
-              },
-              sorter = conf.generic_sorter {},
-              previewer = previewers.commit.new { repo = buffer.repo },
-              attach_mappings = function()
-                action_set.select:replace(function(prompt_bufnr, type)
-                  open_preview_buffer(type)(prompt_bufnr)
-                end)
-                return true
-              end,
-            })
-            :find()
+          .new({}, {
+            prompt_title = false,
+            results_title = false,
+            preview_title = false,
+            finder = finders.new_table {
+              results = results,
+              entry_maker = entry_maker.gen_from_git_commits(),
+            },
+            sorter = conf.generic_sorter {},
+            previewer = previewers.commit.new { repo = buffer.repo },
+            attach_mappings = function()
+              action_set.select:replace(function(prompt_bufnr, type)
+                open_preview_buffer(type)(prompt_bufnr)
+              end)
+              return true
+            end,
+          })
+          :find()
       end
     end,
   }
@@ -378,7 +378,7 @@ function M.review_commits(callback)
   end
   -- TODO: graphql
   local url =
-      string.format("repos/%s/pulls/%d/commits", current_review.pull_request.repo, current_review.pull_request.number)
+    string.format("repos/%s/pulls/%d/commits", current_review.pull_request.repo, current_review.pull_request.number)
   gh.run {
     args = { "api", url },
     cb = function(output, stderr)
@@ -406,28 +406,28 @@ function M.review_commits(callback)
         })
 
         pickers
-            .new({}, {
-              prompt_title = false,
-              results_title = false,
-              preview_title = false,
-              finder = finders.new_table {
-                results = results,
-                entry_maker = entry_maker.gen_from_git_commits(),
-              },
-              sorter = conf.generic_sorter {},
-              previewer = previewers.commit.new { repo = current_review.pull_request.repo },
-              attach_mappings = function()
-                action_set.select:replace(function(prompt_bufnr)
-                  local commit = action_state.get_selected_entry(prompt_bufnr)
-                  local right = commit.value
-                  local left = commit.parent
-                  actions.close(prompt_bufnr)
-                  callback(right, left)
-                end)
-                return true
-              end,
-            })
-            :find()
+          .new({}, {
+            prompt_title = false,
+            results_title = false,
+            preview_title = false,
+            finder = finders.new_table {
+              results = results,
+              entry_maker = entry_maker.gen_from_git_commits(),
+            },
+            sorter = conf.generic_sorter {},
+            previewer = previewers.commit.new { repo = current_review.pull_request.repo },
+            attach_mappings = function()
+              action_set.select:replace(function(prompt_bufnr)
+                local commit = action_state.get_selected_entry(prompt_bufnr)
+                local right = commit.value
+                local left = commit.parent
+                actions.close(prompt_bufnr)
+                callback(right, left)
+              end)
+              return true
+            end,
+          })
+          :find()
       end
     end,
   }
@@ -451,24 +451,24 @@ function M.changed_files()
       elseif output then
         local results = vim.fn.json_decode(output)
         pickers
-            .new({}, {
-              prompt_title = false,
-              results_title = false,
-              preview_title = false,
-              finder = finders.new_table {
-                results = results,
-                entry_maker = entry_maker.gen_from_git_changed_files(),
-              },
-              sorter = conf.generic_sorter {},
-              previewer = previewers.changed_files.new { repo = buffer.repo, number = buffer.number },
-              attach_mappings = function()
-                action_set.select:replace(function(prompt_bufnr, type)
-                  open_preview_buffer(type)(prompt_bufnr)
-                end)
-                return true
-              end,
-            })
-            :find()
+          .new({}, {
+            prompt_title = false,
+            results_title = false,
+            preview_title = false,
+            finder = finders.new_table {
+              results = results,
+              entry_maker = entry_maker.gen_from_git_changed_files(),
+            },
+            sorter = conf.generic_sorter {},
+            previewer = previewers.changed_files.new { repo = buffer.repo, number = buffer.number },
+            attach_mappings = function()
+              action_set.select:replace(function(prompt_bufnr, type)
+                open_preview_buffer(type)(prompt_bufnr)
+              end)
+              return true
+            end,
+          })
+          :find()
       end
     end,
   }
@@ -523,20 +523,20 @@ function M.search(opts)
   opts.prompt_title = opts.prompt_title or ""
   opts.results_title = opts.results_title or ""
   pickers
-      .new(opts, {
-        finder = finder,
-        sorter = conf.generic_sorter(opts),
-        previewer = previewers.issue.new(opts),
-        attach_mappings = function(_, map)
-          action_set.select:replace(function(prompt_bufnr, type)
-            open(type)(prompt_bufnr)
-          end)
-          map("i", "<c-b>", open_in_browser())
-          map("i", "<c-y>", copy_url())
-          return true
-        end,
-      })
-      :find()
+    .new(opts, {
+      finder = finder,
+      sorter = conf.generic_sorter(opts),
+      previewer = previewers.issue.new(opts),
+      attach_mappings = function(_, map)
+        action_set.select:replace(function(prompt_bufnr, type)
+          open(type)(prompt_bufnr)
+        end)
+        map("i", "<c-b>", open_in_browser())
+        map("i", "<c-y>", copy_url())
+        return true
+      end,
+    })
+    :find()
 end
 
 ---
@@ -549,26 +549,26 @@ function M.pending_threads(threads)
     max_linenr_length = math.max(max_linenr_length, #tostring(thread.line))
   end
   pickers
-      .new({}, {
-        prompt_title = false,
-        results_title = false,
-        preview_title = false,
-        finder = finders.new_table {
-          results = threads,
-          entry_maker = entry_maker.gen_from_review_thread(max_linenr_length),
-        },
-        sorter = conf.generic_sorter {},
-        previewer = previewers.review_thread.new {},
-        attach_mappings = function()
-          actions.select_default:replace(function(prompt_bufnr)
-            local thread = action_state.get_selected_entry(prompt_bufnr).thread
-            actions.close(prompt_bufnr)
-            reviews.jump_to_pending_review_thread(thread)
-          end)
-          return true
-        end,
-      })
-      :find()
+    .new({}, {
+      prompt_title = false,
+      results_title = false,
+      preview_title = false,
+      finder = finders.new_table {
+        results = threads,
+        entry_maker = entry_maker.gen_from_review_thread(max_linenr_length),
+      },
+      sorter = conf.generic_sorter {},
+      previewer = previewers.review_thread.new {},
+      attach_mappings = function()
+        actions.select_default:replace(function(prompt_bufnr)
+          local thread = action_state.get_selected_entry(prompt_bufnr).thread
+          actions.close(prompt_bufnr)
+          reviews.jump_to_pending_review_thread(thread)
+        end)
+        return true
+      end,
+    })
+    :find()
 end
 
 ---
@@ -588,22 +588,22 @@ function M.select_project_card(cb)
   else
     local opts = vim.deepcopy(dropdown_opts)
     pickers
-        .new(opts, {
-          finder = finders.new_table {
-            results = cards.nodes,
-            entry_maker = entry_maker.gen_from_project_card(),
-          },
-          sorter = conf.generic_sorter(opts),
-          attach_mappings = function(_, _)
-            actions.select_default:replace(function(prompt_bufnr)
-              local source_card = action_state.get_selected_entry(prompt_bufnr)
-              actions.close(prompt_bufnr)
-              cb(source_card.card.id)
-            end)
-            return true
-          end,
-        })
-        :find()
+      .new(opts, {
+        finder = finders.new_table {
+          results = cards.nodes,
+          entry_maker = entry_maker.gen_from_project_card(),
+        },
+        sorter = conf.generic_sorter(opts),
+        attach_mappings = function(_, _)
+          actions.select_default:replace(function(prompt_bufnr)
+            local source_card = action_state.get_selected_entry(prompt_bufnr)
+            actions.close(prompt_bufnr)
+            cb(source_card.card.id)
+          end)
+          return true
+        end,
+      })
+      :find()
   end
 end
 
@@ -634,39 +634,39 @@ function M.select_target_project_column(cb)
 
         local opts = vim.deepcopy(dropdown_opts)
         pickers
-            .new(opts, {
-              finder = finders.new_table {
-                results = projects,
-                entry_maker = entry_maker.gen_from_project(),
-              },
-              sorter = conf.generic_sorter(opts),
-              attach_mappings = function()
-                action_set.select:replace(function(prompt_bufnr)
-                  local selected_project = action_state.get_selected_entry(prompt_bufnr)
-                  actions._close(prompt_bufnr, true)
-                  local opts2 = vim.deepcopy(dropdown_opts)
-                  pickers
-                      .new(opts2, {
-                        finder = finders.new_table {
-                          results = selected_project.project.columns.nodes,
-                          entry_maker = entry_maker.gen_from_project_column(),
-                        },
-                        sorter = conf.generic_sorter(opts2),
-                        attach_mappings = function()
-                          action_set.select:replace(function(prompt_bufnr2)
-                            local selected_column = action_state.get_selected_entry(prompt_bufnr2)
-                            actions.close(prompt_bufnr2)
-                            cb(selected_column.column.id)
-                          end)
-                          return true
-                        end,
-                      })
-                      :find()
-                end)
-                return true
-              end,
-            })
-            :find()
+          .new(opts, {
+            finder = finders.new_table {
+              results = projects,
+              entry_maker = entry_maker.gen_from_project(),
+            },
+            sorter = conf.generic_sorter(opts),
+            attach_mappings = function()
+              action_set.select:replace(function(prompt_bufnr)
+                local selected_project = action_state.get_selected_entry(prompt_bufnr)
+                actions._close(prompt_bufnr, true)
+                local opts2 = vim.deepcopy(dropdown_opts)
+                pickers
+                  .new(opts2, {
+                    finder = finders.new_table {
+                      results = selected_project.project.columns.nodes,
+                      entry_maker = entry_maker.gen_from_project_column(),
+                    },
+                    sorter = conf.generic_sorter(opts2),
+                    attach_mappings = function()
+                      action_set.select:replace(function(prompt_bufnr2)
+                        local selected_column = action_state.get_selected_entry(prompt_bufnr2)
+                        actions.close(prompt_bufnr2)
+                        cb(selected_column.column.id)
+                      end)
+                      return true
+                    end,
+                  })
+                  :find()
+              end)
+              return true
+            end,
+          })
+          :find()
       end
     end,
   }
@@ -693,22 +693,22 @@ function M.select_label(cb)
         local resp = vim.fn.json_decode(output)
         local labels = resp.data.repository.labels.nodes
         pickers
-            .new(opts, {
-              finder = finders.new_table {
-                results = labels,
-                entry_maker = entry_maker.gen_from_label(),
-              },
-              sorter = conf.generic_sorter(opts),
-              attach_mappings = function(_, _)
-                actions.select_default:replace(function(prompt_bufnr)
-                  local selected_label = action_state.get_selected_entry(prompt_bufnr)
-                  actions.close(prompt_bufnr)
-                  cb(selected_label.label.id)
-                end)
-                return true
-              end,
-            })
-            :find()
+          .new(opts, {
+            finder = finders.new_table {
+              results = labels,
+              entry_maker = entry_maker.gen_from_label(),
+            },
+            sorter = conf.generic_sorter(opts),
+            attach_mappings = function(_, _)
+              actions.select_default:replace(function(prompt_bufnr)
+                local selected_label = action_state.get_selected_entry(prompt_bufnr)
+                actions.close(prompt_bufnr)
+                cb(selected_label.label.id)
+              end)
+              return true
+            end,
+          })
+          :find()
       end
     end,
   }
@@ -738,22 +738,22 @@ function M.select_assigned_label(cb)
         local resp = vim.fn.json_decode(output)
         local labels = resp.data.repository[key].labels.nodes
         pickers
-            .new(opts, {
-              finder = finders.new_table {
-                results = labels,
-                entry_maker = entry_maker.gen_from_label(),
-              },
-              sorter = conf.generic_sorter(opts),
-              attach_mappings = function(_, _)
-                actions.select_default:replace(function(prompt_bufnr)
-                  local selected_label = action_state.get_selected_entry(prompt_bufnr)
-                  actions.close(prompt_bufnr)
-                  cb(selected_label.label.id)
-                end)
-                return true
-              end,
-            })
-            :find()
+          .new(opts, {
+            finder = finders.new_table {
+              results = labels,
+              entry_maker = entry_maker.gen_from_label(),
+            },
+            sorter = conf.generic_sorter(opts),
+            attach_mappings = function(_, _)
+              actions.select_default:replace(function(prompt_bufnr)
+                local selected_label = action_state.get_selected_entry(prompt_bufnr)
+                actions.close(prompt_bufnr)
+                cb(selected_label.label.id)
+              end)
+              return true
+            end,
+          })
+          :find()
       end
     end,
   }
@@ -827,47 +827,47 @@ function M.select_user(cb)
   end
 
   pickers
-      .new(opts, {
-        finder = finders.new_dynamic {
-          entry_maker = entry_maker.gen_from_user(),
-          fn = get_user_requester(),
-        },
-        sorter = sorters.get_fuzzy_file(opts),
-        attach_mappings = function()
-          actions.select_default:replace(function(prompt_bufnr)
-            local selected_user = action_state.get_selected_entry(prompt_bufnr)
-            actions._close(prompt_bufnr, true)
-            if not selected_user.teams then
-              -- user
-              cb(selected_user.value)
-            else
-              -- organization, pick a team
-              pickers
-                  .new(opts, {
-                    prompt_title = false,
-                    results_title = false,
-                    preview_title = false,
-                    finder = finders.new_table {
-                      results = selected_user.teams,
-                      entry_maker = entry_maker.gen_from_team(),
-                    },
-                    sorter = conf.generic_sorter(opts),
-                    attach_mappings = function()
-                      actions.select_default:replace(function(prompt_bufnr)
-                        local selected_team = action_state.get_selected_entry(prompt_bufnr)
-                        actions.close(prompt_bufnr)
-                        cb(selected_team.team.id)
-                      end)
-                      return true
-                    end,
-                  })
-                  :find()
-            end
-          end)
-          return true
-        end,
-      })
-      :find()
+    .new(opts, {
+      finder = finders.new_dynamic {
+        entry_maker = entry_maker.gen_from_user(),
+        fn = get_user_requester(),
+      },
+      sorter = sorters.get_fuzzy_file(opts),
+      attach_mappings = function()
+        actions.select_default:replace(function(prompt_bufnr)
+          local selected_user = action_state.get_selected_entry(prompt_bufnr)
+          actions._close(prompt_bufnr, true)
+          if not selected_user.teams then
+            -- user
+            cb(selected_user.value)
+          else
+            -- organization, pick a team
+            pickers
+              .new(opts, {
+                prompt_title = false,
+                results_title = false,
+                preview_title = false,
+                finder = finders.new_table {
+                  results = selected_user.teams,
+                  entry_maker = entry_maker.gen_from_team(),
+                },
+                sorter = conf.generic_sorter(opts),
+                attach_mappings = function()
+                  actions.select_default:replace(function(prompt_bufnr)
+                    local selected_team = action_state.get_selected_entry(prompt_bufnr)
+                    actions.close(prompt_bufnr)
+                    cb(selected_team.team.id)
+                  end)
+                  return true
+                end,
+              })
+              :find()
+          end
+        end)
+        return true
+      end,
+    })
+    :find()
 end
 
 --
@@ -897,22 +897,22 @@ function M.select_assignee(cb)
         local resp = vim.fn.json_decode(output)
         local assignees = resp.data.repository[key].assignees.nodes
         pickers
-            .new(opts, {
-              finder = finders.new_table {
-                results = assignees,
-                entry_maker = entry_maker.gen_from_user(),
-              },
-              sorter = conf.generic_sorter(opts),
-              attach_mappings = function(_, _)
-                actions.select_default:replace(function(prompt_bufnr)
-                  local selected_assignee = action_state.get_selected_entry(prompt_bufnr)
-                  actions.close(prompt_bufnr)
-                  cb(selected_assignee.user.id)
-                end)
-                return true
-              end,
-            })
-            :find()
+          .new(opts, {
+            finder = finders.new_table {
+              results = assignees,
+              entry_maker = entry_maker.gen_from_user(),
+            },
+            sorter = conf.generic_sorter(opts),
+            attach_mappings = function(_, _)
+              actions.select_default:replace(function(prompt_bufnr)
+                local selected_assignee = action_state.get_selected_entry(prompt_bufnr)
+                actions.close(prompt_bufnr)
+                cb(selected_assignee.user.id)
+              end)
+              return true
+            end,
+          })
+          :find()
       end
     end,
   }
@@ -957,22 +957,22 @@ function M.repos(opts)
         opts.prompt_title = opts.prompt_title or ""
         opts.results_title = opts.results_title or ""
         pickers
-            .new(opts, {
-              finder = finders.new_table {
-                results = repos,
-                entry_maker = entry_maker.gen_from_repo(max_nameWithOwner, max_forkCount, max_stargazerCount),
-              },
-              sorter = conf.generic_sorter(opts),
-              attach_mappings = function(_, map)
-                action_set.select:replace(function(prompt_bufnr, type)
-                  open(type)(prompt_bufnr)
-                end)
-                map("i", "<c-b>", open_in_browser())
-                map("i", "<c-y>", copy_url())
-                return true
-              end,
-            })
-            :find()
+          .new(opts, {
+            finder = finders.new_table {
+              results = repos,
+              entry_maker = entry_maker.gen_from_repo(max_nameWithOwner, max_forkCount, max_stargazerCount),
+            },
+            sorter = conf.generic_sorter(opts),
+            attach_mappings = function(_, map)
+              action_set.select:replace(function(prompt_bufnr, type)
+                open(type)(prompt_bufnr)
+              end)
+              map("i", "<c-b>", open_in_browser())
+              map("i", "<c-y>", copy_url())
+              return true
+            end,
+          })
+          :find()
       end
     end,
   }
@@ -989,22 +989,22 @@ function M.actions(flattened_actions)
   }
 
   pickers
-      .new(opts, {
-        finder = finders.new_table {
-          results = flattened_actions,
-          entry_maker = entry_maker.gen_from_octo_actions(),
-        },
-        sorter = conf.generic_sorter(opts),
-        attach_mappings = function()
-          actions.select_default:replace(function(prompt_bufnr)
-            local selected_command = action_state.get_selected_entry(prompt_bufnr)
-            actions.close(prompt_bufnr)
-            selected_command.action.fun()
-          end)
-          return true
-        end,
-      })
-      :find()
+    .new(opts, {
+      finder = finders.new_table {
+        results = flattened_actions,
+        entry_maker = entry_maker.gen_from_octo_actions(),
+      },
+      sorter = conf.generic_sorter(opts),
+      attach_mappings = function()
+        actions.select_default:replace(function(prompt_bufnr)
+          local selected_command = action_state.get_selected_entry(prompt_bufnr)
+          actions.close(prompt_bufnr)
+          selected_command.action.fun()
+        end)
+        return true
+      end,
+    })
+    :find()
 end
 
 --
@@ -1018,23 +1018,23 @@ function M.issue_templates(templates, cb)
   }
 
   pickers
-      .new(opts, {
-        finder = finders.new_table {
-          results = templates,
-          entry_maker = entry_maker.gen_from_issue_templates(),
-        },
-        sorter = conf.generic_sorter(opts),
-        previewer = previewers.issue_template.new {},
-        attach_mappings = function()
-          actions.select_default:replace(function(prompt_bufnr)
-            local selected_template = action_state.get_selected_entry(prompt_bufnr)
-            actions.close(prompt_bufnr)
-            cb(selected_template.template)
-          end)
-          return true
-        end,
-      })
-      :find()
+    .new(opts, {
+      finder = finders.new_table {
+        results = templates,
+        entry_maker = entry_maker.gen_from_issue_templates(),
+      },
+      sorter = conf.generic_sorter(opts),
+      previewer = previewers.issue_template.new {},
+      attach_mappings = function()
+        actions.select_default:replace(function(prompt_bufnr)
+          local selected_template = action_state.get_selected_entry(prompt_bufnr)
+          actions.close(prompt_bufnr)
+          cb(selected_template.template)
+        end)
+        return true
+      end,
+    })
+    :find()
 end
 
 M.picker = {

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -140,8 +140,8 @@ end
 
 function M.setup()
   for name, v in pairs(get_hl_groups()) do
-    local fg  = v.fg and " guifg=" .. v.fg or ""
-    local bg  = v.bg and " guibg=" .. v.bg or ""
+    local fg = v.fg and " guifg=" .. v.fg or ""
+    local bg = v.bg and " guibg=" .. v.bg or ""
     local gui = v.gui and " gui=" .. v.gui or ""
     local cmd = "hi def Octo" .. name .. fg .. bg .. gui
     vim.cmd(cmd)
@@ -168,7 +168,7 @@ local function color_is_bright(r, g, b)
   -- Counting the perceptive luminance - human eye favors green color
   local luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
   if luminance > 0.5 then
-    return true  -- Bright colors, black font
+    return true -- Bright colors, black font
   else
     return false -- Dark colors, white font
   end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

 the function `M.load_buffer` accepts the buffer number but the reload function passes in several arguments, causing the `Octo pr reload` always to fail 

https://github.com/pwntester/octo.nvim/blob/bd53dee3ab1bf13882e3e5013f355d802b0a76ad/lua/octo/init.lua#L64

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

