### PR TITLE
fix: create OctoBuffers for issue previews

### DIFF
--- a/lua/octo/pickers/fzf-lua/previewers.lua
+++ b/lua/octo/pickers/fzf-lua/previewers.lua
@@ -77,6 +77,17 @@ M.issue = function(formatted_issues)
           elseif entry.kind == "pull_request" then
             obj = result.data.repository.pullRequest
           end
+
+          -- We have to create a new buffer since writers.write_state relies on
+          -- octo_buffers containing a buffer at a index of the current buffer number.
+          -- OctoBuffer:new adds that buffer to octo_buffers
+          OctoBuffer:new {
+            bufnr = tmpbuf,
+            number = obj.number,
+            repo = entry.repo,
+            node = obj,
+          }
+
           writers.write_title(tmpbuf, obj.title, 1)
           writers.write_details(tmpbuf, obj)
           writers.write_body(tmpbuf, obj)

--- a/lua/octo/pickers/telescope/previewers.lua
+++ b/lua/octo/pickers/telescope/previewers.lua
@@ -38,6 +38,17 @@ local issue = defaulter(function(opts)
               elseif entry.kind == "pull_request" then
                 obj = result.data.repository.pullRequest
               end
+
+              -- We have to create a new buffer since writers.write_state relies on
+              -- octo_buffers containing a buffer at a index of the current buffer number.
+              -- OctoBuffer:new adds that buffer to octo_buffers
+              OctoBuffer:new {
+                bufnr = bufnr,
+                number = obj.number,
+                repo = entry.repo,
+                node = obj,
+              }
+
               writers.write_title(bufnr, obj.title, 1)
               writers.write_details(bufnr, obj)
               writers.write_body(bufnr, obj)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

The write_state function relies on there being a buffer in the octo_buffers table but there is none when called from the callback which is called after running Github CLI when defining a issue preview.

This causes that `[DRAFT]` isn't included in the issue preview title virtual text of draft pull requests.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

A part of fixing #453.

### Describe how you did it

By making it so that before `write_state` is called, a `OctoBuffer` is created.

### Describe how to verify it

Do `:Octo pr list` in a repository with draft pull requests and you'll see the preview(s) contain `[DRAFT]`

### Special notes for reviews

