### PR TITLE
Use repo assignable / mentionable users in finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ require"octo".setup({
   outdated_icon = "󰅒 ",                    -- outdated indicator
   resolved_icon = " ",                    -- resolved indicator
   reaction_viewer_hint_icon = " ";        -- marker for user reactions
+  users = "search",                        -- Users for assignees or reviewers. Values: "search" | "mentionable" | "assignable"
   user_icon = " ";                        -- user icon
   timeline_marker = " ";                  -- timeline marker
   timeline_indent = "2";                   -- timeline indentation
@@ -406,6 +407,16 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 
 - `<CR>`: Append Gist to buffer
   [Available keys](https://cli.github.com/manual/gh_gist_list): `repo`\|`public`\|`secret`
+
+5. Users in the assignee and reviewer commands: 
+
+- `search`: Dynamically search all GitHub users
+- `mentionable`: List of *mentionable* users in current repo
+- `assignable`: List of *assignable* users in current repo
+
+Here, `search` is the default value and most broad. Both `assignable` and
+`mentionable` are specific to the current repo. The `assignable` option is more
+restrictive than `mentionable`.
 
 ## 🔥 Examples
 

--- a/README.md
+++ b/README.md
@@ -414,9 +414,9 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 - `mentionable`: List of *mentionable* users in current repo
 - `assignable`: List of *assignable* users in current repo
 
-Here, `search` is the default value and most broad. Both `assignable` and
-`mentionable` are specific to the current repo. The `assignable` option is more
-restrictive than `mentionable`.
+  Here, `search` is the default value and most broad. Both `assignable` and
+  `mentionable` are specific to the current repo. The `assignable` option is more
+  restrictive than `mentionable`.
 
 ## 🔥 Examples
 

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -53,6 +53,7 @@ local M = {}
 ---@field default_merge_method string
 ---@field ssh_aliases {[string]:string}
 ---@field reaction_viewer_hint_icon string
+---@field users string
 ---@field user_icon string
 ---@field comment_icon string
 ---@field outdated_icon string
@@ -96,6 +97,7 @@ function M.get_default_values()
     default_merge_method = "commit",
     ssh_aliases = {},
     reaction_viewer_hint_icon = " ",
+    users = "search",
     user_icon = " ",
     comment_icon = "▎",
     outdated_icon = "󰅒 ",
@@ -346,6 +348,25 @@ function M.validate_config()
     validate_type(config.picker_config.mappings, "picker_config.mappings", "table")
   end
 
+  local function validate_user_search()
+    if not validate_type(config.users, "users", "string") then
+      return
+    end
+
+    local valid_finders = { "search", "mentionable", "assignable" }
+
+    if not vim.tbl_contains(valid_finders, config.users) then
+      err(
+        "users." .. config.users,
+        string.format(
+          "Expected a valid user finder, received '%s', which is not a supported finder! Valid finders: %s",
+          config.users,
+          table.concat(valid_finders, ", ")
+        )
+      )
+    end
+  end
+
   local function validate_aliases()
     if not validate_type(config.ssh_aliases, "ssh_aliases", "table") then
       return
@@ -395,6 +416,7 @@ function M.validate_config()
     validate_type(config.gh_cmd, "gh_cmd", "string")
     validate_type(config.gh_env, "gh_env", { "table", "function" })
     validate_type(config.reaction_viewer_hint_icon, "reaction_viewer_hint_icon", "string")
+    validate_user_search()
     validate_type(config.user_icon, "user_icon", "string")
     validate_type(config.comment_icon, "comment_icon", "string")
     validate_type(config.outdated_icon, "outdated_icon", "string")

--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -2681,7 +2681,7 @@ query {
 
 M.mentionable_users_query = [[
 query($endCursor: String) {
-  repository(owner: %s, name: %s) {
+  repository(owner: "%s", name: "%s") {
       mentionableUsers(first: 100, after: $endCursor) {
       pageInfo {
         hasNextPage

--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -2679,6 +2679,24 @@ query {
 }
 ]]
 
+M.mentionable_users_query = [[
+query($endCursor: String) {
+  repository(owner: %s, name: %s) {
+      mentionableUsers(first: 100, after: $endCursor) {
+      pageInfo {
+        hasNextPage
+        endCursor
+        startCursor
+      }
+      nodes {
+        id
+        login
+      }
+    }
+  }
+}
+]]
+
 M.users_query = [[
 query($endCursor: String) {
   search(query: "%s", type: USER, first: 100) {

--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -2697,6 +2697,24 @@ query($endCursor: String) {
 }
 ]]
 
+M.assignable_users_query = [[
+query($endCursor: String) {
+  repository(owner: "%s", name: "%s") {
+    assignableUsers(first: 100, after: $endCursor) {
+      pageInfo {
+        hasNextPage
+        endCursor
+        startCursor
+      }
+      nodes {
+        id
+        login
+      }
+    }
+  }
+}
+]]
+
 M.users_query = [[
 query($endCursor: String) {
   search(query: "%s", type: USER, first: 100) {

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -824,12 +824,14 @@ local function get_user_requester()
 end
 
 local function get_mentionable_users()
-  local query = graphql "mentionable_users_query"
+  local repo = utils.get_remote_name()
+  local owner, name = utils.split_repo(repo)
+  local query = graphql("mentionable_users_query", owner, name, { escape = true })
   local output = gh.run {
     args = { "api", "graphql", "--paginate", "-f", string.format("query=%s", query) },
     mode = "sync",
   }
-  if output then
+  if not output then
     return {}
   end
 
@@ -839,10 +841,10 @@ local function get_mentionable_users()
 
   for _, resp in ipairs(responses) do
     for _, user in ipairs(resp.data.repository.mentionableUsers.nodes) do
-      users[user.login] = {
+      table.insert(users, {
         id = user.id,
         login = user.login,
-      }
+      })
     end
   end
 

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -771,7 +771,6 @@ end
 --
 local function get_user_requester()
   return function(prompt)
-    print("The prompt is: " .. prompt)
     -- skip empty queries
     if not prompt or prompt == "" or utils.is_blank(prompt) then
       return {}
@@ -827,7 +826,6 @@ local function get_user_requester()
 end
 
 local function get_users(query_name, node_name)
-  print "Calling the get_users function"
   local repo = utils.get_remote_name()
   local owner, name = utils.split_repo(repo)
   local query = graphql(query_name, owner, name, { escape = true })
@@ -869,8 +867,6 @@ local function create_user_finder()
 
   local finder
   local user_entry_maker = entry_maker.gen_from_user()
-  print "Using the configuration setting"
-  print(cfg.users)
   if cfg.users == "search" then
     finder = finders.new_dynamic {
       entry_maker = user_entry_maker,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Use repo's assignable / mentionable users to populate finder instead of general GitHub search.


TODO:

- [x] Add a configuration option so that the previous behavior can be used if desired
- [ ] Implement for the other pickers / refactor user list logic to separate file. Thoughts on this @pwntester?
- [ ] Update any documentation


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Closes #423 

### Describe how you did it

Pull out the finder creation logic


### Describe how to verify it

Use `Octo assignee add` or `Octo reviewer add` to see the new behavior.


### Special notes for reviews

