### PR TITLE
Use plenary sync job to get local file content

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -342,13 +342,10 @@ function M.get_file_at_commit(path, commit, cb)
     enable_recording = true,
     command = "git",
     args = { "show", string.format("%s:%s", commit, path) },
-    on_exit = vim.schedule_wrap(function(j_self, _, _)
-      local output = table.concat(j_self:result(), "\n")
-      local stderr = table.concat(j_self:stderr_result(), "\n")
-      cb(vim.split(output, "\n"), vim.split(stderr, "\n"))
-    end),
   }
-  job:start()
+  local result = job:sync()
+  local output = table.concat(result, "\n")
+  cb(vim.split(output, "\n"))
 end
 
 function M.in_pr_repo()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Fixes #608


I gave up on trying to troubleshoot async plenary, and switched to sync, this fixes the empty diff buffer for local mode that is quite hard to reproduce.
Since this is a local git command, and, impact should be minimal, and the only caller of this function waits for the job to be done anyway by calling vim.wait on a condition that is done by the callback