### PR TITLE
Fix wrong bubble background colors

### DIFF
--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -175,9 +175,9 @@ local function color_is_bright(r, g, b)
 end
 
 function M.get_background_color_of_highlight_group(highlight_group_name)
-  local highlight_group = vim.api.nvim_get_hl(0, { name = highlight_group_name })
-  local highlight_group_normal = vim.api.nvim_get_hl(0, { name = "Normal" })
-  local background_color = highlight_group.background or highlight_group_normal.background
+  local highlight_group = vim.api.nvim_get_hl(0, { name = highlight_group_name, link = false })
+  local highlight_group_normal = vim.api.nvim_get_hl(0, { name = "Normal", link = false })
+  local background_color = highlight_group.bg or highlight_group_normal.bg
   if background_color then
     return string.format("#%06x", background_color)
   end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This PR fixes the wrong bubble background colors, which should be introduced in https://github.com/pwntester/octo.nvim/pull/433

### Does this pull request fix one issue?

Possibly fixes https://github.com/pwntester/octo.nvim/issues/412

### Describe how you did it

Looks like `vim.api.nvim_get_hl` returns a different structure that contains `{ bg, fg }` instead of `{ background, foreground }`, this PR fixes the property names.

### Describe how to verify it

- Before this PR:

<img width="2048" alt="image" src="https://github.com/pwntester/octo.nvim/assets/15965696/000afaf9-126f-4086-abd2-842ae2d13471">

- After this PR:

<img width="2048" alt="image" src="https://github.com/pwntester/octo.nvim/assets/15965696/f7b129e1-0e6e-4477-87fb-82949ed0b066">


### Special notes for reviews

