### PR TITLE
Add keymaps for start, resume, submit and discard Reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ require"octo".setup({
       react_rocket = { lhs = "<space>rr", desc = "add/remove 🚀 reaction" },
       react_laugh = { lhs = "<space>rl", desc = "add/remove 😄 reaction" },
       react_confused = { lhs = "<space>rc", desc = "add/remove 😕 reaction" },
+      review_start = { lhs = "<space>vs", desc = "start a review for the current PR" },
+      review_resume = { lhs = "<space>vr", desc = "resume a pending review for the current PR" },
     },
     review_thread = {
       goto_issue = { lhs = "<space>gi", desc = "navigate to a local repo issue" },
@@ -251,6 +253,8 @@ require"octo".setup({
       close_review_tab = { lhs = "<C-c>", desc = "close review tab" },
     },
     review_diff = {
+      submit_review = { lhs = "<leader>vs", desc = "submit review" },
+      discard_review = { lhs = "<leader>vd", desc = "discard review" },
       add_review_comment = { lhs = "<space>ca", desc = "add a new review comment" },
       add_review_suggestion = { lhs = "<space>sa", desc = "add a new review suggestion" },
       focus_files = { lhs = "<leader>e", desc = "move focus to changed file panel" },
@@ -266,6 +270,8 @@ require"octo".setup({
       goto_file = { lhs = "gf", desc = "go to file" },
     },
     file_panel = {
+      submit_review = { lhs = "<leader>vs", desc = "submit review" },
+      discard_review = { lhs = "<leader>vd", desc = "discard review" },
       next_entry = { lhs = "j", desc = "move to next changed file" },
       prev_entry = { lhs = "k", desc = "move to previous changed file" },
       select_entry = { lhs = "<cr>", desc = "show selected changed file diffs" },

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -204,20 +204,10 @@ function M.setup()
         end
       end,
       submit = function()
-        local current_review = reviews.get_current_review()
-        if current_review then
-          current_review:collect_submit_info()
-        else
-          utils.error "Please start or resume a review first"
-        end
+        reviews.submit_review()
       end,
       discard = function()
-        local current_review = reviews.get_current_review()
-        if current_review then
-          current_review:discard()
-        else
-          utils.error "Please start or resume a review first"
-        end
+        reviews.discard_review()
       end,
       close = function()
         if reviews.get_current_review() then

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -205,6 +205,8 @@ function M.get_default_values()
         react_rocket = { lhs = "<space>rr", desc = "add/remove 🚀 reaction" },
         react_laugh = { lhs = "<space>rl", desc = "add/remove 😄 reaction" },
         react_confused = { lhs = "<space>rc", desc = "add/remove 😕 reaction" },
+        review_start = { lhs = "<space>vs", desc = "start a review for the current PR" },
+        review_resume = { lhs = "<space>vr", desc = "resume a pending review for the current PR" },
       },
       review_thread = {
         goto_issue = { lhs = "<space>gi", desc = "navigate to a local repo issue" },
@@ -234,6 +236,8 @@ function M.get_default_values()
         close_review_tab = { lhs = "<C-c>", desc = "close review tab" },
       },
       review_diff = {
+        submit_review = { lhs = "<leader>vs", desc = "submit review" },
+        discard_review = { lhs = "<leader>vd", desc = "discard review" },
         add_review_comment = { lhs = "<space>ca", desc = "add a new review comment" },
         add_review_suggestion = { lhs = "<space>sa", desc = "add a new review suggestion" },
         focus_files = { lhs = "<leader>e", desc = "move focus to changed file panel" },
@@ -249,6 +253,8 @@ function M.get_default_values()
         goto_file = { lhs = "gf", desc = "go to file" },
       },
       file_panel = {
+        submit_review = { lhs = "<leader>vs", desc = "submit review" },
+        discard_review = { lhs = "<leader>vd", desc = "discard review" },
         next_entry = { lhs = "j", desc = "move to next changed file" },
         prev_entry = { lhs = "k", desc = "move to previous changed file" },
         select_entry = { lhs = "<cr>", desc = "show selected changed file diffs" },

--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -111,14 +111,27 @@ return {
   react_confused = function()
     require("octo.commands").reaction_action "confused"
   end,
+  review_start = function()
+    reviews.start_review()
+  end,
+  review_resume = function()
+    reviews.resume_review()
+  end,
+  discard_review = function()
+    reviews.discard_review()
+  end,
+  submit_review = function()
+    reviews.submit_review()
+  end,
   add_review_comment = function()
-    require("octo.reviews").add_review_comment(false)
+    reviews.add_review_comment(false)
   end,
   add_review_suggestion = function()
-    require("octo.reviews").add_review_comment(true)
+    reviews.add_review_comment(true)
   end,
   close_review_tab = function()
-    require("octo.reviews").close()
+    local tabpage = vim.api.nvim_get_current_tabpage()
+    reviews.close(tabpage)
   end,
   next_thread = function()
     require("octo.reviews.file-panel").next_thread()
@@ -207,15 +220,15 @@ return {
     vim.api.nvim_win_close(vim.api.nvim_get_current_win())
   end,
   approve_review = function()
-    local current_review = require("octo.reviews").get_current_review()
+    local current_review = reviews.get_current_review()
     current_review:submit "APPROVE"
   end,
   comment_review = function()
-    local current_review = require("octo.reviews").get_current_review()
+    local current_review = reviews.get_current_review()
     current_review:submit "COMMENT"
   end,
   request_changes = function()
-    local current_review = require("octo.reviews").get_current_review()
+    local current_review = reviews.get_current_review()
     current_review:submit "REQUEST_CHANGES"
   end,
   toggle_viewed = function()

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -527,4 +527,22 @@ function M.resume_review()
   end
 end
 
+function M.discard_review()
+  local current_review = M.get_current_review()
+  if current_review then
+    current_review:discard()
+  else
+    utils.error "Please start or resume a review first"
+  end
+end
+
+function M.submit_review()
+  local current_review = M.get_current_review()
+  if current_review then
+    current_review:collect_submit_info()
+  else
+    utils.error "Please start or resume a review first"
+  end
+end
+
 return M


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

The process of opening a pull-request and starting a review was a little disconnected, as we had keymaps to almost everything we can do with a pull-request, except for starting a review.


https://github.com/pwntester/octo.nvim/assets/4634613/68458e0b-d791-4ab4-b568-3ef8532142ac
 

### Describe how you did it

I followed the project standard and created named mappings that mirror the configuration keys and added them to:

* Pull request buffer (`pull_reqest`)
* The diff-view of the Review (`review_diff`)
* The review pane (`file_pane`)

The new commands are:

| Command | Binding |
|--------|--------|
| `review_start` | `<leader>vs` |
| `review_resume` | `<leader>vr` |
| `submit_review` | `<leader>vs` | 
| `discard_review` | `<leader>vd` |


### Describe how to verify it

#### Start and resume a PR:
1. Open a Pull-Request 
2. press `<leader>vs` to start a review
3. press `Ctrl+c` to close the review 
4. press `<leader>vr` to resume the review

#### Submit or discard a PR
1. Open a Pull-request
2. 2. press `<leader>vs` to start a review
3. from the diff-view or the files pane, press `<leader>vs` to open the submit modal
4. Run the command `:q` to close it
5. press `<leader>vd` to discard the review, you should see a prompt asking to confirm.



### Special notes for reviews

Aside from the keybindings, this PR also fixed the `Ctrl+C` to close the review, that wasn't working, as it wasn't passing the current tab as an argument to the `close()` function, so the key press was just ignored. 


