### PR TITLE
fix: handle local filesystem remotes

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -156,6 +156,13 @@ function M.is_blank(s)
 end
 
 function M.parse_remote_url(url, aliases)
+  -- filesystem path
+  if vim.startswith(url, "/") or vim.startswith(url, ".") then
+    return {
+      host = nil,
+      repo = url,
+    }
+  end
   -- remove trailing ".git"
   url = string.gsub(url, ".git$", "")
   -- remove protocol scheme
@@ -616,7 +623,7 @@ function M.get_repo_number_from_varargs(...)
     return
   end
   if not repo then
-    M.error "Cant find repo name"
+    M.error "Can not find repo name"
     return
   end
   if not number then


### PR DESCRIPTION
### Describe what this PR does / why we need it

Absolute and relative filesystem paths are also valid remote urls. Using them on a repo results in an error when listing PRs.

### Does this pull request fix one issue?

### Describe how you did it

Set `host = nil` and `repo = url` when remote url starts with `/` or `.`.

### Describe how to verify it

```
$ git remote add foo ${HOME}/somepath
:Octo pr list
:Octo pr search
```

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
