### PR TITLE
fix: trim off .git from remote url properly

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -210,7 +210,7 @@ function M.parse_remote_url(url, aliases)
     }
   end
   -- remove trailing ".git"
-  url = string.gsub(url, ".git$", "")
+  url = string.gsub(url, "%.git$", "")
   -- remove protocol scheme
   url = string.gsub(url, "^[^:]+://", "")
   -- remove user


### PR DESCRIPTION
### Describe what this PR does / why we need it
We were attempting to trim off the .git from the remote url to get the
remote repo name with owner. However, when the repo name ended with git,
that part of the repo name was trimmed off, e.g. cmp-git became cmp.
This properly escapes the `.` to only trim off `.git`.

