### PR TITLE
feat: allow disabling auto review thread opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ require"octo".setup({
       direction = "DESC"                   -- either DESC or ASC (https://docs.github.com/en/graphql/reference/enums#orderdirection)
     }
   },
+  reviews = {
+    auto_show_threads = true,              -- automatically show comment threads on cursor move
+  },
   pull_requests = {
     order_by = {                           -- criteria to sort the results of `Octo pr list`
       field = "CREATED_AT",                -- either COMMENTS, CREATED_AT or UPDATED_AT (https://docs.github.com/en/graphql/reference/enums#issueorderfield)

--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -1,4 +1,6 @@
 local vim = vim
+local config = require "octo.config"
+
 local create = vim.api.nvim_create_augroup
 local define = vim.api.nvim_create_autocmd
 
@@ -36,13 +38,15 @@ function M.setup()
       require("octo").on_cursor_hold()
     end,
   })
-  define({ "CursorMoved" }, {
-    group = "octo_autocmds",
-    pattern = { "*" },
-    callback = function()
-      require("octo.reviews.thread-panel").show_review_threads()
-    end,
-  })
+  if config.values.reviews.auto_show_threads then
+    define({ "CursorMoved" }, {
+      group = "octo_autocmds",
+      pattern = { "*" },
+      callback = function()
+        require("octo.reviews.thread-panel").show_review_threads()
+      end,
+    })
+  end
   define({ "TabClosed" }, {
     group = "octo_autocmds",
     pattern = { "*" },

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -226,6 +226,9 @@ function M.setup()
           utils.error "Please start or resume a review first"
         end
       end,
+      thread = function()
+        require("octo.reviews.thread-panel").show_review_threads { jump_to_buffer = true }
+      end,
     },
     gist = {
       list = function(...)

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -35,6 +35,9 @@ local M = {}
 ---@class OctoConfigIssues
 ---@field order_by OctoConfigOrderBy
 
+---@class OctoConfigReviews
+---@field auto_show_threads boolean
+
 ---@class OctoConfigPR
 ---@field order_by OctoConfigOrderBy
 ---@field always_select_remote_on_create boolean
@@ -72,6 +75,7 @@ local M = {}
 ---@field suppress_missing_scope OctoMissingScopeConfig
 ---@field ui OctoConfigUi
 ---@field issues OctoConfigIssues
+---@field reviews OctoConfigReviews
 ---@field pull_requests OctoConfigPR
 ---@field file_panel OctoConfigFilePanel
 ---@field colors OctoConfigColors
@@ -125,6 +129,9 @@ function M.get_default_values()
         field = "CREATED_AT",
         direction = "DESC",
       },
+    },
+    reviews = {
+      auto_show_threads = true,
     },
     pull_requests = {
       order_by = {

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -402,6 +402,14 @@ function Review:add_comment(isSuggestion)
       vim.cmd [[diffoff!]]
       vim.cmd [[normal! vvGk]]
       vim.cmd [[startinsert]]
+
+      vim.keymap.set("n", "q", function()
+        thread_panel.hide_thread_buffer(split, file)
+        local file_win = file:get_win(split)
+        if vim.api.nvim_win_is_valid(file_win) then
+          vim.api.nvim_set_current_win(file_win)
+        end
+      end, { buffer = thread_buffer.bufnr })
     end
   else
     utils.error("Cannot find diff window " .. alt_win)

--- a/lua/octo/reviews/thread-panel.lua
+++ b/lua/octo/reviews/thread-panel.lua
@@ -1,10 +1,12 @@
 local OctoBuffer = require("octo.model.octo-buffer").OctoBuffer
 local utils = require "octo.utils"
 local vim = vim
+local config = require "octo.config"
 
 local M = {}
 
-function M.show_review_threads()
+function M.show_review_threads(params)
+  local params = params or {}
   -- This function is called from a very broad CursorHold event
   -- Check if we are in a diff buffer and otherwise return early
   local bufnr = vim.api.nvim_get_current_buf()
@@ -67,6 +69,18 @@ function M.show_review_threads()
         table.insert(file.associated_bufs, thread_buffer.bufnr)
         vim.api.nvim_win_set_buf(alt_win, thread_buffer.bufnr)
         thread_buffer:configure()
+
+        vim.keymap.set("n", "q", function()
+          M.hide_thread_buffer(split, file)
+          local file_win = file:get_win(split)
+          if vim.api.nvim_win_is_valid(file_win) then
+            vim.api.nvim_set_current_win(file_win)
+          end
+        end, { buffer = thread_buffer.bufnr })
+
+        if params.jump_to_buffer then
+          vim.api.nvim_set_current_win(alt_win)
+        end
         vim.api.nvim_buf_call(thread_buffer.bufnr, function()
           vim.cmd [[diffoff!]]
           pcall(vim.cmd, "normal ]c")
@@ -75,18 +89,21 @@ function M.show_review_threads()
     end
   else
     -- no threads at the current line, hide the thread buffer
-    local alt_buf = file:get_alternative_buf(split)
-    local alt_win = file:get_alternative_win(split)
-    local cur_win = file:get_win(split)
-    if vim.api.nvim_win_is_valid(alt_win) and vim.api.nvim_buf_is_valid(alt_buf) then
-      local current_alt_bufnr = vim.api.nvim_win_get_buf(alt_win)
-      if current_alt_bufnr ~= alt_buf then
-        -- if we are not showing the corresponging alternative diff buffer, do so
-        vim.api.nvim_win_set_buf(alt_win, alt_buf)
+    M.hide_thread_buffer(split, file)
+  end
+end
 
-        -- show the diff
-        file:show_diff()
-      end
+function M.hide_thread_buffer(split, file)
+  local alt_buf = file:get_alternative_buf(split)
+  local alt_win = file:get_alternative_win(split)
+  if vim.api.nvim_win_is_valid(alt_win) and vim.api.nvim_buf_is_valid(alt_buf) then
+    local current_alt_bufnr = vim.api.nvim_win_get_buf(alt_win)
+    if current_alt_bufnr ~= alt_buf then
+      -- if we are not showing the corresponging alternative diff buffer, do so
+      vim.api.nvim_win_set_buf(alt_win, alt_buf)
+
+      -- show the diff
+      file:show_diff()
     end
   end
 end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Add a config option to disable the auto thread opening on cursor move during review

Due to how diff works in nvim, I found it very hard to focus whenever there was more than one or two comments on a file


### Does this pull request fix one issue?
Fixes #536

### Describe how you did it
- Add the config option
- Create a command to call show review thread so that users can bind it
- When the config option is set,
    - do not create the cursor move autocmd that calls show review thread
    - create an local buffer keybind to close the comment buffer on q since it no longer auto closes when going back to diff


### Describe how to verify it

Octo config
```lua
  opts = {
    reviews = {
      auto_show_threads = false,
    },
  },
```

Open a pr review
- Go on a thread, call `<CMD>Octo review thread<CR>`
or
- Create a comment using `<CMD>Octo comment add<CR>`

See buffer open, and press q to close it
