### PR TITLE
fix(file-entry): ignore possible extmark out of bounds error

### DIFF
--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -387,8 +387,13 @@ function FileEntry:place_signs()
           local opts = {
             virt_text = { { vt_msg, "Comment" } },
             virt_text_pos = "right_align",
+            -- adding the extmark below can fail if we are in the `COMMIT` review level and the commit contains thread comments
+            -- that is why we set strict to `false` here to ignore this possible error
+            strict = false
           }
           vim.api.nvim_buf_set_extmark(split.bufnr, constants.OCTO_REVIEW_COMMENTS_NS, startLine - 1, -1, opts)
+          -- break out to prevent duplicate extmarks for the current comment thread
+          break
         end
       end
     end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fixes a bug where attempting to review a specific commit fails if the comment contains comments due to us attempting to add an extmark to a line that is out of bounds, which results in the following error:

```
Error executing vim.schedule lua callback: ...hare/nvim/lazy/octo.nvim/lua/octo/reviews/file-entry.lua:394: Invalid 'line': out of range
stack traceback:
        [C]: in function 'nvim_buf_set_extmark'
        ...hare/nvim/lazy/octo.nvim/lua/octo/reviews/file-entry.lua:394: in function 'place_signs'
        ...hare/nvim/lazy/octo.nvim/lua/octo/reviews/file-entry.lua:266: in function 'load_buffers'
        ...al/share/nvim/lazy/octo.nvim/lua/octo/reviews/layout.lua:116: in function 'set_file'
        ...al/share/nvim/lazy/octo.nvim/lua/octo/reviews/layout.lua:136: in function 'update_files'
        ...ocal/share/nvim/lazy/octo.nvim/lua/octo/reviews/init.lua:120: in function 'callback'
        ...hare/nvim/lazy/octo.nvim/lua/octo/model/pull-request.lua:137: in function 'cb'
        ...ck/.local/share/nvim/lazy/octo.nvim/lua/octo/gh/init.lua:160: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

In this case we can ignore this error to be able to at least view the changes in the commit.

Also this PR fixes duplicate extmarks for comments that was getting printed when a comment thread contained more than 
1 comment:

Before:

<img width="886" alt="image" src="https://github.com/pwntester/octo.nvim/assets/22531177/4c03ce5e-80de-4025-9ea0-9318f887d590">

After:

<img width="487" alt="image" src="https://github.com/pwntester/octo.nvim/assets/22531177/1331968a-5d22-47b7-bccf-71ce5a201d2b">


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

https://github.com/pwntester/octo.nvim/issues/440

### Describe how you did it

Added `strict = false` to the `vim.api.nvim_buf_set_extmark` call opts to ignore possible line out of bounds errors.

### Describe how to verify it

Attempt to review a commit that contains comments before this change to ensure it throws the error described above.
Then attempt to review a commit that contains comments with this change applied and verify that you can review to commit changes without any errors being raised.

### Special notes for reviews

