### PR TITLE
fix typo in docs to suppress projects v2 warning

### DIFF
--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -341,7 +341,7 @@ I can't see my v2 projects in issues and/or pull requests!~
   cards) you need to add the `project` scope to your token instead.
 
   If you don't care about projects v2 you can suppress the warning by setting
-  `suppress_missing_scope.project_v2 = true` in your Octo config.
+  `suppress_missing_scope.projects_v2 = true` in your Octo config.
 
 
 CREDITS                                         *octo-credits*


### PR DESCRIPTION
### Describe what this PR does / why we need it
The docs to suppress project v2 warnings have a typo and should be `projects_v2` instead of `project_v2`.

### Does this pull request fix one issue?

Not a GH issue.

### Describe how you did it
Updated docs


### Describe how to verify it
Compare with config: https://github.com/stickperson/octo.nvim/blob/2d3b4c1e3ad5a75968476c0f2e75ef5476346d37/lua/octo/config.lua#L107-L109


### Special notes for reviews

