### PR TITLE
Remove 'Status Column' from README's TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Edit and review GitHub issues and pull requests from the comfort of your favorit
   - [📋 PR reviews](#-pr-reviews)
   - [🍞 Completion](#-completion)
   - [🎨 Colors](#-colors)
-  - [🗿 Status Column](#-status-column)
   - [📺 Demos](#-demos)
   - [🙋 FAQ](#-faq)
   - [🙌 Contributing](#-contributing)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

- There isn't a `Status column` subsection in the README.
- `Status column` is currently a broken link in the README's TOC (table of contents).

### Does this pull request fix one issue?

Fixes #655 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

- I removed the broken link from the README

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
