### PR TITLE
Improve the `Octo pr list` command

### DIFF
--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -2129,6 +2129,7 @@ query($endCursor: String) {
         repository { nameWithOwner }
         headRefName
         isDraft
+        author { username: login }
       }
       pageInfo {
         hasNextPage

--- a/lua/octo/pickers/fzf-lua/pickers/prs.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/prs.lua
@@ -66,7 +66,7 @@ return function(opts)
                 highlight = "OctoStateOpen"
               end
               local prefix = fzf.utils.ansi_from_hl(highlight, entry.value)
-              fzf_cb(prefix .. " " .. entry.obj.title)
+              fzf_cb(prefix .. " " .. entry.obj.title .. " (" .. entry.obj.headRefName .. ")")
             end
           end
         end

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -40,6 +40,10 @@ function M.gen_from_issue(max_number, print_repo)
       }
     end
 
+    if entry.kind == "pull_request" then
+      table.insert(columns, "(" .. entry.obj.headRefName .. ")")
+    end
+
     local displayer = entry_display.create(layout)
 
     return displayer(columns)

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -299,10 +299,12 @@ function M.pull_requests(opts)
           return
         end
         local max_number = -1
+        local username_col_len = 0
+        local branch_name_col_len = 0
         for _, pull in ipairs(pull_requests) do
-          if #tostring(pull.number) > max_number then
-            max_number = #tostring(pull.number)
-          end
+          max_number = math.max(max_number, #tostring(pull.number))
+          username_col_len = math.min(20, math.max(username_col_len, #tostring(pull.author.username)))
+          branch_name_col_len = math.min(20, math.max(branch_name_col_len, #tostring(pull.headRefName)))
         end
         opts.preview_title = opts.preview_title or ""
         opts.prompt_title = opts.prompt_title or ""
@@ -311,7 +313,7 @@ function M.pull_requests(opts)
           .new(opts, {
             finder = finders.new_table {
               results = pull_requests,
-              entry_maker = entry_maker.gen_from_issue(max_number),
+              entry_maker = entry_maker.gen_from_pull_request(max_number, username_col_len, branch_name_col_len),
             },
             sorter = conf.generic_sorter(opts),
             previewer = previewers.issue.new(opts),


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This PR includes improvements to the `pr list` command. Specifically:

- it changes the fetch implementation to one based on REST rather than GraphQL, since GraphQL lacks several important features, such as the ability to filter on authors or assignees or labels.
- it abandons the attempt to fetch all PRs via pagination, since repos with hundreds or even thousands of PRs will cause this to be inefficient or unusable
- it changes the display in telescope of PRs to show authors and branches, and allows the user to filter based on these values. This is very important in organizations where practices such as including ticket IDs in branch names are followed.

### Does this pull request fix one issue?

NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

The main changes are in `pickers/telescope/entry_maker.lua` and `pickers/telescope/provider.lua`. These files define both the mechanism for retrieving pull requests and how they are passed to the telescope picker.

A new function `gen_from_pull_request` is added in `entry_maker.lua` to handle the display of the pull request data, including the addition of the new author and branch columns. The `ordinal` for pull requests now includes the author and branch information, allowing this to be used in filtering (displaying this is not enough).

The retrieval is changed in `telescope/provider.lua` (specifically in the `pull_requests` function). Here we call `gh pr list` rather than using the exisiting GraphQL implementation in order to provide access to the additional features that allows.

The retrieved records are modified to conform to the GraphQL result schema, meaning that they can be used in existing functions if necessary.

### Describe how to verify it

The following actions will be useful in verification:

- run `Octo pr list` and then use telescope to filter by author name
- run `Octo pr list author=@me` and see that only your PRs are shown

### Special notes for reviews

