### PR TITLE
feat: add pr draft command to send a ready PR back to draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 | | diff | Show PR diff |
 | | merge [commit\|rebase\|squash] [delete] | Merge current PR using the specified method|
 | | ready| Mark a draft PR as ready for review |
+| | draft| Send a ready PR back to draft |
 | | checks | Show the status of all checks run on the PR |
 | | reload | Reload PR. Same as doing `e!`|
 | | browser | Open current PR in the browser|

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -71,6 +71,7 @@ See |octo-command-examples| for examples.
   merge [strategy]      Merge the current PR using the specified strategy.
                         Strategies: `commit`, `rebase`, `squash`, `delete`
   ready                 Mark a draft PR as ready for review.          
+  draft                 Send a ready for review PR back to draft.          
   checks                Show the status of all checks run on the PR.
   reload                Reload PR. Same as doing `e!`.
   browser               Open current PR in the browser.

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -112,6 +112,9 @@ function M.setup()
       ready = function()
         M.pr_ready_for_review()
       end,
+      draft = function()
+        M.pr_draft()
+      end,
       search = function(repo, ...)
         local opts = M.process_varargs(repo, ...)
         if utils.is_blank(opts.repo) then
@@ -978,6 +981,22 @@ function M.pr_ready_for_review()
   end
   gh.run {
     args = { "pr", "ready", tostring(buffer.number) },
+    cb = function(output, stderr)
+      utils.info(output)
+      utils.error(stderr)
+      writers.write_state(bufnr)
+    end,
+  }
+end
+
+function M.pr_draft()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local buffer = octo_buffers[bufnr]
+  if not buffer or not buffer:isPullRequest() then
+    return
+  end
+  gh.run {
+    args = { "pr", "ready", tostring(buffer.number), "--undo" },
     cb = function(output, stderr)
       utils.info(output)
       utils.error(stderr)


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR adds an `Octo pr draft` command to send a "ready for review" PR back to draft status.

### Does this pull request fix one issue?

Fixes #451 .

### Describe how you did it

I copied the `pr ready` command related code, and added the `--undo` switch as specified in the `gh` documentation.

### Describe how to verify it

Open a PR with `Octo pr open`, and issue `Octo pr draft`. It will be sent back to draft.

### Special notes for reviews

