### PR TITLE
use "comment" over "comments" in review buffer

### DIFF
--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -382,7 +382,9 @@ function FileEntry:place_signs()
 
           -- place the virtual text only on first line
           local last_date = comment.lastEditedAt ~= vim.NIL and comment.lastEditedAt or comment.createdAt
-          local vt_msg = string.format("    %d comments (%s)", #thread.comments.nodes, utils.format_date(last_date))
+          local comments_count = #thread.comments.nodes
+          local comments_word = comments_count == 1 and "comment" or "comments"
+          local vt_msg = string.format("    %d %s (%s)", comments_count, comments_word, utils.format_date(last_date))
           --vim.api.nvim_buf_set_virtual_text(split.bufnr, -1, startLine - 1, { { vt_msg, "Comment" } }, {})
           local opts = {
             virt_text = { { vt_msg, "Comment" } },


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Displays "comment" in review buffer instead of "comments"

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #648

### Describe how you did it


### Describe how to verify it

Make a comment in your review and see that it's displayed as "1 comment" in diff

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
