### PR TITLE
chore(ci): set stylua action version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,3 +12,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --check lua/
+          version: latest


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fixes failing stylua action check.

### Describe how you did it

Set `version` field of stylua-action, in accordance with usage: https://github.com/JohnnyMorganz/stylua-action#usage.

### Describe how to verify it

Take a look at current commits in `master` and recently open PRs. They are failing the stylua action check. This PR is not failing that check.

### Special notes for reviews

I'm not sure if `latest` actually makes sense here. Just picked a working value.

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
