### PR TITLE
display auto-merge in pr view

### DIFF
--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -1873,6 +1873,10 @@ query($endCursor: String) {
       }
       mergeStateStatus
       mergeable
+      autoMergeRequest {
+        enabledBy { login }
+        mergeMethod
+      }
     }
   }
 }

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -491,6 +491,17 @@ function M.write_details(bufnr, issue, update)
       table.insert(details, merge_state_vt)
     end
 
+    if not issue.merged and issue.autoMergeRequest ~= vim.NIL then
+      local auto_merge_vt = {
+        { "Auto-merge: ", "OctoDetailsLabel" },
+        { "ENABLED", "OctoStateApproved" },
+        { " by " },
+        { issue.autoMergeRequest.enabledBy.login, "OctoUser" },
+        { " (" .. utils.auto_merge_method_map[issue.autoMergeRequest.mergeMethod] .. ")" },
+      }
+      table.insert(details, auto_merge_vt)
+    end
+
     -- changes
     local changes_vt = {
       { "Commits: ", "OctoDetailsLabel" },

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -121,6 +121,12 @@ M.merge_state_message_map = {
   UNSTABLE = "! UNSTABLE",
 }
 
+M.auto_merge_method_map = {
+  MERGE = "commit",
+  REBASE = "rebase",
+  SQUASH = "squash",
+}
+
 function M.trim(str)
   if type(vim.fn.trim) == "function" then
     return vim.fn.trim(str)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Displays "Auto-merge" section for PR if it was enabled, it's nice to see if I need to merge PR or it's already scheduled for auto-merge.

<img width="751" alt="image" src="https://github.com/user-attachments/assets/d7cdcc6b-4907-477b-9cc5-45c15221529b">


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how to verify it

Apply auto-merge to blocked PR with `gh pr merge --auto` and see this section.

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
