### PR TITLE
Keep cursor location while reloading

### DIFF
--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -21,8 +21,7 @@ function M.setup()
     group = "octo_autocmds",
     pattern = { "octo://*" },
     callback = function(ev)
-      opts = { bufnr = ev.buf }
-      require("octo").load_buffer(opts)
+      require("octo").load_buffer { bufnr = ev.buf }
     end,
   })
   define({ "BufWriteCmd" }, {

--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -21,7 +21,8 @@ function M.setup()
     group = "octo_autocmds",
     pattern = { "octo://*" },
     callback = function(ev)
-      require("octo").load_buffer(ev.buf)
+      opts = { bufnr = ev.buf }
+      require("octo").load_buffer(opts)
     end,
   })
   define({ "BufWriteCmd" }, {

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -94,9 +94,7 @@ function M.setup()
         picker.search(opts)
       end,
       reload = function()
-        M.reload {
-          verbose = true,
-        }
+        M.reload { verbose = true }
       end,
       browser = function()
         navigation.open_in_browser()

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -94,7 +94,9 @@ function M.setup()
         picker.search(opts)
       end,
       reload = function()
-        M.reload()
+        M.reload {
+          verbose = true,
+        }
       end,
       browser = function()
         navigation.open_in_browser()
@@ -167,7 +169,7 @@ function M.setup()
         picker.search(opts)
       end,
       reload = function()
-        M.reload()
+        M.reload { verbose = true }
       end,
       browser = function()
         navigation.open_in_browser()
@@ -1436,8 +1438,8 @@ function M.remove_project_v2_card()
   end)
 end
 
-function M.reload(bufnr)
-  require("octo").load_buffer(bufnr)
+function M.reload(opts)
+  require("octo").load_buffer(opts)
 end
 
 function random_hex_color()

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -64,12 +64,12 @@ function M.save_buffer()
   buffer:save()
 end
 
----@class Opts
+---@class ReloadOpts
 ---@field bufnr number
 ---@field verbose boolean
 
 --- Load issue/pr/repo buffer
----@param opts Opts
+---@param opts ReloadOpts
 ---@return nil
 function M.load_buffer(opts)
   local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -64,8 +64,16 @@ function M.save_buffer()
   buffer:save()
 end
 
-function M.load_buffer(bufnr)
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
+---@class Opts
+---@field bufnr number
+---@field verbose boolean
+
+--- Load issue/pr/repo buffer
+---@param opts Opts
+---@return nil
+function M.load_buffer(opts)
+  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  local cursor_pos = vim.api.nvim_win_get_cursor(0)
   local bufname = vim.fn.bufname(bufnr)
   local repo, kind, number = string.match(bufname, "octo://(.+)/(.+)/(%d+)")
   if not repo then
@@ -84,6 +92,17 @@ function M.load_buffer(bufnr)
   M.load(repo, kind, number, function(obj)
     vim.api.nvim_buf_call(bufnr, function()
       M.create_buffer(kind, obj, repo, false)
+
+      -- One to the left
+      local new_cursor_pos = {
+        cursor_pos[1],
+        math.max(0, cursor_pos[2] - 1),
+      }
+      vim.api.nvim_win_set_cursor(0, new_cursor_pos)
+
+      if opts.verbose then
+        utils.info(string.format("Loaded %s/%s/%d", repo, kind, number))
+      end
     end)
   end)
 end


### PR DESCRIPTION
Both the `:Octo pr reload` and `:Octo issue reload` will keep the cursor location. There be an info message displayed when the buffer is reloaded.

The `load_buffer` function now accepts a table with bufnr and verbose keys. 

Closes #623
