### PR TITLE
Wrapper to support parameterized queries

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -218,6 +218,9 @@ local create_graphql_args = function(query, fields, paginate, slurp, jq)
   return args
 end
 
+---Run a graphql query
+---@param opts table the options for the graphql query
+---@return table
 function M.graphql(opts)
   local run_opts = opts.opts or {}
   return M.run {

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -218,7 +218,7 @@ local create_graphql_args = function(query, fields, paginate, slurp, jq)
   return args
 end
 
-function M.query(opts)
+function M.graphql(opts)
   local run_opts = opts.opts or {}
   return M.run {
     args = create_graphql_args(opts.query, opts.fields, opts.paginate, opts.slurp, opts.jq),

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -195,6 +195,7 @@ end
 local create_graphql_args = function(query, fields, paginate, slurp, jq)
   local args = { "api", "graphql" }
 
+  fields = fields or {}
   local formatted_fields = format_fields(fields)
   for _, field in ipairs(formatted_fields) do
     table.insert(args, field)

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -173,4 +173,54 @@ function M.run(opts)
   end
 end
 
+---Format fields for the graphql query
+---@param fields table key value pairs for graphql query
+---@return table
+local format_fields = function(fields)
+  local formatted_fields = {}
+  for key, value in pairs(fields) do
+    table.insert(formatted_fields, "-F")
+    table.insert(formatted_fields, key .. "=" .. value)
+  end
+  return formatted_fields
+end
+
+---Create the arguments for the graphql query
+---@param query string the graphql query
+---@param fields table key value pairs for graphql query
+---@param paginate boolean whether to paginate the results
+---@param slurp boolean whether to slurp the results
+---@return table
+local create_graphql_args = function(query, fields, paginate, slurp)
+  local args = { "api", "graphql" }
+
+  local formatted_fields = format_fields(fields)
+  for _, field in ipairs(formatted_fields) do
+    table.insert(args, field)
+  end
+  table.insert(args, "-f")
+  table.insert(args, string.format("query=%s", query))
+
+  if paginate then
+    table.insert(args, "--paginate")
+  end
+
+  if slurp then
+    table.insert(args, "--slurp")
+  end
+  return args
+end
+
+function M.query(opts)
+  local run_opts = opts.opts or {}
+  return M.run {
+    args = create_graphql_args(opts.query, opts.fields, opts.paginate, opts.slurp),
+    mode = run_opts.mode,
+    cb = run_opts.cb,
+    stream_cb = run_opts.stream_cb,
+    headers = run_opts.headers,
+    hostname = run_opts.hostname,
+  }
+end
+
 return M

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -190,8 +190,9 @@ end
 ---@param fields table key value pairs for graphql query
 ---@param paginate boolean whether to paginate the results
 ---@param slurp boolean whether to slurp the results
+---@param jq string the jq query to apply to the results
 ---@return table
-local create_graphql_args = function(query, fields, paginate, slurp)
+local create_graphql_args = function(query, fields, paginate, slurp, jq)
   local args = { "api", "graphql" }
 
   local formatted_fields = format_fields(fields)
@@ -208,13 +209,19 @@ local create_graphql_args = function(query, fields, paginate, slurp)
   if slurp then
     table.insert(args, "--slurp")
   end
+
+  if jq then
+    table.insert(args, "--jq")
+    table.insert(args, jq)
+  end
+
   return args
 end
 
 function M.query(opts)
   local run_opts = opts.opts or {}
   return M.run {
-    args = create_graphql_args(opts.query, opts.fields, opts.paginate, opts.slurp),
+    args = create_graphql_args(opts.query, opts.fields, opts.paginate, opts.slurp, opts.jq),
     mode = run_opts.mode,
     cb = run_opts.cb,
     stream_cb = run_opts.stream_cb,

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -90,7 +90,7 @@ function Review:resume()
     end
 
     if self.id == default_id then
-      vim.error "No pending reviews found for viewer"
+      utils.error "No pending reviews found for viewer"
       return
     end
 
@@ -201,7 +201,7 @@ function Review:discard()
     args = { "api", "graphql", "-f", string.format("query=%s", query) },
     cb = function(output, stderr)
       if stderr and not utils.is_blank(stderr) then
-        vim.error(stderr)
+        utils.error(stderr)
       elseif output then
         local resp = vim.fn.json_decode(output)
         if #resp.data.repository.pullRequest.reviews.nodes == 0 then
@@ -217,7 +217,7 @@ function Review:discard()
             args = { "api", "graphql", "-f", string.format("query=%s", delete_query) },
             cb = function(output_inner, stderr_inner)
               if stderr_inner and not utils.is_blank(stderr_inner) then
-                vim.error(stderr_inner)
+                utils.error(stderr_inner)
               elseif output_inner then
                 self.id = default_id
                 self.threads = {}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Wrapper function around gh.run in order to support parameterized queries. Also makes it more transparent what fields are being passed to the queries.

```lua
local gh = require "octo.gh"

local lastest_issue_query = [[
query($owner: String!, $repo: String!, $num_issues: Int!) {
  repository(owner: $owner, name: $repo) {
    issues(last: $num_issues) {
      nodes {
        title
      }
    }
  }
}
]]

local result = gh.graphql {
  query = lastest_issue_query,
  fields = {
    owner = "pwntester",
    repo = "octo.nvim",
    num_issues = 5,
  }, 
  jq = ".data.repository.issues.nodes | map(.title)",
  opts = {
    mode = "sync",
  }
}
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Wrapper function around gh.run and parsing of fields to support parameterized queries.

### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt