### PR TITLE
feat: start or resume a review with `:Octo review` command

### DIFF
--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -51,6 +51,8 @@ See |octo-command-examples| for examples.
 
 :Octo pr [action] {args}                        *octo-commands-pr*
 
+  Omit action to open the pull request matching the current branch.
+
   list [repo] {key=val} Lists all PRs satisfying a given filter.
                         In-menu mappings: 
                           <CR>    Edit PR.
@@ -147,6 +149,9 @@ See |octo-command-examples| for examples.
 
 
 :Octo review [action]                           *octo-commands-review*
+
+  Omit action to resume a review if one is in progress, or start a new one if
+  no review is in progress.
 
   start                 Start a new review.
   submit                Submit the review.

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -353,6 +353,12 @@ function M.setup()
       end)
     end,
   })
+
+  setmetatable(M.commands.review, {
+    __call = function(_)
+      reviews.start_or_resume_review()
+    end,
+  })
 end
 
 function M.process_varargs(repo, ...)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Automatically resume a pr or open a new one depending on whether one is already in progress


### Does this pull request fix one issue?
Helps #601

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add a new `start_or_resume` function, and bind it to `:Octo review`


### Describe how to verify it
Go to a pr

- With no review started, use the `:Octo review` command
    - See review started and diff opened
- Close review and open same pr (or any pr with a review pending), use the `:Octo review` command
    - See review resumed and diff opened