### PR TITLE
fix: Adjust get_user_name regex to match updates to the cli

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -56,8 +56,12 @@ function M.get_user_name(remote_hostname)
   job:sync()
   local stderr = table.concat(job:stderr_result(), "\n")
   local stdout = table.concat(job:result(), "\n")
+  -- Newer versions of the gh cli have a different message. See #467
   local name_err = string.match(stderr, "Logged in to [^%s]+ as ([^%s]+)")
+    or string.match(stderr, "Logged in to [^%s]+ account ([^%s]+)")
   local name_out = string.match(stdout, "Logged in to [^%s]+ as ([^%s]+)")
+    or string.match(stdout, "Logged in to [^%s]+ account ([^%s]+)")
+
   if name_err then
     return name_err
   elseif name_out then


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This commit fixes an issue with the newer version of the gh cli tool where they updated the stdout message.

Reference: https://github.com/cli/cli/commit/e806664ef736a1cba373155842112831d094b91f

Closes: #466 
