### PR TITLE
fix: setting title for pr create

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -887,8 +887,10 @@ function M.save_pr(opts)
   local title, body
   local last_commit = string.gsub(vim.fn.system "git log -1 --pretty=%B", "%s+$", "")
   local last_commit_lines = vim.split(last_commit, "\n")
-  if #last_commit_lines > 1 then
+  if #last_commit_lines >= 1 then
     title = last_commit_lines[1]
+  end
+  if #last_commit_lines > 1 then
     if utils.is_blank(last_commit_lines[2]) and #last_commit_lines > 2 then
       body = table.concat(vim.list_slice(last_commit_lines, 3, #last_commit_lines), "\n")
     else


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes the issue where the PR title doesn't get populated on create.

### Does this pull request fix one issue?

Fixes #444 

### Describe how you did it

If the last commit doesn't have body, the logic skips setting the title. So I adjusted it to always set the title if the commit has a description (even without a body).

### Describe how to verify it

1. Create a commit without a body (just a title)
2. Create a PR with Octo
3. The "Enter title:" input will be populated with the commit title
