### PR TITLE
Add missing title renaming event

### DIFF
--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -1739,6 +1739,12 @@ query($endCursor: String) {
             viewerCanUpdate
             viewerCanDelete
           }
+          ... on RenamedTitleEvent {
+            actor { login }
+            createdAt
+            previousTitle
+            currentTitle
+          }
           ... on PullRequestReview {
             id
             body

--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -2005,6 +2005,12 @@ query($endCursor: String) {
             }
             createdAt
           }
+          ... on RenamedTitleEvent {
+            actor { login }
+            createdAt
+            previousTitle
+            currentTitle
+          }
         }
       }
       labels(first: 20) {

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -211,6 +211,9 @@ function OctoBuffer:render_issue()
     elseif item.__typename == "ReviewDismissedEvent" then
       writers.write_review_dismissed_event(self.bufnr, item)
       prev_is_event = true
+    elseif item.__typename == "RenamedTitleEvent" then
+      writers.write_renamed_title_event(self.bufnr, item)
+      prev_is_event = true
     end
   end
   if prev_is_event then

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -64,6 +64,7 @@ local function get_hl_groups()
     NormalFront = { fg = get_fg "Normal" or colors.white },
     Viewer = { fg = colors.black, bg = colors.blue },
     Editable = { bg = float_bg },
+    Strikethrough = { fg = colors.grey, gui = "strikethrough" },
   }
 end
 

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -1323,6 +1323,29 @@ function M.write_commit_event(bufnr, item)
   write_event(bufnr, vt)
 end
 
+function M.write_renamed_title_event(bufnr, item)
+  local vt = {}
+  local conf = config.values
+  table.insert(vt, { conf.timeline_marker .. " ", "OctoTimelineMarker" })
+  table.insert(vt, { "EVENT: ", "OctoTimelineItemHeading" })
+  if utils.is_blank(item.actor) then
+    table.insert(vt, { "Title renamed", "OctoTimelineItemHeading" })
+    write_event(bufnr, vt)
+    return
+  end
+
+  table.insert(vt, {
+    item.actor.login,
+    item.actor.login == vim.g.octo_viewer and "OctoUserViewer" or "OctoUser",
+  })
+  table.insert(vt, { " renamed from ", "OctoTimelineItemHeading" })
+  table.insert(vt, { item.previousTitle, "OctoDetailsLabel" })
+  table.insert(vt, { " to ", "OctoTimelineItemHeading" })
+  table.insert(vt, { item.currentTitle, "OctoDetailsLabel" })
+  table.insert(vt, { " " .. utils.format_date(item.createdAt), "OctoDate" })
+  write_event(bufnr, vt)
+end
+
 function M.write_merged_event(bufnr, item)
   -- local actor_bubble = bubbles.make_user_bubble(
   --   item.actor.login,

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -1338,9 +1338,9 @@ function M.write_renamed_title_event(bufnr, item)
     item.actor.login,
     item.actor.login == vim.g.octo_viewer and "OctoUserViewer" or "OctoUser",
   })
-  table.insert(vt, { " renamed from ", "OctoTimelineItemHeading" })
-  table.insert(vt, { item.previousTitle, "OctoDetailsLabel" })
-  table.insert(vt, { " to ", "OctoTimelineItemHeading" })
+  table.insert(vt, { " changed the title ", "OctoTimelineItemHeading" })
+  table.insert(vt, { item.previousTitle, "OctoStrikethrough" })
+  table.insert(vt, { " ", "OctoTimelineItemHeading" })
   table.insert(vt, { item.currentTitle, "OctoDetailsLabel" })
   table.insert(vt, { " " .. utils.format_date(item.createdAt), "OctoDate" })
   write_event(bufnr, vt)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Title renaming events are now in the issues and pr buffers

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Related to #680

### Describe how you did it

Three steps: 

- Change to graphql query to get the title renaming events
- Add some parsing to render
- Add writer 

### Describe how to verify it

Can view in prs like this one or like #635 

Or in Issues like #680


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt