### PR TITLE
fix: replace vim.error with utils.error

### DIFF
--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -90,7 +90,7 @@ function Review:resume()
     end
 
     if self.id == default_id then
-      vim.error "No pending reviews found for viewer"
+      utils.error "No pending reviews found for viewer"
       return
     end
 
@@ -201,7 +201,7 @@ function Review:discard()
     args = { "api", "graphql", "-f", string.format("query=%s", query) },
     cb = function(output, stderr)
       if stderr and not utils.is_blank(stderr) then
-        vim.error(stderr)
+        utils.error(stderr)
       elseif output then
         local resp = vim.fn.json_decode(output)
         if #resp.data.repository.pullRequest.reviews.nodes == 0 then
@@ -217,7 +217,7 @@ function Review:discard()
             args = { "api", "graphql", "-f", string.format("query=%s", delete_query) },
             cb = function(output_inner, stderr_inner)
               if stderr_inner and not utils.is_blank(stderr_inner) then
-                vim.error(stderr_inner)
+                utils.error(stderr_inner)
               elseif output_inner then
                 self.id = default_id
                 self.threads = {}


### PR DESCRIPTION
Fixes #739

- replace vim.error with utils.error in review:discard and review:resume

`vim.error` call leftovers are being replaced with `utils.error` call to avoid the error

https://github.com/user-attachments/assets/41d0de39-9642-4959-b253-f139aa75c923

