### PR TITLE
fix(fzf-lua): when no search result

### DIFF
--- a/lua/octo/pickers/fzf-lua/previewers.lua
+++ b/lua/octo/pickers/fzf-lua/previewers.lua
@@ -53,6 +53,9 @@ M.issue = function(formatted_issues)
   end
 
   function previewer:populate_preview_buf(entry_str)
+    if entry_str == "" then
+      return
+    end
     local tmpbuf = self:get_tmp_buffer()
     local entry = formatted_issues[entry_str]
 
@@ -107,6 +110,9 @@ M.search = function()
   end
 
   function previewer:populate_preview_buf(entry_str)
+    if entry_str == "" then
+      return
+    end
     local tmpbuf = self:get_tmp_buffer()
     local match = string.gmatch(entry_str, "[^%s]+")
     local kind = match()
@@ -163,6 +169,9 @@ M.commit = function(formatted_commits, repo)
   end
 
   function previewer:populate_preview_buf(entry_str)
+    if entry_str == "" then
+      return
+    end
     local tmpbuf = self:get_tmp_buffer()
     local entry = formatted_commits[entry_str]
 
@@ -210,6 +219,9 @@ M.changed_files = function(formatted_files)
   end
 
   function previewer:populate_preview_buf(entry_str)
+    if entry_str == "" then
+      return
+    end
     local tmpbuf = self:get_tmp_buffer()
     local entry = formatted_files[entry_str]
 
@@ -236,6 +248,9 @@ M.review_thread = function(formatted_threads)
   end
 
   function previewer:populate_preview_buf(entry_str)
+    if entry_str == "" then
+      return
+    end
     local tmpbuf = self:get_tmp_buffer()
     local entry = formatted_threads[entry_str]
 
@@ -266,6 +281,9 @@ M.gist = function(formatted_gists)
   end
 
   function previewer:populate_preview_buf(entry_str)
+    if entry_str == "" then
+      return
+    end
     local tmpbuf = self:get_tmp_buffer()
 
     local entry = formatted_gists[entry_str]
@@ -297,6 +315,9 @@ M.repo = function(formatted_repos)
   end
 
   function previewer:populate_preview_buf(entry_str)
+    if entry_str == "" then
+      return
+    end
     local tmpbuf = self:get_tmp_buffer()
     local entry = formatted_repos[entry_str]
 
@@ -346,6 +367,9 @@ M.issue_template = function(formatted_templates)
   end
 
   function previewer:populate_preview_buf(entry_str)
+    if entry_str == "" then
+      return
+    end
     local tmpbuf = self:get_tmp_buffer()
     local entry = formatted_templates[entry_str]
     local template = entry.template.body


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Fzf-lua previewer didn't handle error when no matched result found.

### Does this pull request fix one issue?
Fix https://github.com/pwntester/octo.nvim/issues/611.

### Describe how you did it
Do noting when no matched result found.
