### PR TITLE
Allowing configuration of `gh` binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ require"octo".setup({
   left_bubble_delimiter = "";             -- bubble delimiter
   github_hostname = "";                    -- GitHub Enterprise host
   snippet_context_lines = 4;               -- number or lines around commented lines
+  gh_cmd = "gh",                           -- Command to use when calling Github CLI
   gh_env = {},                             -- extra environment variables to pass on to GitHub CLI, can be a table or function returning a table
   timeout = 5000,                          -- timeout for requests between the remote server
   default_to_projects_v2 = false,          -- use projects v2 for the `Octo card ...` command by default. Both legacy and v2 commands are available under `Octo cardlegacy ...` and `Octo cardv2 ...` respectively.

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -62,6 +62,7 @@ local M = {}
 ---@field use_local_fs boolean
 ---@field enable_builtin boolean
 ---@field snippet_context_lines number
+---@field gh_cmd string
 ---@field gh_env table
 ---@field timeout number
 ---@field default_to_projects_v2 boolean
@@ -103,6 +104,7 @@ function M.get_default_values()
     use_local_fs = false,
     enable_builtin = false,
     snippet_context_lines = 4,
+    gh_cmd = "gh",
     gh_env = {},
     timeout = 5000,
     default_to_projects_v2 = false,
@@ -383,6 +385,7 @@ function M.validate_config()
     if validate_type(config.suppress_missing_scope, "supress_missing_scope", "table") then
       validate_type(config.suppress_missing_scope.projects_v2, "supress_missing_scope.projects_v2", "boolean")
     end
+    validate_type(config.gh_cmd, "gh_cmd", "string")
     validate_type(config.gh_env, "gh_env", "table")
     validate_type(config.reaction_viewer_hint_icon, "reaction_viewer_hint_icon", "string")
     validate_type(config.user_icon, "user_icon", "string")

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -51,7 +51,7 @@ function M.get_user_name(remote_hostname)
 
   local job = Job:new {
     enable_recording = true,
-    command = "gh",
+    command = config.values.gh_cmd,
     args = { "auth", "status", "--hostname", remote_hostname },
     env = get_env(),
   }
@@ -89,7 +89,7 @@ function M.setup()
   _G.octo_pv2_fragment = ""
   Job:new({
     enable_recording = true,
-    command = "gh",
+    command = config.values.gh_cmd,
     args = { "auth", "status" },
     env = get_env(),
     on_exit = vim.schedule_wrap(function(j_self, _, _)
@@ -146,7 +146,7 @@ function M.run(opts)
   end
   local job = Job:new {
     enable_recording = true,
-    command = "gh",
+    command = config.values.gh_cmd,
     args = opts.args,
     on_stdout = vim.schedule_wrap(function(err, data, _)
       if mode == "async" and opts.stream_cb then

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -26,8 +26,8 @@ function M.setup(user_config)
     utils.error "octo.nvim requires neovim 0.7+"
     return
   end
-  config.setup(user_config or {})
 
+  config.setup(user_config or {})
   if not vim.fn.executable(config.values.gh_cmd) then
     utils.error("gh executable not found using path: " .. config.values.gh_cmd)
     return

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -22,15 +22,17 @@ _G.octo_colors_loaded = false
 local M = {}
 
 function M.setup(user_config)
-  if not vim.fn.executable "gh" then
-    utils.error "gh executable not found"
-    return
-  end
   if not vim.fn.has "nvim-0.7" then
     utils.error "octo.nvim requires neovim 0.7+"
     return
   end
   config.setup(user_config or {})
+
+  if not vim.fn.executable(config.values.gh_cmd) then
+    utils.error("gh executable not found using path: " .. config.values.gh_cmd)
+    return
+  end
+
   signs.setup()
   picker.setup()
   completion.setup()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This allows defining the path of the `gh` binary


### Describe how you did it
Following the convention set out by other configurable values I simply added in `gh_cmd` with a default of `"gh"`.
For all uses of `command = "gh"` I changed it to `command = config.values.gh_cmd`


### Describe how to verify it
Setting the `gh_cmd` value in setup to the path of a working Github CLI binary

### Special notes for reviews

If this isn't something you are interested in including that is all good. I made the changes so I could use this plugin with my neovim configuration and thought it may come in handy to others as well 😄 

