### PR TITLE
feat: Use gh's resolved repo config for git remotes

### DIFF
--- a/lua/tests/plenary/utils_spec.lua
+++ b/lua/tests/plenary/utils_spec.lua
@@ -14,16 +14,24 @@ describe("Utils module:", function()
       local aliases = {
         ["hub.com"] = "github.com",
       }
-      eq(this.parse_remote_url(remote_urls[1], aliases).host, "github.com")
-      eq(this.parse_remote_url(remote_urls[1], aliases).repo, "pwntester/octo.nvim")
-      eq(this.parse_remote_url(remote_urls[2], aliases).host, "github.com")
-      eq(this.parse_remote_url(remote_urls[2], aliases).repo, "pwntester/octo.nvim")
-      eq(this.parse_remote_url(remote_urls[3], aliases).host, "github.com")
-      eq(this.parse_remote_url(remote_urls[3], aliases).repo, "pwntester/octo.nvim")
-      eq(this.parse_remote_url(remote_urls[4], aliases).host, "github.com")
-      eq(this.parse_remote_url(remote_urls[4], aliases).repo, "pwntester/octo.nvim")
-      eq(this.parse_remote_url(remote_urls[5], aliases).host, "github.com")
-      eq(this.parse_remote_url(remote_urls[5], aliases).repo, "pwntester/octo.nvim")
+      eq(this.parse_raw_remote_url(remote_urls[1], "origin", aliases).host, "github.com")
+      eq(this.parse_raw_remote_url(remote_urls[1], "origin", aliases).repo, "pwntester/octo.nvim")
+      eq(this.parse_raw_remote_url(remote_urls[2], "origin", aliases).host, "github.com")
+      eq(this.parse_raw_remote_url(remote_urls[2], "origin", aliases).repo, "pwntester/octo.nvim")
+      eq(this.parse_raw_remote_url(remote_urls[3], "origin", aliases).host, "github.com")
+      eq(this.parse_raw_remote_url(remote_urls[3], "origin", aliases).repo, "pwntester/octo.nvim")
+      eq(this.parse_raw_remote_url(remote_urls[4], "origin", aliases).host, "github.com")
+      eq(this.parse_raw_remote_url(remote_urls[4], "origin", aliases).repo, "pwntester/octo.nvim")
+      eq(this.parse_raw_remote_url(remote_urls[5], "origin", aliases).host, "github.com")
+      eq(this.parse_raw_remote_url(remote_urls[5], "origin", aliases).repo, "pwntester/octo.nvim")
+    end)
+
+    it("populate_resolved_remotes adds resolved repo name.", function()
+      local remotes = {
+        ["origin"] = { name = "origin", resolved = nil, repo = "pwntester/octo.nvim", host = "github.com" },
+      }
+      local raw_config = { "remote.origin.gh-resolved pwntester/octo_override.nvim" }
+      eq(this.populate_resolved_remotes(remotes, raw_config)["origin"].resolved, "pwntester/octo_override.nvim")
     end)
 
     it("convert_vim_mapping_to_fzf changes vim mappings to fzf mappings", function()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This commit adjusts the fetching remote function to also consider
default repositories set by the `gh` cli. When the local git repository
has `remote.origin.gh-resolved pwntester/octo.nvim` set, the resolved
repository name will be used instead of the default one.

When attempting to run any gh cli commands in a repo where there are multiple
remotes defined, it requires the user to set the default repo to use via `gh
repo set-default`. This repo is then used as the default remote for all gh
commands. This commit attempts to also utilize the same configuration.

This is needed because on my fork when I run `Octo issue list` I get the issues
from my fork and not the original repo. Now that I have set the default repo
locally, I can fetch the issues from above command.

When fetching remotes it will:
1) Fetch remotes via `git remote -v`
2) Apply user_defined ssh_aliases against the set
3) Fetch the local `gh-resolved` value
4) When returning the default remote, if a resolved value is set from step 3,
utilize that value

Let me know if theres any issues/ideas.

