### PR TITLE
Add name in user queries

### DIFF
--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -2698,6 +2698,7 @@ query($endCursor: String) {
       nodes {
         id
         login
+        name
       }
     }
   }
@@ -2716,6 +2717,7 @@ query($endCursor: String) {
       nodes {
         id
         login
+        name
       }
     }
   }

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -412,13 +412,25 @@ function M.gen_from_team()
 end
 
 function M.gen_from_user()
+  local function create_name(user, parens)
+    if not user.name or user.name == vim.NIL then
+      return user.login
+    end
+
+    if parens then
+      return user.login .. " (" .. user.name .. ")"
+    end
+
+    return user.login .. user.name
+  end
+
   local make_display = function(entry)
     if not entry then
       return nil
     end
 
     local columns = {
-      { entry.user.login },
+      { create_name(entry.user, true) },
     }
 
     local displayer = entry_display.create {
@@ -438,7 +450,7 @@ function M.gen_from_user()
 
     return {
       value = user.id,
-      ordinal = user.login,
+      ordinal = create_name(user, false),
       display = make_display,
       user = user,
     }

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -815,6 +815,7 @@ local function get_user_requester()
             users[user.login] = {
               id = user.id,
               login = user.login,
+              name = user.name,
             }
           end
         elseif user.teams and user.teams.totalCount > 0 then
@@ -867,6 +868,7 @@ local function get_users(query_name, node_name)
       table.insert(users, {
         id = user.id,
         login = user.login,
+        name = user.name,
       })
     end
   end


### PR DESCRIPTION
This adds the name in parenthesis to the list of users in various commands.
Helps with assigning people's whose logins are not the same as their names and you know name over username

![users](https://github.com/user-attachments/assets/c9e73acb-ee6e-4033-9afe-5703f534fb80)

