### PR TITLE
fix(pickers/telescope): handle nil selection in open

### DIFF
--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -76,7 +76,9 @@ local function open(command)
     elseif command == "tab" then
       vim.cmd [[:tab sb %]]
     end
-    utils.get(selection.kind, selection.repo, selection.value)
+    if selection then
+      utils.get(selection.kind, selection.repo, selection.value)
+    end
   end
 end
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

It may happen that `selection` is `nil`, which results in an error being logged.


### Does this pull request fix one issue?

### Describe how you did it

This silently skips the failing function in such cases.

### Describe how to verify it

Run `Octo pr search` and fiddle around with filtering and navigation

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
