### PR TITLE
fix the :Octo repo url command

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1674,13 +1674,7 @@ function M.copy_url()
   if buffer then
     url = buffer.node.url
   else
-    local host = utils.get_remote_host()
-    local remote_name = utils.get_remote_name()
-    if not host or not remote_name then
-      utils.error "No remote repository found"
-      return
-    end
-    url = "https://" .. host .. "/" .. remote_name
+    url = utils.get_remote_url()
   end
 
   vim.fn.setreg("+", url, "c")

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1669,10 +1669,20 @@ end
 function M.copy_url()
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
-  if not buffer then
-    return
+  local url
+
+  if buffer then
+    url = buffer.node.url
+  else
+    local host = utils.get_remote_host()
+    local remote_name = utils.get_remote_name()
+    if not host or not remote_name then
+      utils.error "No remote repository found"
+      return
+    end
+    url = "https://" .. host .. "/" .. remote_name
   end
-  local url = buffer.node.url
+
   vim.fn.setreg("+", url, "c")
   utils.info("Copied URL '" .. url .. "' to the system clipboard (+ register)")
 end

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -206,6 +206,16 @@ function M.get_remote()
   }
 end
 
+function M.get_remote_url()
+  local host = M.get_remote_host()
+  local remote_name = M.get_remote_name()
+  if not host or not remote_name then
+    M.error "No remote repository found"
+    return
+  end
+  return "https://" .. host .. "/" .. remote_name
+end
+
 function M.get_all_remotes()
   return vim.tbl_values(M.parse_git_remote())
 end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This PR fixes the `:Octo repo url` command. It silently fails when an Octo buffer is not opened, but this command should not require one to get the remote url.

### Does this pull request fix one issue?

Closes https://github.com/pwntester/octo.nvim/issues/628

### Describe how you did it
To fix, I've just used the utility functions `get_remote_host` and `get_remote_name` and concatenation to build out the remote url name, which can be used to get the remote url when an Octo buffer is/is not opened.

### Describe how to verify it

#### When not in a Git repo
- `cd` to a local directory that is not a `git` repository:
- open `neovim`
- run `:Octo repo url`
- verify you see the "No remote repository found" message

#### When in a Git repo that is _not_ tracking a GitHub repository:
- `cd` to a local `git` repository that is tracking a remote GitHub repository:
- open `neovim`
- run `:Octo repo url`
- verify you see the "No remote repository found" message

#### When in a Git repo that _is_ tracking a remote GitHub repository
- `cd` to a local `git` repository that _is_ tracking a remote GitHub repository:
- open `neovim`
- run `:Octo repo url`
- verify you see the "Copied URL <> to the system clipboard (+ register)" message
- verify that when you paste, you see the remote url as contents


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
