### PR TITLE
Add `Octo issue develop` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 | issue    | close                                   | Close the current issue                                                                                                                                |
 |          | reopen                                  | Reopen the current issue                                                                                                                               |
 |          | create [repo]                           | Creates a new issue in the current or specified repo                                                                                                   |
+|          | develop                                 | Create and checkout a new branch for an issue in the current repo                                                                                      |
 |          | edit [repo] <number>                    | Edit issue `<number>` in current or specified repo                                                                                                     |
 |          | list [repo] [key=value] (1)             | List all issues satisfying given filter                                                                                                                |
 |          | search                                  | Live issue search                                                                                                                                      |

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -66,13 +66,12 @@ function M.setup()
         local bufnr = vim.api.nvim_get_current_buf()
         local buffer = octo_buffers[bufnr]
 
-        if not buffer then
+        if buffer and buffer.kind and buffer.kind == "issue" then
+          utils.develop_issue(buffer.node.number)
+        else
           local opts = M.process_varargs(repo, ...)
           picker.issues(opts, true)
-          return
         end
-
-        utils.develop_issue(buffer.node.number)
       end,
       reopen = function()
         M.change_state "OPEN"

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -62,6 +62,18 @@ function M.setup()
       close = function()
         M.change_state "CLOSED"
       end,
+      develop = function(repo, ...)
+        local bufnr = vim.api.nvim_get_current_buf()
+        local buffer = octo_buffers[bufnr]
+
+        if not buffer then
+          local opts = M.process_varargs(repo, ...)
+          picker.issues(opts, true)
+          return
+        end
+
+        utils.develop_issue(buffer.node.number)
+      end,
       reopen = function()
         M.change_state "OPEN"
       end,

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -123,7 +123,25 @@ end
 --
 -- ISSUES
 --
-function M.issues(opts)
+local function open_issue_buffer(prompt_bufnr, type)
+  open(type)(prompt_bufnr)
+end
+
+local function develop_issue(prompt_bufnr, type)
+  local selection = action_state.get_selected_entry(prompt_bufnr)
+  actions.close(prompt_bufnr)
+
+  utils.develop_issue(selection.obj.number)
+end
+
+function M.issues(opts, develop)
+  local replace
+  if develop then
+    replace = develop_issue
+  else
+    replace = open_issue_buffer
+  end
+
   opts = opts or {}
   if not opts.states then
     opts.states = "OPEN"
@@ -172,9 +190,7 @@ function M.issues(opts)
             sorter = conf.generic_sorter(opts),
             previewer = previewers.issue.new(opts),
             attach_mappings = function(_, map)
-              action_set.select:replace(function(prompt_bufnr, type)
-                open(type)(prompt_bufnr)
-              end)
+              action_set.select:replace(replace)
               map("i", cfg.picker_config.mappings.open_in_browser.lhs, open_in_browser())
               map("i", cfg.picker_config.mappings.copy_url.lhs, copy_url())
               return true

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -236,6 +236,22 @@ function M.commit_exists(commit, cb)
   }):start()
 end
 
+function M.develop_issue(issue_number)
+  if not Job then
+    return
+  end
+
+  Job:new({
+    enable_recording = true,
+    command = "gh",
+    args = { "issue", "develop", issue_number, "--checkout" },
+    on_exit = vim.schedule_wrap(function()
+      local output = vim.fn.system "git branch --show-current"
+      M.info("Switched to " .. output)
+    end),
+  }):start()
+end
+
 function M.get_file_at_commit(path, commit, cb)
   if not Job then
     return


### PR DESCRIPTION
Adds `issue develop` command. 

If on issue buffer, the current issue is checked out and the branch is created.
If not, then a picker is shown to select an issue to checkout and create a branch.

NOTE: Only implemented for the telescope picker

Related to #443