### PR TITLE
Support label multiselection

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1501,6 +1501,22 @@ function M.create_label(label)
   }
 end
 
+local function format(str)
+  return string.format('"%s"', str)
+end
+
+local function create_list(values, fmt)
+  if type(values) == "string" then
+    return fmt(values)
+  end
+
+  local formatted_values = {}
+  for _, value in ipairs(values) do
+    table.insert(formatted_values, fmt(value))
+  end
+  return "[" .. table.concat(formatted_values, ", ") .. "]"
+end
+
 local function label_action(opts)
   local label = opts.label
 
@@ -1515,8 +1531,13 @@ local function label_action(opts)
     utils.error "Cannot get issue/pr id"
   end
 
-  local cb = function(label_id)
-    local query = graphql(opts.query_name, iid, label_id)
+  local cb = function(labels)
+    local label_ids = {}
+    for _, lbl in ipairs(labels) do
+      table.insert(label_ids, lbl.id)
+    end
+
+    local query = graphql(opts.query_name, iid, create_list(label_ids, format))
     gh.run {
       args = { "api", "graphql", "-f", string.format("query=%s", query) },
       cb = function(output, stderr)

--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -2530,7 +2530,7 @@ M.create_label_mutation = [[
 -- https://docs.github.com/en/graphql/reference/mutations#removelabelsfromlabelable
 M.add_labels_mutation = [[
   mutation {
-    addLabelsToLabelable(input: {labelableId: "%s", labelIds: ["%s"]}) {
+    addLabelsToLabelable(input: {labelableId: "%s", labelIds: %s}) {
       labelable {
         ... on Issue {
           id
@@ -2546,7 +2546,7 @@ M.add_labels_mutation = [[
 -- https://docs.github.com/en/graphql/reference/mutations#removelabelsfromlabelable
 M.remove_labels_mutation = [[
   mutation {
-    removeLabelsFromLabelable(input: {labelableId: "%s", labelIds: ["%s"]}) {
+    removeLabelsFromLabelable(input: {labelableId: "%s", labelIds: %s}) {
       labelable {
         ... on Issue {
           id

--- a/lua/octo/pickers/fzf-lua/pickers/assigned_labels.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/assigned_labels.lua
@@ -51,10 +51,12 @@ return function(cb)
       },
       actions = {
         ["default"] = function(selected)
+          local labels = {}
           for _, row in ipairs(selected) do
             local id, _ = unpack(vim.split(row, " "))
-            cb(id)
+            table.insert(labels, { id = id })
           end
+          cb(labels)
         end,
       },
     })

--- a/lua/octo/pickers/fzf-lua/pickers/labels.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/labels.lua
@@ -44,10 +44,12 @@ return function(cb)
       },
       actions = {
         ["default"] = function(selected)
+          local labels = {}
           for _, row in ipairs(selected) do
             local id, _ = unpack(vim.split(row, " "))
-            cb(id)
+            table.insert(labels, { id = id })
           end
+          cb(labels)
         end,
       },
     })

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -741,6 +741,30 @@ end
 --
 -- LABELS
 --
+
+local function select(opts)
+  local prompt_bufnr = opts.bufnr
+  local single_cb = opts.single_cb
+  local multiple_cb = opts.multiple_cb
+
+  local picker = action_state.get_current_picker(prompt_bufnr)
+  local selections = picker:get_multi_selection()
+  local cb
+  local labels = {}
+  if #selections == 0 then
+    local selected_label = action_state.get_selected_entry(prompt_bufnr)
+    table.insert(labels, selected_label.label)
+    cb = single_cb
+  else
+    for _, selection in ipairs(selections) do
+      table.insert(labels, selection.label)
+    end
+    cb = multiple_cb
+  end
+  actions.close(prompt_bufnr)
+  cb(labels)
+end
+
 function M.select_label(cb)
   local opts = vim.deepcopy(dropdown_opts)
   local bufnr = vim.api.nvim_get_current_buf()
@@ -767,9 +791,7 @@ function M.select_label(cb)
             sorter = conf.generic_sorter(opts),
             attach_mappings = function(_, _)
               actions.select_default:replace(function(prompt_bufnr)
-                local selected_label = action_state.get_selected_entry(prompt_bufnr)
-                actions.close(prompt_bufnr)
-                cb(selected_label.label.id)
+                select { bufnr = prompt_bufnr, single_cb = cb, multiple_cb = cb }
               end)
               return true
             end,
@@ -812,9 +834,7 @@ function M.select_assigned_label(cb)
             sorter = conf.generic_sorter(opts),
             attach_mappings = function(_, _)
               actions.select_default:replace(function(prompt_bufnr)
-                local selected_label = action_state.get_selected_entry(prompt_bufnr)
-                actions.close(prompt_bufnr)
-                cb(selected_label.label.id)
+                select { bufnr = prompt_bufnr, single_cb = cb, multiple_cb = cb }
               end)
               return true
             end,

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -746,23 +746,24 @@ local function select(opts)
   local prompt_bufnr = opts.bufnr
   local single_cb = opts.single_cb
   local multiple_cb = opts.multiple_cb
+  local get_item = opts.get_item
 
   local picker = action_state.get_current_picker(prompt_bufnr)
   local selections = picker:get_multi_selection()
   local cb
-  local labels = {}
+  local items = {}
   if #selections == 0 then
-    local selected_label = action_state.get_selected_entry(prompt_bufnr)
-    table.insert(labels, selected_label.label)
+    local selection = action_state.get_selected_entry(prompt_bufnr)
+    table.insert(items, get_item(selection))
     cb = single_cb
   else
     for _, selection in ipairs(selections) do
-      table.insert(labels, selection.label)
+      table.insert(items, get_item(selection))
     end
     cb = multiple_cb
   end
   actions.close(prompt_bufnr)
-  cb(labels)
+  cb(items)
 end
 
 function M.select_label(cb)
@@ -791,7 +792,14 @@ function M.select_label(cb)
             sorter = conf.generic_sorter(opts),
             attach_mappings = function(_, _)
               actions.select_default:replace(function(prompt_bufnr)
-                select { bufnr = prompt_bufnr, single_cb = cb, multiple_cb = cb }
+                select {
+                  bufnr = prompt_bufnr,
+                  single_cb = cb,
+                  multiple_cb = cb,
+                  get_item = function(selection)
+                    return selection.label
+                  end,
+                }
               end)
               return true
             end,
@@ -834,7 +842,14 @@ function M.select_assigned_label(cb)
             sorter = conf.generic_sorter(opts),
             attach_mappings = function(_, _)
               actions.select_default:replace(function(prompt_bufnr)
-                select { bufnr = prompt_bufnr, single_cb = cb, multiple_cb = cb }
+                select {
+                  bufnr = prompt_bufnr,
+                  single_cb = cb,
+                  multiple_cb = cb,
+                  get_item = function(selection)
+                    return selection.label
+                  end,
+                }
               end)
               return true
             end,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Allows user to allow multiselect for adding and removing labels

Related to #675


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

- Adapt the graphql command to pass list of labelIds
- Generalize telescope logic to grab multiple selection and check if non-empty
- Use callback on list of labels including list of single label

### Describe how to verify it

For telescope, use `<Tab>` to select multiple labels (while adding or removing) then press enter to confirm. If Tab is not pressed, then the behavior will be the same as before.

### Special notes for reviews

Telescope only. However, fzf had support before but the cb was changed to support batch label add.

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt