### PR TITLE
feat: match patterns in ssh_aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ require"octo".setup({
   enable_builtin = false,                  -- shows a list of builtin actions when no action is provided
   default_remote = {"upstream", "origin"}; -- order to try remotes
   default_merge_method = "commit",         -- default merge method which should be used when calling `Octo pr merge`, could be `commit`, `rebase` or `squash`
-  ssh_aliases = {},                        -- SSH aliases. e.g. `ssh_aliases = {["github.com-work"] = "github.com"}`
+  ssh_aliases = {},                        -- SSH aliases. e.g. `ssh_aliases = {["github.com-work"] = "github.com"}`. The key part will be interpreted as an anchored Lua pattern.
   picker = "telescope",                    -- or "fzf-lua"
   picker_config = {
     use_emojis = false,                    -- only used by "fzf-lua" picker for now
@@ -411,7 +411,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 - `<CR>`: Append Gist to buffer
   [Available keys](https://cli.github.com/manual/gh_gist_list): `repo`\|`public`\|`secret`
 
-5. Users in the assignee and reviewer commands: 
+5. Users in the assignee and reviewer commands:
 
 - `search`: Dynamically search all GitHub users
 - `mentionable`: List of *mentionable* users in current repo

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -174,8 +174,8 @@ function M.parse_remote_url(url, aliases)
     repo = chunks[#chunks]
   end
 
-  if aliases[host] then
-    host = aliases[host]
+  for alias, rhost in pairs(aliases) do
+    host = host:gsub("^" .. alias .. "$", rhost, 1)
   end
   if not M.is_blank(host) and not M.is_blank(repo) then
     return {

--- a/lua/tests/plenary/utils_spec.lua
+++ b/lua/tests/plenary/utils_spec.lua
@@ -10,9 +10,11 @@ describe("Utils module:", function()
         "git@github.com:pwntester/octo.nvim.git",
         "git@github.com:pwntester/octo.nvim.git",
         "hub.com:pwntester/octo.nvim.git",
+        "hub.com-alias:pwntester/octo.nvim.git",
       }
       local aliases = {
         ["hub.com"] = "github.com",
+        ["hub.com-.*"] = "github.com",
       }
       eq(this.parse_remote_url(remote_urls[1], aliases).host, "github.com")
       eq(this.parse_remote_url(remote_urls[1], aliases).repo, "pwntester/octo.nvim")
@@ -24,6 +26,8 @@ describe("Utils module:", function()
       eq(this.parse_remote_url(remote_urls[4], aliases).repo, "pwntester/octo.nvim")
       eq(this.parse_remote_url(remote_urls[5], aliases).host, "github.com")
       eq(this.parse_remote_url(remote_urls[5], aliases).repo, "pwntester/octo.nvim")
+      eq(this.parse_remote_url(remote_urls[6], aliases).host, "github.com")
+      eq(this.parse_remote_url(remote_urls[6], aliases).repo, "pwntester/octo.nvim")
     end)
 
     it("convert_vim_mapping_to_fzf changes vim mappings to fzf mappings", function()


### PR DESCRIPTION
### Describe what this PR does / why we need it

Some people may use "dynamic" remote hosts like `github.com-foo`, `github.com-bar`, etc. Having to additionally add each as an explicit `ssh_aliases` entry can become a chore.


### Does this pull request fix one issue?

### Describe how you did it

Interpret keys in `ssh_alieses` configuration as [Lua patterns](https://lua.org/pil/20.1.html). This allows an alias like `github\.com-.*`.


### Describe how to verify it

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
