### PR TITLE
doc: remove duplicate options from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,6 @@ require"octo".setup({
   ui = {
     use_signcolumn = true,                 -- show "modified" marks on the sign column
   },
-  picker = "telescope",                    -- "telescope" | "fzf-lua"
-  picker_config = {
-    use_emojis = false,                    -- Only used in fzf-lua picker. If you want emojis when viewing the picker set to true.
-  },
   issues = {
     order_by = {                           -- criteria to sort results of `Octo issue list`
       field = "CREATED_AT",                -- either COMMENTS, CREATED_AT or UPDATED_AT (https://docs.github.com/en/graphql/reference/enums#issueorderfield)


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes typo in docs, wherein the `picker` and `picker_config` configuration keys appear twice in the list of config options.

### Does this pull request fix one issue?

Fixes #509

### Describe how you did it

Removed the duplicate entries that had less complete information, compared to the other set of entries.

### Describe how to verify it

N/A

### Special notes for reviews

N/A