### PR TITLE
feat: comment statuscolumn & foldtext

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Edit and review GitHub issues and pull requests from the comfort of your favorit
 ## 🌲 Table of Contents
 
 <!--toc:start-->
+
 - [:octopus: Octo.nvim](#octopus-octonvim)
   - [🌲 Table of Contents](#-table-of-contents)
   - [💫 Features](#-features)
@@ -124,7 +125,8 @@ require"octo".setup({
   timeout = 5000,                          -- timeout for requests between the remote server
   default_to_projects_v2 = false,          -- use projects v2 for the `Octo card ...` command by default. Both legacy and v2 commands are available under `Octo cardlegacy ...` and `Octo cardv2 ...` respectively.
   ui = {
-    use_signcolumn = true,                 -- show "modified" marks on the sign column
+    use_signcolumn = false,                -- show "modified" marks on the sign column
+    use_signstatus = true,                 -- show "modified" marks on the status column
   },
   issues = {
     order_by = {                           -- criteria to sort results of `Octo issue list`
@@ -296,70 +298,70 @@ Just edit the issue title, body or comments as a regular buffer and use `:w(rite
 There is only an `Octo <object> <action> [arguments]` command:
 If no command is passed, the argument to `Octo` is treated as a URL from where an issue or pr repo and number are extracted.
 
-| Object | Action | Arguments|
-|---|---|---|
-| issue | close | Close the current issue|
-| | reopen | Reopen the current issue|
-| | create [repo]| Creates a new issue in the current or specified repo |
-| | edit [repo] <number> | Edit issue `<number>` in current or specified repo |
-| | list [repo] [key=value] (1) | List all issues satisfying given filter |
-| | search | Live issue search |
-| | reload | Reload issue. Same as doing `e!`|
-| | browser | Open current issue in the browser |
-| | url | Copies the URL of the current issue to the system clipboard|
-| pr | list [repo] [key=value] (2)| List all PRs satisfying given filter |
-| | search | Live issue search |
-| | edit [repo] <number> | Edit PR `<number>` in current or specified repo|
-| | reopen | Reopen the current PR|
-| | create | Creates a new PR for the current branch|
-| | close | Close the current PR|
-| | checkout | Checkout PR|
-| | commits | List all PR commits|
-| | changes | Show all PR changes (diff hunks)|
-| | diff | Show PR diff |
-| | merge [commit\|rebase\|squash] [delete] | Merge current PR using the specified method|
-| | ready| Mark a draft PR as ready for review |
-| | draft| Send a ready PR back to draft |
-| | checks | Show the status of all checks run on the PR |
-| | reload | Reload PR. Same as doing `e!`|
-| | browser | Open current PR in the browser|
-| | url | Copies the URL of the current PR to the system clipboard|
-| repo | list (3) | List repos user owns, contributes or belong to |
-| | fork | Fork repo |
-| | browser | Open current repo in the browser|
-| | url | Copies the URL of the current repo to the system clipboard|
-| | view | Open a repo by path ({organization}/{name})|
-| gist | list [repo] [key=value] (4) | List user gists |
-| comment | add | Add a new comment |
-| | delete | Delete a comment |
-| thread | resolve| Mark a review thread as resolved |
-| | unresolve | Mark a review thread as unresolved |
-| label | add [label] | Add a label from available label menu |
-| | remove [label] | Remove a label |
-| | create [label] | Create a new label |
-| assignee| add [login] | Assign a user |
-| | remove [login] | Unassign a user |
-| reviewer | add [login] | Assign a PR reviewer |
-| reaction | `thumbs_up` \| `+1` | Add 👍 reaction|
-| | `thumbs_down` \| `-1` | Add 👎 reaction|
-| | `eyes` | Add 👀 reaction|
-| | `laugh` | Add 😄 reaction|
-| | `confused` | Add 😕 reaction|
-| | `rocket` | Add 🚀 reaction|
-| | `heart` | Add ❤️ reaction|
-| | `hooray` \| `party` \| `tada` | Add 🎉 reaction|
-| card | add | Assign issue/PR to a project new card |
-| | remove | Delete project card |
-| | move | Move project card to different project/column|
-| review| start| Start a new review |
-| | submit| Submit the review |
-| | resume| Edit a pending review for current PR |
-| | discard| Deletes a pending review for current PR if any |
-| | comments| View pending review comments |
-| | commit | Pick a specific commit to review |
-| | close | Close the review window and return to the PR |
-| actions |  | Lists all available Octo actions|
-| search | <query> | Search GitHub for issues and PRs matching the [query](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) |
+| Object   | Action                                  | Arguments                                                                                                                                              |
+| -------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| issue    | close                                   | Close the current issue                                                                                                                                |
+|          | reopen                                  | Reopen the current issue                                                                                                                               |
+|          | create [repo]                           | Creates a new issue in the current or specified repo                                                                                                   |
+|          | edit [repo] <number>                    | Edit issue `<number>` in current or specified repo                                                                                                     |
+|          | list [repo] [key=value] (1)             | List all issues satisfying given filter                                                                                                                |
+|          | search                                  | Live issue search                                                                                                                                      |
+|          | reload                                  | Reload issue. Same as doing `e!`                                                                                                                       |
+|          | browser                                 | Open current issue in the browser                                                                                                                      |
+|          | url                                     | Copies the URL of the current issue to the system clipboard                                                                                            |
+| pr       | list [repo] [key=value] (2)             | List all PRs satisfying given filter                                                                                                                   |
+|          | search                                  | Live issue search                                                                                                                                      |
+|          | edit [repo] <number>                    | Edit PR `<number>` in current or specified repo                                                                                                        |
+|          | reopen                                  | Reopen the current PR                                                                                                                                  |
+|          | create                                  | Creates a new PR for the current branch                                                                                                                |
+|          | close                                   | Close the current PR                                                                                                                                   |
+|          | checkout                                | Checkout PR                                                                                                                                            |
+|          | commits                                 | List all PR commits                                                                                                                                    |
+|          | changes                                 | Show all PR changes (diff hunks)                                                                                                                       |
+|          | diff                                    | Show PR diff                                                                                                                                           |
+|          | merge [commit\|rebase\|squash] [delete] | Merge current PR using the specified method                                                                                                            |
+|          | ready                                   | Mark a draft PR as ready for review                                                                                                                    |
+|          | draft                                   | Send a ready PR back to draft                                                                                                                          |
+|          | checks                                  | Show the status of all checks run on the PR                                                                                                            |
+|          | reload                                  | Reload PR. Same as doing `e!`                                                                                                                          |
+|          | browser                                 | Open current PR in the browser                                                                                                                         |
+|          | url                                     | Copies the URL of the current PR to the system clipboard                                                                                               |
+| repo     | list (3)                                | List repos user owns, contributes or belong to                                                                                                         |
+|          | fork                                    | Fork repo                                                                                                                                              |
+|          | browser                                 | Open current repo in the browser                                                                                                                       |
+|          | url                                     | Copies the URL of the current repo to the system clipboard                                                                                             |
+|          | view                                    | Open a repo by path ({organization}/{name})                                                                                                            |
+| gist     | list [repo] [key=value] (4)             | List user gists                                                                                                                                        |
+| comment  | add                                     | Add a new comment                                                                                                                                      |
+|          | delete                                  | Delete a comment                                                                                                                                       |
+| thread   | resolve                                 | Mark a review thread as resolved                                                                                                                       |
+|          | unresolve                               | Mark a review thread as unresolved                                                                                                                     |
+| label    | add [label]                             | Add a label from available label menu                                                                                                                  |
+|          | remove [label]                          | Remove a label                                                                                                                                         |
+|          | create [label]                          | Create a new label                                                                                                                                     |
+| assignee | add [login]                             | Assign a user                                                                                                                                          |
+|          | remove [login]                          | Unassign a user                                                                                                                                        |
+| reviewer | add [login]                             | Assign a PR reviewer                                                                                                                                   |
+| reaction | `thumbs_up` \| `+1`                     | Add 👍 reaction                                                                                                                                        |
+|          | `thumbs_down` \| `-1`                   | Add 👎 reaction                                                                                                                                        |
+|          | `eyes`                                  | Add 👀 reaction                                                                                                                                        |
+|          | `laugh`                                 | Add 😄 reaction                                                                                                                                        |
+|          | `confused`                              | Add 😕 reaction                                                                                                                                        |
+|          | `rocket`                                | Add 🚀 reaction                                                                                                                                        |
+|          | `heart`                                 | Add ❤️ reaction                                                                                                                                        |
+|          | `hooray` \| `party` \| `tada`           | Add 🎉 reaction                                                                                                                                        |
+| card     | add                                     | Assign issue/PR to a project new card                                                                                                                  |
+|          | remove                                  | Delete project card                                                                                                                                    |
+|          | move                                    | Move project card to different project/column                                                                                                          |
+| review   | start                                   | Start a new review                                                                                                                                     |
+|          | submit                                  | Submit the review                                                                                                                                      |
+|          | resume                                  | Edit a pending review for current PR                                                                                                                   |
+|          | discard                                 | Deletes a pending review for current PR if any                                                                                                         |
+|          | comments                                | View pending review comments                                                                                                                           |
+|          | commit                                  | Pick a specific commit to review                                                                                                                       |
+|          | close                                   | Close the review window and return to the PR                                                                                                           |
+| actions  |                                         | Lists all available Octo actions                                                                                                                       |
+| search   | <query>                                 | Search GitHub for issues and PRs matching the [query](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) |
 
 0. `[repo]`: If repo is not provided, it will be derived from `<cwd>/.git/config`.
 
@@ -445,102 +447,45 @@ Octo provides a built-in omnifunc completion for issues, PRs and users that you 
 ## 🎨 Colors
 
 | Highlight Group             | Defaults to     |
-| ---                         | ---             |
-| *OctoDirty*                 | ErrorMsg        |
-| *OctoIssueTitle*            | PreProc         |
-| *OctoIssueId*               | Question        |
-| *OctoEmpty*                 | Comment         |
-| *OctoFloat*                 | NormalNC        |
-| *OctoDate*                  | Comment         |
-| *OctoSymbol*                | Comment         |
-| *OctoTimelineItemHeading*   | Comment         |
-| *OctoDetailsLabel*          | Title           |
-| *OctoMissingDetails*        | Comment         |
-| *OctoDetailsValue*          | Identifier      |
-| *OctoDiffHunkPosition*      | NormalFloat     |
-| *OctoCommentLine*           | TabLineSel      |
-| *OctoEditable*              | NormalFloat bg  |
-| *OctoViewer*                | GitHub color    |
-| *OctoBubble*                | NormalFloat     |
-| *OctoBubbleGreen*           | GitHub color    |
-| *OctoBubbleRed*             | GitHub color    |
-| *OctoUser*                  | OctoBubble      |
-| *OctoUserViewer*            | OctoViewer      |
-| *OctoReaction*              | OctoBubble      |
-| *OctoReactionViewer*        | OctoViewer      |
-| *OctoPassingTest*           | GitHub color    |
-| *OctoFailingTest*           | GitHub color    |
-| *OctoPullAdditions*         | GitHub color    |
-| *OctoPullDeletions*         | GitHub color    |
-| *OctoPullModifications*     | GitHub color    |
-| *OctoStateOpen*             | GitHub color    |
-| *OctoStateClosed*           | GitHub color    |
-| *OctoStateMerge*            | GitHub color    |
-| *OctoStatePending*          | GitHub color    |
-| *OctoStateApproved*         | OctoStateOpen   |
-| *OctoStateChangesRequested* | OctoStateClosed |
-| *OctoStateCommented*        | Normal          |
-| *OctoStateDismissed*        | OctoStateClosed |
+| --------------------------- | --------------- |
+| _OctoDirty_                 | ErrorMsg        |
+| _OctoIssueTitle_            | PreProc         |
+| _OctoIssueId_               | Question        |
+| _OctoEmpty_                 | Comment         |
+| _OctoFloat_                 | NormalNC        |
+| _OctoDate_                  | Comment         |
+| _OctoSymbol_                | Comment         |
+| _OctoTimelineItemHeading_   | Comment         |
+| _OctoDetailsLabel_          | Title           |
+| _OctoMissingDetails_        | Comment         |
+| _OctoDetailsValue_          | Identifier      |
+| _OctoDiffHunkPosition_      | NormalFloat     |
+| _OctoCommentLine_           | TabLineSel      |
+| _OctoEditable_              | NormalFloat bg  |
+| _OctoViewer_                | GitHub color    |
+| _OctoBubble_                | NormalFloat     |
+| _OctoBubbleGreen_           | GitHub color    |
+| _OctoBubbleRed_             | GitHub color    |
+| _OctoUser_                  | OctoBubble      |
+| _OctoUserViewer_            | OctoViewer      |
+| _OctoReaction_              | OctoBubble      |
+| _OctoReactionViewer_        | OctoViewer      |
+| _OctoPassingTest_           | GitHub color    |
+| _OctoFailingTest_           | GitHub color    |
+| _OctoPullAdditions_         | GitHub color    |
+| _OctoPullDeletions_         | GitHub color    |
+| _OctoPullModifications_     | GitHub color    |
+| _OctoStateOpen_             | GitHub color    |
+| _OctoStateClosed_           | GitHub color    |
+| _OctoStateMerge_            | GitHub color    |
+| _OctoStatePending_          | GitHub color    |
+| _OctoStateApproved_         | OctoStateOpen   |
+| _OctoStateChangesRequested_ | OctoStateClosed |
+| _OctoStateCommented_        | Normal          |
+| _OctoStateDismissed_        | OctoStateClosed |
 
 The term `GitHub color` refers to the colors used in the WebUI.
 The (addition) `viewer` means the user of the plugin or more precisely the user authenticated via the `gh` CLI tool used to retrieve the data from GitHub.
-
-## 🗿 Status Column
-
-If you are using the `vim.opt.statuscolumn` feature, you can disable Octo's comment marks in the `signcolumn` and replace them with any customizations on the `statuscolumn`.
-
-Disable the `signcolumn` with:
-
-```lua
-ui = {
-    use_signcolumn = false
-}
-```
-
-Then, provide a `statuscolumn` replacement such as:
-
-```lua
-local function mk_hl(group, sym)
-  return table.concat({ "%#", group, "#", sym, "%*" })
-end
-
-_G.get_statuscol_octo = function(bufnum, lnum)
-  if vim.api.nvim_buf_get_option(bufnum, "filetype") == "octo" then
-    if type(octo_buffers) == "table" then
-      local buffer = octo_buffers[bufnum]
-      if buffer then
-        buffer:update_metadata()
-        local hl = "OctoSignColumn"
-        local metadatas = {buffer.titleMetadata, buffer.bodyMetadata}
-        for _, comment_metadata in ipairs(buffer.commentsMetadata) do
-          table.insert(metadatas, comment_metadata)
-        end
-        for _, metadata in ipairs(metadatas) do
-          if metadata and metadata.startLine and metadata.endLine then
-            if metadata.dirty then
-              hl = "OctoDirty"
-            else
-              hl = "OctoSignColumn"
-            end
-            if lnum - 1 == metadata.startLine and lnum - 1 == metadata.endLine then
-              return mk_hl(hl, "[ ")
-            elseif lnum - 1 == metadata.startLine then
-              return mk_hl(hl, "┌ ")
-            elseif lnum - 1 == metadata.endLine then
-              return mk_hl(hl, "└ ")
-            elseif metadata.startLine < lnum - 1 and lnum - 1 < metadata.endLine then
-              return mk_hl(hl, "│ ")
-            end
-          end
-        end
-      end
-    end
-  end
-  return "  "
-end
-
-vim.opt.statuscolumn = "%{%v:lua.get_statuscol_octo(bufnr(), v:lnum)%}"
-```
 
 ## 📺 Demos
 
@@ -563,7 +508,6 @@ You add the scope by using `gh auth refresh -s read:project` or you can suppress
   }
 }
 ```
-
 
 **How can I disable bubbles for XYZ?**
 

--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -18,7 +18,6 @@ function M.setup()
     group = "octo_autocmds",
     pattern = { "octo://*" },
     callback = function(ev)
-      dd(ev)
       require("octo").load_buffer(ev.buf)
     end,
   })

--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -1,3 +1,4 @@
+local vim = vim
 local create = vim.api.nvim_create_augroup
 local define = vim.api.nvim_create_autocmd
 
@@ -65,7 +66,7 @@ function M.setup()
   })
 end
 
-function M.update_signcolumn(bufnr)
+function M.update_signs(bufnr)
   define({ "TextChanged", "TextChangedI" }, {
     group = "octobuffer_autocmds",
     buffer = bufnr,

--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -17,8 +17,9 @@ function M.setup()
   define({ "BufReadCmd" }, {
     group = "octo_autocmds",
     pattern = { "octo://*" },
-    callback = function()
-      require("octo").load_buffer()
+    callback = function(ev)
+      dd(ev)
+      require("octo").load_buffer(ev.buf)
     end,
   })
   define({ "BufWriteCmd" }, {

--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -70,7 +70,7 @@ function M.update_signcolumn(bufnr)
     group = "octobuffer_autocmds",
     buffer = bufnr,
     callback = function()
-      require("octo").render_signcolumn()
+      require("octo").render_signs()
     end,
   })
 end

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -29,6 +29,7 @@ local M = {}
 
 ---@class OctoConfigUi
 ---@field use_signcolumn boolean
+---@field use_statuscolumn boolean
 
 ---@class OctoConfigIssues
 ---@field order_by OctoConfigOrderBy
@@ -115,6 +116,7 @@ function M.get_default_values()
     },
     ui = {
       use_signcolumn = true,
+      use_statuscolumn = true,
     },
     issues = {
       order_by = {
@@ -408,6 +410,7 @@ function M.validate_config()
     validate_type(config.default_merge_method, "default_merge_method", "string")
     if validate_type(config.ui, "ui", "table") then
       validate_type(config.ui.use_signcolumn, "ui.use_signcolumn", "boolean")
+      validate_type(config.ui.use_statuscolumn, "ui.use_statuscolumn", "boolean")
     end
     if validate_type(config.colors, "colors", "table") then
       for k, v in pairs(config.colors) do
@@ -472,6 +475,7 @@ function M.setup(opts)
       vim.log.levels.ERROR
     )
   end
+  M.values.ui.use_statuscolumn = M.values.ui.use_statuscolumn and vim.fn.has "nvim-0.9" == 1
 end
 
 return M

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -30,6 +30,7 @@ local M = {}
 ---@class OctoConfigUi
 ---@field use_signcolumn boolean
 ---@field use_statuscolumn boolean
+---@field use_foldtext boolean
 
 ---@class OctoConfigIssues
 ---@field order_by OctoConfigOrderBy
@@ -117,6 +118,7 @@ function M.get_default_values()
     ui = {
       use_signcolumn = true,
       use_statuscolumn = true,
+      use_foldtext = true,
     },
     issues = {
       order_by = {
@@ -411,6 +413,7 @@ function M.validate_config()
     if validate_type(config.ui, "ui", "table") then
       validate_type(config.ui.use_signcolumn, "ui.use_signcolumn", "boolean")
       validate_type(config.ui.use_statuscolumn, "ui.use_statuscolumn", "boolean")
+      validate_type(config.ui.use_foldtext, "ui.use_foldtext", "boolean")
     end
     if validate_type(config.colors, "colors", "table") then
       for k, v in pairs(config.colors) do
@@ -476,6 +479,7 @@ function M.setup(opts)
     )
   end
   M.values.ui.use_statuscolumn = M.values.ui.use_statuscolumn and vim.fn.has "nvim-0.9" == 1
+  M.values.ui.use_foldtext = M.values.ui.use_foldtext and vim.fn.has "nvim-0.10" == 1
 end
 
 return M

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -116,7 +116,7 @@ function M.get_default_values()
       projects_v2 = false,
     },
     ui = {
-      use_signcolumn = true,
+      use_signcolumn = false,
       use_statuscolumn = true,
       use_foldtext = true,
     },

--- a/lua/octo/folds.lua
+++ b/lua/octo/folds.lua
@@ -1,8 +1,13 @@
+local config = require "octo.config"
+
 local M = {}
 
 function M.setup() end
 
 function M.create(bufnr, start_line, end_line, is_opened)
+  if config.values.ui.use_foldtext then
+    start_line = start_line - 1
+  end
   vim.api.nvim_buf_call(bufnr, function()
     vim.cmd [[setlocal foldmethod=manual]]
     vim.cmd(string.format("%d,%dfold", start_line, end_line))
@@ -10,6 +15,21 @@ function M.create(bufnr, start_line, end_line, is_opened)
       vim.cmd(string.format("%d,%dfoldopen", start_line, end_line))
     end
   end)
+end
+
+--- Folds will already have correct highlighting, but the fold background will
+--- extend over the entire line. This function will make sure the whitespace
+--- before the fold icon is using no background.
+function M.foldtext()
+  local buf = vim.api.nvim_get_current_buf()
+  local lnum = vim.v.foldstart
+  local extmark =
+    vim.api.nvim_buf_get_extmarks(buf, -1, { lnum - 1, 0 }, { lnum - 1, -1 }, { details = true, type = "virt_text" })[1]
+
+  local text = vim.tbl_get(extmark, 4, "virt_text", 1, 1)
+  if text then
+    return { { text:match "^%s+", "Normal" } }
+  end
 end
 
 return M

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -82,7 +82,9 @@ function M.load_buffer(bufnr)
     return
   end
   M.load(repo, kind, number, function(obj)
-    M.create_buffer(kind, obj, repo, false)
+    vim.api.nvim_buf_call(bufnr, function()
+      M.create_buffer(kind, obj, repo, false)
+    end)
   end)
 end
 

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -121,10 +121,10 @@ function M.load(repo, kind, number, cb)
   }
 end
 
-function M.render_signcolumn()
+function M.render_signs()
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
-  buffer:render_signcolumn()
+  buffer:render_signs()
 end
 
 function M.on_cursor_hold()

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -239,6 +239,7 @@ function OctoBuffer:configure()
   vim.api.nvim_buf_call(self.bufnr, function()
     local use_signcolumn = config.values.ui.use_signcolumn
     local use_statuscolumn = config.values.ui.use_statuscolumn
+    local use_foldtext = config.values.ui.use_foldtext
     vim.cmd [[setlocal filetype=octo]]
     vim.cmd [[setlocal buftype=acwrite]]
     vim.cmd [[setlocal omnifunc=v:lua.octo_omnifunc]]
@@ -247,6 +248,9 @@ function OctoBuffer:configure()
 
     if use_statuscolumn then
       vim.opt_local.statuscolumn = [[%!v:lua.require'octo.ui.statuscolumn'.statuscolumn()]]
+    end
+    if use_foldtext then
+      vim.opt_local.foldtext = [[v:lua.require'octo.folds'.foldtext()]]
     end
     if use_signcolumn then
       vim.cmd [[setlocal signcolumn=yes]]

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -9,6 +9,7 @@ local graphql = require "octo.gh.graphql"
 local signs = require "octo.ui.signs"
 local writers = require "octo.ui.writers"
 local utils = require "octo.utils"
+local vim = vim
 
 local M = {}
 
@@ -398,7 +399,7 @@ function OctoBuffer:do_save_title_and_body()
             self.bodyMetadata = desc_metadata
           end
 
-          self:render_signcolumn()
+          self:render_signs()
           utils.info "Saved!"
         end
       end,
@@ -430,7 +431,7 @@ function OctoBuffer:do_add_issue_comment(comment_metadata)
               break
             end
           end
-          self:render_signcolumn()
+          self:render_signs()
         end
       end
     end,
@@ -473,7 +474,7 @@ function OctoBuffer:do_add_thread_comment(comment_metadata)
             review:update_threads(threads)
           end
 
-          self:render_signcolumn()
+          self:render_signs()
 
           -- update thread map
           local thread_id
@@ -577,7 +578,7 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
               if review then
                 review:update_threads(threads)
               end
-              self:render_signcolumn()
+              self:render_signs()
             end
           else
             utils.error "Failed to create thread"
@@ -674,7 +675,7 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
                   local threads = resp.comment.pullRequest.reviewThreads.nodes
                   review:update_threads(threads)
                 end
-                self:render_signcolumn()
+                self:render_signs()
               end
             else
               utils.error "Failed to create thread"
@@ -722,7 +723,7 @@ function OctoBuffer:do_add_pull_request_comment(comment_metadata)
                 break
               end
             end
-            self:render_signcolumn()
+            self:render_signs()
           end
         else
           utils.error "Failed to create thread"
@@ -774,7 +775,7 @@ function OctoBuffer:do_update_comment(comment_metadata)
               break
             end
           end
-          self:render_signcolumn()
+          self:render_signs()
         end
       end
     end,
@@ -806,10 +807,11 @@ function OctoBuffer:update_metadata()
   end
 end
 
----Renders the signcolumn
-function OctoBuffer:render_signcolumn()
+---Renders the signs in the signcolumn or statuscolumn
+function OctoBuffer:render_signs()
   local use_signcolumn = config.values.ui.use_signcolumn
-  if not use_signcolumn or not self.ready then
+  local use_statuscolumn = config.values.ui.use_statuscolumn
+  if not self.ready or (not use_statuscolumn and not use_signcolumn) then
     return
   end
 

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -238,11 +238,16 @@ function OctoBuffer:configure()
   -- configure buffer
   vim.api.nvim_buf_call(self.bufnr, function()
     local use_signcolumn = config.values.ui.use_signcolumn
+    local use_statuscolumn = config.values.ui.use_statuscolumn
     vim.cmd [[setlocal filetype=octo]]
     vim.cmd [[setlocal buftype=acwrite]]
     vim.cmd [[setlocal omnifunc=v:lua.octo_omnifunc]]
     vim.cmd [[setlocal conceallevel=2]]
     vim.cmd [[setlocal nonumber norelativenumber nocursorline wrap]]
+
+    if use_statuscolumn then
+      vim.opt_local.statuscolumn = [[%!v:lua.require'octo.ui.statuscolumn'.statuscolumn()]]
+    end
     if use_signcolumn then
       vim.cmd [[setlocal signcolumn=yes]]
       autocmds.update_signcolumn(self.bufnr)

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -238,24 +238,22 @@ end
 function OctoBuffer:configure()
   -- configure buffer
   vim.api.nvim_buf_call(self.bufnr, function()
-    local use_signcolumn = config.values.ui.use_signcolumn
-    local use_statuscolumn = config.values.ui.use_statuscolumn
-    local use_foldtext = config.values.ui.use_foldtext
     vim.cmd [[setlocal filetype=octo]]
     vim.cmd [[setlocal buftype=acwrite]]
     vim.cmd [[setlocal omnifunc=v:lua.octo_omnifunc]]
     vim.cmd [[setlocal conceallevel=2]]
     vim.cmd [[setlocal nonumber norelativenumber nocursorline wrap]]
 
-    if use_statuscolumn then
-      vim.opt_local.statuscolumn = [[%!v:lua.require'octo.ui.statuscolumn'.statuscolumn()]]
-    end
-    if use_foldtext then
-      vim.opt_local.foldtext = [[v:lua.require'octo.folds'.foldtext()]]
-    end
-    if use_signcolumn then
+    if config.values.ui.use_signcolumn then
       vim.cmd [[setlocal signcolumn=yes]]
-      autocmds.update_signcolumn(self.bufnr)
+      autocmds.update_signs(self.bufnr)
+    end
+    if config.values.ui.use_statuscolumn then
+      vim.opt_local.statuscolumn = [[%!v:lua.require'octo.ui.statuscolumn'.statuscolumn()]]
+      autocmds.update_signs(self.bufnr)
+    end
+    if config.values.ui.use_foldtext then
+      vim.opt_local.foldtext = [[v:lua.require'octo.folds'.foldtext()]]
     end
   end)
 

--- a/lua/octo/reviews/thread-panel.lua
+++ b/lua/octo/reviews/thread-panel.lua
@@ -1,5 +1,6 @@
 local OctoBuffer = require("octo.model.octo-buffer").OctoBuffer
 local utils = require "octo.utils"
+local vim = vim
 
 local M = {}
 
@@ -108,7 +109,7 @@ function M.create_thread_buffer(threads, repo, number, side, path)
       repo = repo,
     }
     buffer:render_threads(threads)
-    buffer:render_signcolumn()
+    buffer:render_signs()
   elseif vim.api.nvim_buf_is_loaded(bufnr) then
     buffer = octo_buffers[bufnr]
   else

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -73,6 +73,7 @@ local function get_hl_links()
     CursorLine = "CursorLine",
     VertSplit = "VertSplit",
     SignColumn = "Normal",
+    StatusColumn = "SignColumn",
     StatusLine = "StatusLine",
     StatusLineNC = "StatusLineNC",
     EndOfBuffer = "EndOfBuffer",

--- a/lua/octo/ui/signs.lua
+++ b/lua/octo/ui/signs.lua
@@ -34,12 +34,20 @@ end
 function M.unplace(bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   pcall(vim.fn.sign_unplace, "octo_ns", { buffer = bufnr })
+  if config.values.ui.use_statuscolumn then
+    require("octo.ui.statuscolumn").reset(bufnr)
+  end
 end
 
 function M.place_signs(bufnr, start_line, end_line, is_dirty)
   if not start_line or not end_line then
     return
   end
+
+  if config.values.ui.use_statuscolumn then
+    return require("octo.ui.statuscolumn").add(bufnr, start_line, end_line, is_dirty)
+  end
+
   local dirty_mod = is_dirty and "dirty" or "clean"
 
   if start_line == end_line or end_line < start_line then

--- a/lua/octo/ui/signs.lua
+++ b/lua/octo/ui/signs.lua
@@ -1,4 +1,5 @@
 local config = require "octo.config"
+local vim = vim
 
 local M = {}
 
@@ -28,12 +29,21 @@ function M.place(name, bufnr, line)
   if not line then
     return
   end
-  pcall(vim.fn.sign_place, 0, "octo_ns", name, bufnr, { lnum = line + 1 })
+  -- sign column
+  if config.values.ui.use_signcolumn then
+    pcall(vim.fn.sign_place, 0, "octo_ns", name, bufnr, { lnum = line + 1 })
+  end
+  -- status column
+  -- TODO: implement status column support for thread signs
 end
 
 function M.unplace(bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
-  pcall(vim.fn.sign_unplace, "octo_ns", { buffer = bufnr })
+  -- sign column
+  if config.values.ui.use_signcolumn then
+    pcall(vim.fn.sign_unplace, "octo_ns", { buffer = bufnr })
+  end
+  -- status column
   if config.values.ui.use_statuscolumn then
     require("octo.ui.statuscolumn").reset(bufnr)
   end
@@ -43,23 +53,25 @@ function M.place_signs(bufnr, start_line, end_line, is_dirty)
   if not start_line or not end_line then
     return
   end
+  -- sign column
+  if config.values.ui.use_signcolumn then
+    local dirty_mod = is_dirty and "dirty" or "clean"
 
+    if start_line == end_line or end_line < start_line then
+      M.place(string.format("octo_%s_line", dirty_mod), bufnr, start_line)
+    else
+      M.place(string.format("octo_%s_block_start", dirty_mod), bufnr, start_line)
+      M.place(string.format("octo_%s_block_end", dirty_mod), bufnr, end_line)
+    end
+    if start_line + 1 < end_line then
+      for j = start_line + 1, end_line - 1, 1 do
+        M.place(string.format("octo_%s_block_middle", dirty_mod), bufnr, j)
+      end
+    end
+  end
+  -- status column
   if config.values.ui.use_statuscolumn then
     return require("octo.ui.statuscolumn").add(bufnr, start_line, end_line, is_dirty)
-  end
-
-  local dirty_mod = is_dirty and "dirty" or "clean"
-
-  if start_line == end_line or end_line < start_line then
-    M.place(string.format("octo_%s_line", dirty_mod), bufnr, start_line)
-  else
-    M.place(string.format("octo_%s_block_start", dirty_mod), bufnr, start_line)
-    M.place(string.format("octo_%s_block_end", dirty_mod), bufnr, end_line)
-  end
-  if start_line + 1 < end_line then
-    for j = start_line + 1, end_line - 1, 1 do
-      M.place(string.format("octo_%s_block_middle", dirty_mod), bufnr, j)
-    end
   end
 end
 

--- a/lua/octo/ui/statuscolumn.lua
+++ b/lua/octo/ui/statuscolumn.lua
@@ -1,0 +1,86 @@
+local M = {}
+
+-- stylua: ignore
+local corners = {
+  top    = "┌╴",
+  middle = "│ ",
+  last   = "└╴",
+  single = "[ ",
+}
+
+---@alias OctoSign {text: string, hl?: string}
+---@alias OctoComment { from: number, to: number, dirty: boolean }
+---@type table<number, OctoComment[]>
+local comments = {}
+
+function M.reset(buf)
+  comments[buf] = nil
+end
+
+function M.add(bufnr, start_line, end_line, is_dirty)
+  comments[bufnr] = comments[bufnr] or {}
+  table.insert(comments[bufnr], { from = start_line, to = end_line, dirty = is_dirty })
+end
+
+--- Fixes octo's comment rendering to take wrapping into account
+---@param buf number
+---@param lnum number
+---@param vnum number
+---@param win number
+---@return OctoSign?
+function M.get_sign(buf, lnum, vnum, win)
+  lnum = lnum - 1
+  for _, s in ipairs(comments[buf] or {}) do
+    if lnum >= s.from and lnum <= s.to then
+      local height = vim.api.nvim_win_text_height(win, { start_row = s.from, end_row = s.to }).all
+      local height_end = vim.api.nvim_win_text_height(win, { start_row = s.to, end_row = s.to }).all
+      local corner = corners.middle
+      if height == 1 then
+        corner = corners.single
+      elseif lnum == s.from and vnum == 0 then
+        corner = corners.top
+      elseif lnum == s.to and vnum == height_end - 1 then
+        corner = corners.last
+      end
+      return { text = corner, hl = s.dirty and "OctoDirty" or "OctoStatusColumn" }
+    end
+  end
+end
+
+---@param sign OctoSign?
+---@param len? number
+function M.highlight(sign, len)
+  sign = sign or { text = "" }
+  len = len or 2
+  local text = vim.fn.strcharpart(sign.text, 0, len) ---@type string
+  text = text .. string.rep(" ", len - vim.fn.strchars(text))
+  return sign.hl and ("%#" .. sign.hl .. "#" .. text .. "%*") or text
+end
+
+function M.statuscolumn()
+  local win = vim.g.statusline_winid
+  local buf = vim.api.nvim_win_get_buf(win)
+  local components = { "", "" }
+
+  local fold ---@type OctoSign?
+  local comment = M.get_sign(buf, vim.v.lnum, vim.v.virtnum, win)
+
+  vim.api.nvim_win_call(win, function()
+    if vim.fn.foldclosed(vim.v.lnum) >= 0 then
+      fold = { text = vim.opt.fillchars:get().foldclose or "", hl = "Folded" }
+    end
+  end)
+
+  -- Left: mark or non-git sign
+  components[1] = M.highlight(comment)
+  -- Right: fold icon or git sign (only if file)
+  -- components[3] = M.highlight(fold) or ""
+
+  if vim.v.virtnum ~= 0 then
+    components[2] = "%= "
+  end
+
+  return table.concat(components, "")
+end
+
+return M

--- a/lua/octo/ui/statuscolumn.lua
+++ b/lua/octo/ui/statuscolumn.lua
@@ -62,19 +62,9 @@ function M.statuscolumn()
   local buf = vim.api.nvim_win_get_buf(win)
   local components = { "", "" }
 
-  local fold ---@type OctoSign?
   local comment = M.get_sign(buf, vim.v.lnum, vim.v.virtnum, win)
 
-  vim.api.nvim_win_call(win, function()
-    if vim.fn.foldclosed(vim.v.lnum) >= 0 then
-      fold = { text = vim.opt.fillchars:get().foldclose or "", hl = "Folded" }
-    end
-  end)
-
-  -- Left: mark or non-git sign
   components[1] = M.highlight(comment)
-  -- Right: fold icon or git sign (only if file)
-  -- components[3] = M.highlight(fold) or ""
 
   if vim.v.virtnum ~= 0 then
     components[2] = "%= "

--- a/lua/octo/ui/statuscolumn.lua
+++ b/lua/octo/ui/statuscolumn.lua
@@ -1,3 +1,5 @@
+local vim = vim
+
 local M = {}
 
 -- stylua: ignore

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -1402,7 +1402,14 @@ end
 function M.write_virtual_text(bufnr, ns, line, chunks, mode)
   mode = mode or "extmark"
   if mode == "extmark" then
-    pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, { virt_text = chunks, virt_text_pos = "overlay" })
+    pcall(
+      vim.api.nvim_buf_set_extmark,
+      bufnr,
+      ns,
+      line,
+      0,
+      { virt_text = chunks, virt_text_pos = "overlay", hl_mode = "combine" }
+    )
   elseif mode == "vt" then
     pcall(vim.api.nvim_buf_set_virtual_text, bufnr, ns, line, chunks, {})
   end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This PR fixes both issues/features as described in #80:

* use `statuscolumn` on Neovim >= 0.9 for rendering comment signs, so that they render correctly when wrapping
* use `foldtext` on Neovim >= 0.10 for better rendering of folded comments/threads/...

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #80

### Describe how you did it
I implemented both a statuscolumn and foldtext.
See the two different commits.

### Describe how to verify it

In Neovim 0.10, check the features described

### Special notes for reviews

In the screenshot you can see comment markers from a wrapped comment.
And what a folded thread looks like (lighter background)

Edit: I seem to have included the code from my other PR as well :)

![image](https://github.com/pwntester/octo.nvim/assets/292349/42385d71-f62d-497f-b544-c6ad01561725)
