### PR TITLE
fix: nil scopes match

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -94,7 +94,7 @@ function M.setup()
     env = get_env(),
     on_exit = vim.schedule_wrap(function(j_self, _, _)
       local stdout = table.concat(j_self:result(), "\n")
-      local all_scopes = string.match(stdout, " Token scopes: (.*)")
+      local all_scopes = string.match(stdout, " Token scopes: (.*)") or ""
       local split = vim.split(all_scopes, ", ")
       for idx, split_scope in ipairs(split) do
         scopes[idx] = string.gsub(split_scope, "'", "")


### PR DESCRIPTION

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This makes sure we have some scope string, even if the parsed output is nil.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes https://github.com/pwntester/octo.nvim/issues/480

### Describe how you did it

Assign a default to the match.

### Describe how to verify it

Get a `gh` version that doesn't output the scopes properly, or according to how we want to parse them.

### Special notes for reviews

None
