### PR TITLE
fix: load octo in the correct buffer

### DIFF
--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -18,7 +18,6 @@ function M.setup()
     group = "octo_autocmds",
     pattern = { "octo://*" },
     callback = function(ev)
-      dd(ev)
       require("octo").load_buffer(ev.buf)
     end,
   })

--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -17,8 +17,9 @@ function M.setup()
   define({ "BufReadCmd" }, {
     group = "octo_autocmds",
     pattern = { "octo://*" },
-    callback = function()
-      require("octo").load_buffer()
+    callback = function(ev)
+      dd(ev)
+      require("octo").load_buffer(ev.buf)
     end,
   })
   define({ "BufWriteCmd" }, {

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -82,7 +82,9 @@ function M.load_buffer(bufnr)
     return
   end
   M.load(repo, kind, number, function(obj)
-    M.create_buffer(kind, obj, repo, false)
+    vim.api.nvim_buf_call(bufnr, function()
+      M.create_buffer(kind, obj, repo, false)
+    end)
   end)
 end
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

When Octo loads on `BufReadCmd octo://*`, it doesn't pass the correct buffer and can
as such eventually load in a different buffer

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Simply pass the event buffer and wrap the result callback in a `nvim_buf_call` to ensure we render in the correctbuffer

### Describe how to verify it

Add `blank` to `sessionoptions`.
Make a split with one normal file and with an octo buffer.
Make the normal file the current window.
Make a session
Exit Neovim
Open NEovim
Restore Session
The octo buffer will load in the correct window,
Without this PR, it would load in the file window.

### Special notes for reviews

