### PR TITLE
Revert "fix: escape new line in graphql pr review queries"

### DIFF
--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -3194,10 +3194,9 @@ query {
 ]]
 
 local function escape_char(string)
-  local escaped, _ = string.gsub(string, '["\\\n]', {
+  local escaped, _ = string.gsub(string, '["\\]', {
     ['"'] = '\\"',
     ["\\"] = "\\\\",
-    ["\n"] = "\\n",
   })
   return escaped
 end

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -244,7 +244,7 @@ function Review:submit(event)
   local winid = vim.api.nvim_get_current_win()
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   local body = utils.escape_char(utils.trim(table.concat(lines, "\n")))
-  local query = graphql("submit_pull_request_review_mutation", self.id, event, body, { escape = true })
+  local query = graphql("submit_pull_request_review_mutation", self.id, event, body, { escape = false })
   gh.run {
     args = { "api", "graphql", "-f", string.format("query=%s", query) },
     cb = function(output, stderr)


### PR DESCRIPTION
This reverts commit b4923dc97555c64236c4535b2adf75c74c00caca since it caused #592 
