### PR TITLE
feat: Add default (un)resolve mappings to PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ require"octo".setup({
       react_confused = { lhs = "<localleader>rc", desc = "add/remove 😕 reaction" },
       review_start = { lhs = "<localleader>vs", desc = "start a review for the current PR" },
       review_resume = { lhs = "<localleader>vr", desc = "resume a pending review for the current PR" },
+      resolve_thread = { lhs = "<localleader>rt", desc = "resolve PR thread" },
+      unresolve_thread = { lhs = "<localleader>rT", desc = "unresolve PR thread" },
     },
     review_thread = {
       goto_issue = { lhs = "<localleader>gi", desc = "navigate to a local repo issue" },

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ require"octo".setup({
       react_rocket = { lhs = "<localleader>rr", desc = "add/remove 🚀 reaction" },
       react_laugh = { lhs = "<localleader>rl", desc = "add/remove 😄 reaction" },
       react_confused = { lhs = "<localleader>rc", desc = "add/remove 😕 reaction" },
+      resolve_thread = { lhs = "<localleader>rt", desc = "resolve PR thread" },
+      unresolve_thread = { lhs = "<localleader>rT", desc = "unresolve PR thread" },
     },
     submit_win = {
       approve_review = { lhs = "<C-a>", desc = "approve review" },

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -244,6 +244,8 @@ function M.get_default_values()
         react_confused = { lhs = "<localleader>rc", desc = "add/remove 😕 reaction" },
         review_start = { lhs = "<localleader>vs", desc = "start a review for the current PR" },
         review_resume = { lhs = "<localleader>vr", desc = "resume a pending review for the current PR" },
+        resolve_thread = { lhs = "<localleader>rt", desc = "resolve PR thread" },
+        unresolve_thread = { lhs = "<localleader>rT", desc = "unresolve PR thread" },
       },
       review_thread = {
         goto_issue = { lhs = "<localleader>gi", desc = "navigate to a local repo issue" },

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -267,6 +267,8 @@ function M.get_default_values()
         react_rocket = { lhs = "<localleader>rr", desc = "add/remove 🚀 reaction" },
         react_laugh = { lhs = "<localleader>rl", desc = "add/remove 😄 reaction" },
         react_confused = { lhs = "<localleader>rc", desc = "add/remove 😕 reaction" },
+        resolve_thread = { lhs = "<localleader>rt", desc = "resolve PR thread" },
+        unresolve_thread = { lhs = "<localleader>rT", desc = "unresolve PR thread" },
       },
       submit_win = {
         approve_review = { lhs = "<C-a>", desc = "approve review" },

--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -118,10 +118,10 @@ return {
   review_resume = function()
     reviews.resume_review()
   end,
-  resolve_thread = function ()
+  resolve_thread = function()
     require("octo.commands").resolve_thread()
   end,
-  unresolve_thread = function ()
+  unresolve_thread = function()
     require("octo.commands").unresolve_thread()
   end,
   discard_review = function()

--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -118,6 +118,12 @@ return {
   review_resume = function()
     reviews.resume_review()
   end,
+  resolve_thread = function ()
+    require("octo.commands").resolve_thread()
+  end,
+  unresolve_thread = function ()
+    require("octo.commands").unresolve_thread()
+  end,
   discard_review = function()
     reviews.discard_review()
   end,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Add the command functions; resolve_thread() and unresolve_thread() to the mappings.lua to allow setting keymaps to resolve and unresolve threads.

### Does this pull request fix one issue?
fixes #780
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Special notes for reviews
The thread resolver is only accessible for `_G.octo_buffers`. Hence, not possible to add without refactoring for `review_diff` and `file_panel` further.

### Checklist

- [ ] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
- [x] Add more mapping sections - in thread buffer.