### PR TITLE
fix typo in docs regarding projects_v2 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ You add the scope by using `gh auth refresh -s read:project` or you can suppress
 ```
 {
   suppress_missing_scope = {
-    project_v2 = true,
+    projects_v2 = true,
   }
 }
 ```


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
The config option in the README is not named properly.

It currently says:

```
  suppress_missing_scope = {
    project_v2 = true,
  }
```

and yet we can clearly see that the expected option is `projects_v2`:

lua/octo/gh/init.lua:
```lua
      elseif not config.values.suppress_missing_scope.projects_v2 then
        require("octo.utils").info "Cannot request projects v2, missing scope 'read:project'"
      end
```

### Does this pull request fix one issue?

Doesn't fix any outstanding issues that I am aware of.

### Describe how you did it

I fixed the typo by reading the source code handling the option and reading the README.

### Describe how to verify it

The suppression of this warning will actually work (if you use the non-typo'd version of the config present in the README).

### Special notes for reviews

RELATED: https://github.com/pwntester/octo.nvim/commit/2d3b4c1e3ad5a75968476c0f2e75ef5476346d37
