### PR TITLE
Add colors based on Issue / PR state

### DIFF
--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -2108,6 +2108,7 @@ query($endCursor: String) {
         title
         url
         repository { nameWithOwner }
+        state
       }
       pageInfo {
         hasNextPage
@@ -2129,6 +2130,7 @@ query($endCursor: String) {
         repository { nameWithOwner }
         headRefName
         isDraft
+        state
       }
       pageInfo {
         hasNextPage
@@ -2148,6 +2150,7 @@ query {
         number
         url
         title
+        state
         repository { nameWithOwner }
       }
       ... on PullRequest {
@@ -2155,6 +2158,8 @@ query {
         number
         title
         url
+        state
+        isDraft
         repository { nameWithOwner }
       }
     }

--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -2109,6 +2109,7 @@ query($endCursor: String) {
         url
         repository { nameWithOwner }
         state
+        stateReason
       }
       pageInfo {
         hasNextPage
@@ -2152,6 +2153,7 @@ query {
         title
         state
         repository { nameWithOwner }
+        stateReason
       }
       ... on PullRequest {
         __typename

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -4,6 +4,24 @@ local utils = require "octo.utils"
 
 local M = {}
 
+--- @class EntryObject
+--- @field state string
+--- @field isDraft boolean
+--- @field stateReason string
+
+--- @class Entry
+--- @field kind string
+--- @field obj EntryObject
+
+--- @class Icon
+--- @field [1] string The icon
+--- @field [2] string|nil The highlight group for the icon
+--- @see octo.ui.colors for the available highlight groups
+
+--- Get the icon for the entry
+--- @param entry Entry: The entry to get the icon for
+--- @return Icon: The icon for the entry
+
 -- Symbols found with "Telescope symbols"
 local icons = {
   issue = {
@@ -21,8 +39,8 @@ local icons = {
 }
 
 --- Get the icon for the entry
----@param entry table: The entry to get the icon for
----@return table: The icon for the entry
+---@param entry Entry: The entry to get the icon for
+---@return Icon: The icon for the entry
 local function get_icon(entry)
   local kind = entry.kind
   local state = entry.obj.state
@@ -74,11 +92,9 @@ function M.gen_from_issue(max_number, print_repo)
         },
       }
     else
-      local icon = get_icon(entry)
-
       columns = {
         { entry.value, "TelescopeResultsNumber" },
-        icon,
+        get_icon(entry),
         { entry.obj.title },
       }
       layout = {

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -24,32 +24,32 @@ local icons = {
 ---@param entry table: The entry to get the icon for
 ---@return table: The icon for the entry
 local function get_icon(entry)
-  local icon
-
   local kind = entry.kind
   local state = entry.obj.state
   local isDraft = entry.obj.isDraft
   local stateReason = entry.obj.stateReason
 
-  if kind == "issue" and state == "OPEN" then
-    icon = icons.issue.open
-  elseif kind == "issue" and state == "CLOSED" and stateReason == "NOT_PLANNED" then
-    icon = icons.issue.not_planned
-  elseif kind == "issue" and state == "CLOSED" then
-    icon = icons.issue.closed
-  elseif kind == "pull_request" and state == "MERGED" then
-    icon = icons.pull_request.merged
-  elseif kind == "pull_request" and state == "CLOSED" then
-    icon = icons.pull_request.closed
-  elseif kind == "pull_request" and isDraft then
-    icon = icons.pull_request.draft
-  elseif kind == "pull_request" and state == "OPEN" then
-    icon = icons.pull_request.open
-  else
-    icon = icons.unknown
+  if kind == "issue" then
+    if state == "OPEN" then
+      return icons.issue.open
+    elseif state == "CLOSED" and stateReason == "NOT_PLANNED" then
+      return icons.issue.not_planned
+    elseif state == "CLOSED" then
+      return icons.issue.closed
+    end
+  elseif kind == "pull_request" then
+    if state == "MERGED" then
+      return icons.pull_request.merged
+    elseif state == "CLOSED" then
+      return icons.pull_request.closed
+    elseif isDraft then
+      return icons.pull_request.draft
+    elseif state == "OPEN" then
+      return icons.pull_request.open
+    end
   end
 
-  return icon
+  return icons.unknown
 end
 
 function M.gen_from_issue(max_number, print_repo)

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -4,6 +4,23 @@ local utils = require "octo.utils"
 
 local M = {}
 
+---@param row table @A row from the issue or pull request list
+---@return string @The highlight group for the icon
+local function get_icon_highlight_group(row)
+  local highlight_group
+  if row.isDraft then
+    highlight_group = "OctoGrey"
+  elseif row.state == "OPEN" then
+    highlight_group = "OctoGreen"
+  elseif row.state == "CLOSED" then
+    highlight_group = "OctoRed"
+  elseif row.state == "MERGED" then
+    highlight_group = "OctoRed"
+  end
+
+  return highlight_group
+end
+
 function M.gen_from_issue(max_number, print_repo)
   local make_display = function(entry)
     if not entry then
@@ -27,14 +44,18 @@ function M.gen_from_issue(max_number, print_repo)
       }
     else
       local icon = entry.kind == "issue" and " " or " "
+      local highlight_group = get_icon_highlight_group(entry.obj)
+
       columns = {
         { entry.value, "TelescopeResultsNumber" },
-        { icon .. " " .. entry.obj.title },
+        { icon, highlight_group },
+        { entry.obj.title },
       }
       layout = {
         separator = " ",
         items = {
           { width = max_number },
+          { width = 2 },
           { remaining = true },
         },
       }

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -4,7 +4,7 @@ local utils = require "octo.utils"
 
 local M = {}
 
-local symbols = {
+local icons = {
   issue = {
     open = { " ", "OctoGreen" },
     closed = { " ", "OctoPurple" },
@@ -31,21 +31,21 @@ local function get_icon(entry)
   local stateReason = entry.obj.stateReason
 
   if kind == "issue" and state == "OPEN" then
-    icon = symbols.issue.open
+    icon = icons.issue.open
   elseif kind == "issue" and state == "CLOSED" and stateReason == "NOT_PLANNED" then
-    icon = symbols.issue.not_planned
+    icon = icons.issue.not_planned
   elseif kind == "issue" and state == "CLOSED" then
-    icon = symbols.issue.closed
+    icon = icons.issue.closed
   elseif kind == "pull_request" and state == "MERGED" then
-    icon = symbols.pull_request.merged
+    icon = icons.pull_request.merged
   elseif kind == "pull_request" and state == "CLOSED" then
-    icon = symbols.pull_request.closed
+    icon = icons.pull_request.closed
   elseif kind == "pull_request" and isDraft then
-    icon = symbols.pull_request.draft
+    icon = icons.pull_request.draft
   elseif kind == "pull_request" and state == "OPEN" then
-    icon = symbols.pull_request.open
+    icon = icons.pull_request.open
   else
-    icon = symbols.unknown
+    icon = icons.unknown
   end
 
   return icon

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -18,10 +18,6 @@ local M = {}
 --- @field [2] string|nil The highlight group for the icon
 --- @see octo.ui.colors for the available highlight groups
 
---- Get the icon for the entry
---- @param entry Entry: The entry to get the icon for
---- @return Icon: The icon for the entry
-
 -- Symbols found with "Telescope symbols"
 local icons = {
   issue = {

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -4,6 +4,7 @@ local utils = require "octo.utils"
 
 local M = {}
 
+-- Symbols found with "Telescope symbols"
 local icons = {
   issue = {
     open = { " ", "OctoGreen" },

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -181,7 +181,6 @@ function M.issues(opts, develop)
         opts.preview_title = opts.preview_title or ""
         opts.prompt_title = opts.prompt_title or ""
         opts.results_title = opts.results_title or ""
-
         pickers
           .new(opts, {
             finder = finders.new_table {

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -181,6 +181,7 @@ function M.issues(opts, develop)
         opts.preview_title = opts.preview_title or ""
         opts.prompt_title = opts.prompt_title or ""
         opts.results_title = opts.results_title or ""
+
         pickers
           .new(opts, {
             finder = finders.new_table {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Using the state, isDraft, stateReason fields from the graphql API to determine the icon and color of the PR or Issue. This should be consistent with the github interface.

This works for `:Octo issue / pr list / search` and `:Octo search`

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Related to #485


### Describe how you did it

- Add state, isDraft, stateReason to the related graphql queries
- Determine the icon and color based on these fields
- Implement for all list and search commands

### Describe how to verify it

Run any of the affected commands and see that the icons will be colored based on the state of the PR or Issue.

### Special notes for reviews

This only effects telescope picker

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt