### PR TITLE
differentiate between failing and missing actions in error message

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -434,8 +434,13 @@ function M.octo(object, action, ...)
     end
 
     local a = o[action] or o
-    if not pcall(a, ...) then
+    if not a then
       utils.error(action and "Incorrect action: " .. action or "No action specified")
+      return
+    end
+    res = pcall(a, ...)
+    if not res then
+      utils.error(action and "Failed action: " .. action)
       return
     end
   end


### PR DESCRIPTION
### Describe what this PR does / why we need it

If an error is thrown during an action, an error is logged with the message `Incorrect action: $action`. This is the same error message as for actually missing commands.

This is confusing and adds friction for debugging.


### Does this pull request fix one issue?

### Describe how you did it

Differentiate between missing and failing actions and log them differently.

### Describe how to verify it


### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
