### PR TITLE
feat: Add default merge method

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ require"octo".setup({
   use_local_fs = false,                    -- use local files on right side of reviews
   enable_builtin = false,                  -- shows a list of builtin actions when no action is provided
   default_remote = {"upstream", "origin"}; -- order to try remotes
+  default_merge_method = "commit",         -- default merge method which should be used when calling `Octo pr merge`, could be `commit`, `rebase` or `squash`
   ssh_aliases = {},                        -- SSH aliases. e.g. `ssh_aliases = {["github.com-work"] = "github.com"}`
   picker = "telescope",                    -- or "fzf-lua"
   picker_config = {

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1095,6 +1095,9 @@ function M.pr_checks()
 end
 
 function M.merge_pr(...)
+  local conf = config.values
+  local defaultMergeMethod = conf.default_merge_method
+
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
   if not buffer or not buffer:isPullRequest() then
@@ -1121,7 +1124,13 @@ function M.merge_pr(...)
     end
   end
   if not has_flag then
-    table.insert(args, "--merge")
+    if defaultMergeMethod == "squash" then
+      table.insert(args, "--squash")
+    elseif defaultMergeMethod == "rebase" then
+      table.insert(args, "--rebase")
+    else
+      table.insert(args, "--merge")
+    end
   end
   gh.run {
     args = args,

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -47,6 +47,7 @@ local M = {}
 ---@field picker OctoPickers
 ---@field picker_config OctoPickerConfig
 ---@field default_remote table
+---@field default_merge_method string
 ---@field ssh_aliases {[string]:string}
 ---@field reaction_viewer_hint_icon string
 ---@field user_icon string
@@ -87,6 +88,7 @@ function M.get_default_values()
       },
     },
     default_remote = { "upstream", "origin" },
+    default_merge_method = "commit",
     ssh_aliases = {},
     reaction_viewer_hint_icon = " ",
     user_icon = " ",
@@ -390,6 +392,7 @@ function M.validate_config()
         validate_type(v, "remote", "string")
       end
     end
+    validate_type(config.default_merge_method, "default_merge_method", "string")
     if validate_type(config.ui, "ui", "table") then
       validate_type(config.ui.use_signcolumn, "ui.use_signcolumn", "boolean")
     end

--- a/lua/tests/plenary/config_spec.lua
+++ b/lua/tests/plenary/config_spec.lua
@@ -3,6 +3,7 @@ local eq = assert.are.same
 
 local user_config = {
   default_remote = { "remote1", "remote2" },
+  default_merge_method = "rebase",
   file_panel = { use_icons = false },
   ssh_aliases = {
     ["remote"] = "host",
@@ -28,6 +29,7 @@ describe("Config module:", function()
     it("user configuration overrides defaults.", function()
       eq(merged_config.default_remote[1], "remote1")
       eq(merged_config.default_remote[2], "remote2")
+      eq(merged_config.default_merge_method, "rebase")
       eq(merged_config.file_panel.size, 10, "file_panel.size should be 10")
       eq(merged_config.file_panel.use_icons, false, "file_panel.use_icons should be false")
       eq(merged_config.ssh_aliases["remote"], "host")


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This commit adds a new option `default_merge_method`, which can be used to define the default merge method for the `Octo pr merge` command.

Until now the `Octo pr merge` was always using `commit` when no argument was defined. This can now be customized by the user. A user can select between `commit`, `rebase` and `squash`. If another string is provided it will fallback to `commit`.

This is especially useful (at least for me 😅) when the `enable_builtin` option is enabled and the merge command is selected via Telescope where it isn't possible to provide the merge method.

### Does this pull request fix one issue?

NONE

### Special notes for reviews

- I'm not very familiar with Lua and writing Neovim plugins, so maybe this PR is completely shit
- If this isn't a feature you want to add, feel free to just close the PR (sry I was a bit lazy with creating an GitHub issue first to discuss this)