### PR TITLE
pr display: fix collecting review states per reviewer

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -380,19 +380,15 @@ function M.write_details(bufnr, issue, update)
     -- reviewers
     local reviewers = {}
     local collect_reviewer = function(name, state)
-      --if vim.g.octo_viewer ~= name then
       if not reviewers[name] then
-        if not reviewers[name] then
-          reviewers[name] = { state }
-        else
-          local states = reviewers[name]
-          if not vim.tbl_contains(states, state) then
-            table.insert(states, state)
-          end
-          reviewers[name] = states
+        reviewers[name] = { state }
+      else
+        local states = reviewers[name]
+        if not vim.tbl_contains(states, state) then
+          table.insert(states, state)
         end
+        reviewers[name] = states
       end
-      -- end
     end
     local timeline_nodes = {}
     for _, item in ipairs(issue.timelineItems.nodes) do


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

before this PR if reviewer commented first and then approved PR, he will still be displayed with "commented" state in "Reviewers" section because review states weren't collected

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how to verify it

now if you comment/request changes and then approve PR, you'll be displayed with "approved" state

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
