### PR TITLE
710 Bugfix escape char func

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -748,8 +748,7 @@ end
 
 --- Escapes a characters on a string to be used as a JSON string
 function M.escape_char(string)
-  return string.gsub(string, '["\\]', {
-    ['"'] = '\\"',
+  return string.gsub(string, '[\\]', {
     ["\\"] = "\\\\",
   })
 end

--- a/lua/tests/plenary/utils_spec.lua
+++ b/lua/tests/plenary/utils_spec.lua
@@ -47,3 +47,24 @@ describe("Utils module:", function()
     end)
   end)
 end)
+
+describe("Utils escape_char(): ", function()
+  it("escapes backslash characters in a string", function()
+    local input = [[hello \\ world]]
+    local expected = [[hello \\\\ world]]
+    eq(expected, this.escape_char(input))
+  end)
+
+  it("returns the same string if no escape characters", function()
+    local input = [['hello/ ~^'*$"world%]]
+    local expected = [['hello/ ~^'*$"world%]]
+    eq(expected, this.escape_char(input))
+  end)
+
+  it("handles an empty string", function()
+    local input = ""
+    local expected = ""
+    eq(expected, this.escape_char(input))
+  end)
+end)
+


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Since the update in this [commit](https://github.com/pwntester/octo.nvim/commit/ea034128710be0e3fa0768a4ccc8e0e758e301ff#diff-5a72a6018b10915bef41b81020b59395527ba5b4b844d222b4e97192b5450565R370), the `escape_char()` in the `lua/octo/utils.lua` module escapes `"` with `\`. This is not needed, and causes a request bodies to include the `\` in the PR comment for example:
`print("Hello")` will show up in Github as `print(\"Hello\")`.
This is not expected behaviour.

From what I can see, there are no issues with just removing the escaping completely.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #710 . Otherwise, add "NONE" -->
Fixes #710
### Describe how you did it
I removed the table entry for escaping `"` in the `escape_char()` utility function.

### Describe how to verify it
I added `plenary/busted` tests for this function, see `lua/tests/plenary/utils_spec.lua`, which tests the escaping of `\\`, and also the non-escaping (`"` amongst these chars)  of other chars as well as empty string.

For complete coverage, tests would have to be made for all functions that use this utility function:
* `save_pr`
* `save_issue`
* `Review:submit`
* `OctoBuffer:do_add_pull_request_comment`

But manually testing these functions will verify the change.

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
