### PR TITLE
remove extra space from review author bubble

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -531,9 +531,10 @@ function M.write_comment(bufnr, comment, kind, line)
     table.insert(header_vt, { "REVIEW: ", "OctoTimelineItemHeading" })
     --vim.list_extend(header_vt, author_bubble)
     table.insert(header_vt, {
-      comment.author.login .. " ",
+      comment.author.login,
       comment.viewerDidAuthor and "OctoUserViewer" or "OctoUser",
     })
+    table.insert(header_vt, { " ", "OctoTimelineItemHeading" })
     vim.list_extend(header_vt, state_bubble)
     table.insert(header_vt, { " " .. utils.format_date(comment.createdAt), "OctoDate" })
     if not comment.viewerCanUpdate then


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

See extra space in PR > review title:

<img width="881" alt="image" src="https://github.com/user-attachments/assets/a29431d4-6720-4229-a5ca-6357f339ca3c">

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how to verify it

<img width="904" alt="image" src="https://github.com/user-attachments/assets/eb21d470-471b-46cd-ba25-6f81ee064d8b">

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
