### PR TITLE
Fix human readable time differences

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -432,7 +432,7 @@ function M.add_comment()
   local comment = {
     id = -1,
     author = { login = vim.g.octo_viewer },
-    createdAt = vim.fn.strftime "%FT%TZ",
+    createdAt = os.date "!%FT%TZ",
     body = " ",
     viewerCanUpdate = true,
     viewerCanDelete = true,

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -355,6 +355,10 @@ end
 
 ---Formats a string as a date
 function M.format_date(date_string)
+  if date_string == nil then
+    return ""
+  end
+
   -- Parse the input date string (assumed to be in UTC)
   local year, month, day, hour, min, sec = date_string:match "(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)Z"
   local parsedTimeUTC = os.time {
@@ -405,13 +409,13 @@ function M.format_date(date_string)
 
   -- Return the human-readable format for differences within 30 days
   if days > 0 then
-    return days .. " day" .. (days > 1 and "s" or "") .. suffix
+    return days .. " day" .. (days ~= 1 and "s" or "") .. suffix
   elseif hours > 0 then
-    return hours .. " hour" .. (hours > 1 and "s" or "") .. suffix
+    return hours .. " hour" .. (hours ~= 1 and "s" or "") .. suffix
   elseif minutes > 0 then
-    return minutes .. " minute" .. (minutes > 1 and "s" or "") .. suffix
+    return minutes .. " minute" .. (minutes ~= 1 and "s" or "") .. suffix
   else
-    return seconds .. " second" .. (seconds > 1 and "s" or "") .. suffix
+    return seconds .. " second" .. (seconds ~= 1 and "s" or "") .. suffix
   end
 end
 


### PR DESCRIPTION
related to #584. 

The creation of the comments were happening in local time but were being stored in UTC.
Also worked through the `date_format` function to make sure that the date difference is
being calculated correctly.
