### PR TITLE
fix: create pr with upstream remote now works

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -931,7 +931,12 @@ function M.create_pr(is_draft)
     end
     repo = remotes[remote_idx].repo
   else
-    repo = utils.get_remote_name()
+    -- Override the precedence of get_remote, because otherwise upstream is selected
+    -- and the check if the local branch creates on the repo fails.
+    repo = utils.get_remote_name { "origin" }
+    if not repo then
+      repo = utils.get_remote_name()
+    end
     if not repo then
       utils.error "Cant find repo name"
       return


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

I wanted to create a pull request with octo, but for some reason there was a message displayed, that the current branch has no remote and if I wanted to push the current one. 
The reason was that the command pulls remote branches from the remote that takes precedence. 
That is the upstream repo. Therefore, the local branch of course does not exist in that remote.

### Does this pull request fix one issue?

<!--If that, add \"Fixes #xxxx\" below in the next line. For example, Fixes #15. Otherwise, add \"NONE\" -->
Fixes #400

### Describe how you did it

I changed the `pr create` command so that it first tries to get from the remote `origin` not according to the precedence.

### Describe how to verify it

This very PR was created with Octo :-)

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards