### PR TITLE
Fix thread header becoming invisible after toggling resolved-state

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -561,6 +561,23 @@ function M.delete_comment()
   end
 end
 
+local function update_review_thread_header(bufnr, thread, thread_line)
+  local start_line = thread.originalStartLine ~= vim.NIL and thread.originalStartLine or thread.originalLine
+  local end_line = thread.originalLine
+  writers.write_review_thread_header(bufnr, {
+    path = thread.path,
+    start_line = start_line,
+    end_line = end_line,
+    isOutdated = thread.isOutdated,
+    isResolved = thread.isResolved,
+  }, thread_line - 2)
+  local threads = thread.pullRequest.reviewThreads.nodes
+  local review = reviews.get_current_review()
+  if review then
+    review:update_threads(threads)
+  end
+end
+
 function M.resolve_thread()
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
@@ -583,21 +600,7 @@ function M.resolve_thread()
         local resp = vim.fn.json_decode(output)
         local thread = resp.data.resolveReviewThread.thread
         if thread.isResolved then
-          -- review thread header
-          local start_line = thread.originalStartLine ~= vim.NIL and thread.originalStartLine or thread.originalLine
-          local end_line = thread.originalLine
-          writers.write_review_thread_header(bufnr, {
-            path = thread.path,
-            start_line = start_line,
-            end_line = end_line,
-            isOutdated = thread.isOutdated,
-            isResolved = thread.isResolved,
-          }, thread_line - 2)
-          local threads = resp.data.resolveReviewThread.thread.pullRequest.reviewThreads.nodes
-          local review = reviews.get_current_review()
-          if review then
-            review:update_threads(threads)
-          end
+          update_review_thread_header(bufnr, thread, thread_line)
           --vim.cmd(string.format("%d,%dfoldclose", thread_line, thread_line))
         end
       end
@@ -627,21 +630,7 @@ function M.unresolve_thread()
         local resp = vim.fn.json_decode(output)
         local thread = resp.data.unresolveReviewThread.thread
         if not thread.isResolved then
-          -- review thread header
-          local start_line = thread.originalStartLine ~= vim.NIL and thread.originalStartLine or thread.originalLine
-          local end_line = thread.originalLine
-          writers.write_review_thread_header(bufnr, {
-            path = thread.path,
-            start_line = start_line,
-            end_line = end_line,
-            isOutdated = thread.isOutdated,
-            isResolved = thread.isResolved,
-          }, thread_line - 2)
-          local threads = resp.data.unresolveReviewThread.thread.pullRequest.reviewThreads.nodes
-          local review = reviews.get_current_review()
-          if review then
-            review:update_threads(threads)
-          end
+          update_review_thread_header(bufnr, thread, thread_line)
         end
       end
     end,


### PR DESCRIPTION
### Describe what this PR does / why we need it
When resolving threads via `Octo thread [un]resolve` the virtual text of the thread should be updated with the new resolved-state. Currently the text only gets cleared due to an oversight.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #362 

### Describe how you did it
Added a field, which was needed since a feature commit

### Describe how to verify it
Tested it within the timeline (`Octo pr list`)  aswell as within the review mode (`Octo review start`). Just resolved and unresolved some threads.

### Special notes for reviews
Fwiw this seems to be introduced with the commit 50704c5071e9dd4a5643f55403f146b2bbe710bc. With this commit the wrapper around writing this specific virtual_text now expects a `commit` field. 

I have added a for loop to gather the commit sha of the actual thread from the response from github. If there is an easier way, Im happy to change it. 

Sidenote: the duplicated code between resolve_thread and unresolve_thread increases with this commit. If you want, I can extract those twenty-ish lines into another function 