### PR TITLE
fix: improper gh cli flag for repo browser

### DIFF
--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -48,7 +48,7 @@ function M.open_in_browser(kind, repo, number)
     elseif kind == "issue" then
       cmd = string.format("gh issue view --web -R %s/%s %d", remote, repo, number)
     elseif kind == "repo" then
-      cmd = string.format("gh repo view --web %s/%s", remote, repo)
+      cmd = string.format("gh repo view --web %s", repo.url)
     elseif kind == "gist" then
       cmd = string.format("gh gist view --web %s", number)
     elseif kind == "project" then

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -40,7 +40,7 @@ function M.open_in_browser(kind, repo, number)
     elseif buffer:isIssue() then
       cmd = string.format("gh issue view --web -R %s/%s %d", remote, buffer.repo, buffer.number)
     elseif buffer:isRepo() then
-      cmd = string.format("gh repo view --web -R %s/%s", remote, buffer.repo)
+      cmd = string.format("gh repo view --web %s/%s", remote, buffer.repo)
     end
   else
     if kind == "pr" or kind == "pull_request" then
@@ -48,7 +48,7 @@ function M.open_in_browser(kind, repo, number)
     elseif kind == "issue" then
       cmd = string.format("gh issue view --web -R %s/%s %d", remote, repo, number)
     elseif kind == "repo" then
-      cmd = string.format("gh repo view --web -R %s/%s", remote, repo)
+      cmd = string.format("gh repo view --web %s/%s", remote, repo)
     elseif kind == "gist" then
       cmd = string.format("gh gist view --web %s", number)
     elseif kind == "project" then


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Flag `-R` does not exist with `gh repo view`


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #511 
### Describe how you did it
Removed flag

### Describe how to verify it
1. Octo repo view
2. Octo repo browser

### Special notes for reviews

