### PR TITLE
open remote URL from any buffer w/ :Octo repo browser

### DIFF
--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -33,7 +33,13 @@ function M.open_in_browser(kind, repo, number)
     local bufnr = vim.api.nvim_get_current_buf()
     local buffer = octo_buffers[bufnr]
     if not buffer then
-      return
+      local owner_repo = utils.get_remote_name()
+      if not owner_repo then
+        utils.error "No remote repository found"
+        return
+      end
+      cmd = string.format("gh repo view --web %s", owner_repo)
+      return pcall(vim.cmd, "silent !" .. cmd)
     end
     if buffer:isPullRequest() then
       cmd = string.format("gh pr view --web -R %s/%s %d", remote, buffer.repo, buffer.number)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Similar fix to https://github.com/pwntester/octo.nvim/issues/631, but the `Octo repo browser` command fails unless you are viewing an Octo buffer. These changes just enable this command to work when one is not opened.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Added handling within our `if not buffer` block so that `octo` tries opening the remote repo url using the `utils.get_remote_name` function.

### Describe how to verify it
#### When not in a Git repo
- `cd` to a local directory that is not a `git` repository:
- open `neovim`
- run `:Octo repo browser`
- verify you see the "No remote repository found" message

#### When in a Git repo that is _not_ tracking a GitHub repository:
- `cd` to a local `git` repository that is tracking a remote GitHub repository:
- open `neovim`
- run `:Octo repo browser`
- verify you see the "No remote repository found" message

#### When in a Git repo that _is_ tracking a remote GitHub repository
- `cd` to a local `git` repository that _is_ tracking a remote GitHub repository:
- open `neovim`
- run `:Octo repo browser`
- verify that your default browser opens the GitHub page of the remote repo

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
