### PR TITLE
fix(repo parsing): considers cases where git repo has a trailing /

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -149,7 +149,7 @@ function M.parse_remote_url(url, aliases)
   -- if url contains two slashes
   local segments = vim.split(url, "/")
   local host, repo
-  if #segments == 3 or (#segments == 4 and segments[4] == '') then
+  if #segments == 3 or (#segments == 4 and segments[4] == "") then
     host = segments[1]
     repo = segments[2] .. "/" .. segments[3]
   elseif #segments == 2 then

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -149,7 +149,7 @@ function M.parse_remote_url(url, aliases)
   -- if url contains two slashes
   local segments = vim.split(url, "/")
   local host, repo
-  if #segments == 3 then
+  if #segments == 3 or (#segments == 4 and segments[4] == '') then
     host = segments[1]
     repo = segments[2] .. "/" .. segments[3]
   elseif #segments == 2 then


### PR DESCRIPTION


<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

the automatic repository finding (when none passed as args) wouldn't work when the return of `git remote -v` had a trailing '/'. this is reproducible by adding a trailing '/' when cloning a repository

parser would split the lines with '/' as a delimiter. the trailing '/' made the result be an array of length 4 which wasn't considered.

### Does this pull request fix one issue?
Fixes #605 

### Describe how you did it
added condition for when the split segments has a length of 4.

### Describe how to verify it
```bash
git clone https://github.com/pwntester/octo.nvim/ && cd octo.nvim && nvim -c 'Octo issue list'
```

### Special notes for reviews

additional checking that `segment[4] == nil` could be added to ensure this change fixes only this edge case

the opposite approach could be made and use `if #segments > 2` so it becomes the default behavior for more edge cases