### PR TITLE
Fix #564: Improve error checking logic

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -102,10 +102,10 @@ function M.setup()
       end
       if use_proj_v2 then
         if M.has_scope { "read:project", "project" } then
-          require("octo.utils").info "Using projects v2"
+          require("octo.utils").info "Using Projects v2"
           _G.octo_pv2_fragment = fragments.projects_v2_fragment
         elseif not config.values.suppress_missing_scope.projects_v2 then
-          require("octo.utils").info "Cannot request projects v2, missing scope 'read:project'"
+          require("octo.utils").error "Cannot request Projects v2: Missing scope 'read:project' or 'project'"
         end
       end
     end),

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -100,10 +100,13 @@ function M.setup()
       for idx, split_scope in ipairs(split) do
         scopes[idx] = string.gsub(split_scope, "'", "")
       end
-      if M.has_scope { "read:project", "project" } and use_proj_v2 then
-        _G.octo_pv2_fragment = fragments.projects_v2_fragment
-      elseif not config.values.suppress_missing_scope.projects_v2 then
-        require("octo.utils").info "Cannot request projects v2, missing scope 'read:project'"
+      if use_proj_v2 then
+        if M.has_scope { "read:project", "project" } then
+          require("octo.utils").info "Using projects v2"
+          _G.octo_pv2_fragment = fragments.projects_v2_fragment
+        elseif not config.values.suppress_missing_scope.projects_v2 then
+          require("octo.utils").info "Cannot request projects v2, missing scope 'read:project'"
+        end
       end
     end),
   }):start()


### PR DESCRIPTION
### Describe what this PR does / why we need it

Improves the error handling and user notifications when the user does not want to use Projects v2 by default, i.e., when not setting the `default_to_projects_v2` config option or setting it to `false`.

In the current code users see an unexpected error message about missing `gh` token scopes in two different scenarios:

1. They did not enable `default_to_projects_v2` and they do not have the `read:project` or the `project` scopes in their `gh` token
2.  They do have either the `read:project` or the `project` scope in their `gh` token but have not set the `default_to_projects_v2` or have set it to `false`.

In other words: They will always receive an error message if `default_to_projects_v2` is disabled.

They should only recive an error message if they enable `default_to_projects_v2` and do not have one of the necessary scopes in their token.

The PR changes the logic in the check such that it only checks for token scopes if the user actually enables `default_to_projects_v2`.

I believe this change makes the "how to suppress the error" part in the corresponding section in the FAQ unnecessary, but I'm not sure. Please let me know if this assumption is correct, and I will update the README as part of this PR.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #564

### Describe how you did it

Changed a conditional checking both `default_to_projects_v2` and token set conditions (using `and`) to instead check for `default_to_projects_v2` first. If that is not set to `true` then we don't need to check for scopes.

### Describe how to verify it

1. Do not set `default_to_projects_v2` or set it to `false` in the Octo config. Ensure that the `project` and `read:project` scopes are _not_ set. Load the plugin and confirm that no error message is shown.
4. Like 1, but set one of the scopes.
5. Set `default_to_projects_v2` to `true`. Ensure that the `project` and `read:project` scopes are _not_ set. Load the plugin and confirm that an error message is shown.
6. Set `default_to_projects_v2` to `true`. Ensure that the `project` and `read:project` scopes are set. Load the plugin and confirm that an error message is _not_ shown.

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
