### PR TITLE
Add self-assigned to UI

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -1307,8 +1307,12 @@ function M.write_assigned_event(bufnr, item)
   table.insert(vt, { "EVENT: ", "OctoTimelineItemHeading" })
   --vim.list_extend(vt, actor_bubble)
   table.insert(vt, { item.actor.login, item.actor.login == vim.g.octo_viewer and "OctoUserViewer" or "OctoUser" })
-  table.insert(vt, { " assigned this to ", "OctoTimelineItemHeading" })
-  table.insert(vt, { item.assignee.login or item.assignee.name, "OctoDetailsLabel" })
+  if item.actor.login == item.assignee.login then
+    table.insert(vt, { " self-assigned this", "OctoTimelineItemHeading" })
+  else
+    table.insert(vt, { " assigned this to ", "OctoTimelineItemHeading" })
+    table.insert(vt, { item.assignee.login or item.assignee.name, "OctoDetailsLabel" })
+  end
   table.insert(vt, { " " .. utils.format_date(item.createdAt), "OctoDate" })
   write_event(bufnr, vt)
 end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

When the actor and assignee are the same, the writer will say "self-assigned this"


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Case in the writer for self-assigned

### Describe how to verify it

Look at issue that has that condition

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
