### PR TITLE
Smaller number padding for repo specific searches

### DIFF
--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -2151,6 +2151,14 @@ query($endCursor: String) {
 }
 ]]
 
+M.search_count_query = [[
+query {
+  search(query: """%s""", type: ISSUE, last: 100) {
+    issueCount
+  }
+}
+]]
+
 M.search_query = [[
 query {
   search(query: """%s""", type: ISSUE, last: 100) {

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -502,15 +502,22 @@ end
 ---
 -- SEARCH
 ---
+
 local function get_search_query(prompt)
-  local query = prompt[1]
-  local parts = vim.split(query, " ")
+  local full_prompt = prompt[1]
+  local parts = vim.split(full_prompt, " ")
   for _, part in ipairs(parts) do
-    if string.match(part, "repo:") then
-      return part
+    if string.match(part, "^repo:") then
+      return {
+        single_repo = true,
+        prompt = part,
+      }
     end
   end
-  return query
+  return {
+    single_repo = false,
+    prompt = full_prompt,
+  }
 end
 
 local function get_search_size(prompt)
@@ -530,10 +537,10 @@ function M.search(opts)
     opts.prompt = { opts.prompt }
   end
 
-  local search_prompt = get_search_query(opts.prompt)
+  local search = get_search_query(opts.prompt)
   local width = 6
-  if search_prompt:match "repo:" then
-    local num_results = get_search_size(search_prompt)
+  if search.single_repo then
+    local num_results = get_search_size(search.prompt)
     width = math.min(#tostring(num_results), width)
   end
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

The large amount of padding for `Octo search` is now gone when doing *repo specific* search queries.

```
# Repo specific defined by repo:owner/repo
:Octo search repo:microsoft/vscode label:bug # takes min of 6 and the digits from number of issues in the repo
:Octo search is:issue repo:pwntester/octo.nvim label:bug # takes min of 6 and the digits from number of issues in the repo
```
![repo-specific](https://github.com/user-attachments/assets/eaac43c4-307a-430d-834f-210d9525828d)

Same for non-repo specific queries

```
# Non-repo specific will default to 6
:Octo search is:issue label:bug
:Octo search -repo:pwntester/octo.nvim octo.nvim in:body
```
![non-repo-specific](https://github.com/user-attachments/assets/a75cce3a-a378-467b-a208-7c8a3b38a1a8)


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Added a second query to get the number of issues (and PRs) for the repo

### Describe how to verify it

Check out any of the examples above with the telescope picker

### Special notes for reviews

Only for the telescope picker

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt