### PR TITLE
fix: lack of default branch name causes repo display issue

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -86,7 +86,13 @@ function M.write_repo(bufnr, repo)
 
   add_details_line(details, "Name", repo.nameWithOwner)
   add_details_line(details, "Description", repo.description)
-  add_details_line(details, "Default branch", repo.defaultBranchRef.name)
+  local defaultBranchRefName
+  if repo.defaultBranchRef == vim.NIL then
+    defaultBranchRefName = nil
+  else
+    defaultBranchRefName = repo.defaultBranchRef.name
+  end
+  add_details_line(details, "Default branch", defaultBranchRefName)
   add_details_line(details, "URL", repo.url)
   add_details_line(details, "Homepage URL", function()
     if not utils.is_blank(repo.homepageUrl) then
@@ -156,12 +162,14 @@ function M.write_repo(bufnr, repo)
     line = line + 1
   end
 
-  utils.get_file_contents(repo.nameWithOwner, repo.defaultBranchRef.name, "README.md", function(lines)
-    if vim.api.nvim_buf_is_valid(bufnr) then
-      vim.api.nvim_buf_set_lines(bufnr, -1, -1, false, lines)
-      vim.api.nvim_buf_set_option(bufnr, "modified", false)
-    end
-  end)
+  if defaultBranchRefName ~= nil then
+    utils.get_file_contents(repo.nameWithOwner, defaultBranchRefName, "README.md", function(lines)
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_set_lines(bufnr, -1, -1, false, lines)
+        vim.api.nvim_buf_set_option(bufnr, "modified", false)
+      end
+    end)
+  end
 end
 
 function M.write_title(bufnr, title, line)


### PR DESCRIPTION


<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

When a repo doesn't have a default branch name (i.e. a totally empty repo) then Octo gives an error when trying to view that repo.

This fixes that. Additionally, because when using the fzf-lua picker since the repo is previewed the error can show up when that repository is highlighted.

### Does this pull request fix one issue?

Fixes https://github.com/pwntester/octo.nvim/issues/519

### Describe how you did it

Check for the default branch ref and if it's `vim.NIL` the name just becomes nil. This will prevent displaying the name as well as fetching the README from the default branch.

### Describe how to verify it

Make a repo on Github and don't configure anything (no README, no .gitignore, no license file, etc.), then run `:Octo repo view you/your-repo`. Make sure there is no error as seen in #519 

### Special notes for reviews

N/A