### PR TITLE
Fix buffer id error in TabClosed Autocommands

### DIFF
--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -126,12 +126,14 @@ function FileEntry:destroy()
   self:detach_buffers()
 
   for _, bn in ipairs(self.associated_bufs) do
-    if vim.api.nvim_buf_get_name(bn):match "octo://*" then
-      pcall(vim.api.nvim_buf_delete, bn, { force = true })
-    else
-      signs.unplace(bn)
-      vim.api.nvim_buf_set_option(bn, "modifiable", true)
-      vim.api.nvim_buf_clear_namespace(bn, constants.OCTO_REVIEW_COMMENTS_NS, 0, -1)
+    if vim.api.nvim_buf_is_valid(bn) then
+      if vim.api.nvim_buf_get_name(bn):match "octo://*" then
+        pcall(vim.api.nvim_buf_delete, bn, { force = true })
+      else
+        signs.unplace(bn)
+        vim.api.nvim_buf_set_option(bn, "modifiable", true)
+        vim.api.nvim_buf_clear_namespace(bn, constants.OCTO_REVIEW_COMMENTS_NS, 0, -1)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #776

Add a check in the `destroy` function in `lua/octo/reviews/file-entry.lua` to verify if the buffer id is valid before attempting to delete it.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pwntester/octo.nvim/pull/777?shareId=76293ee0-5b35-43d2-ac7d-d5b734aceabf).