### PR TITLE
use reopenIssue to support not_planned and duplicate

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -810,50 +810,65 @@ function M.change_state(state)
   end
 
   local id = buffer.node.id
-  local query, get_obj, desired_state
-  if buffer:isIssue() and (state == "CLOSED" or state == "OPEN") then
+  local query, get_obj, desired_state, fields
+  if buffer:isIssue() and state == "CLOSED" then
     query = graphql("update_issue_state_mutation", id, state)
     desired_state = state
     get_obj = function(resp)
       return resp.data.updateIssue.issue
     end
+    fields = {}
+  elseif buffer:isIssue() and state == "OPEN" then
+    query = graphql "reopen_issue_mutation"
+    desired_state = "OPEN"
+    get_obj = function(resp)
+      return resp.data.reopenIssue.issue
+    end
+    fields = { issueId = id }
   elseif buffer:isIssue() then
     query = graphql("close_issue_mutation", id, state)
     desired_state = "CLOSED"
     get_obj = function(resp)
       return resp.data.closeIssue.issue
     end
+    fields = {}
   elseif buffer:isPullRequest() then
     query = graphql("update_pull_request_state_mutation", id, state)
     desired_state = state
     get_obj = function(resp)
       return resp.data.updatePullRequest.pullRequest
     end
+    fields = {}
   end
 
-  gh.run {
-    args = { "api", "graphql", "-f", string.format("query=%s", query) },
-    cb = function(output, stderr)
-      if stderr and not utils.is_blank(stderr) then
-        utils.error(stderr)
-      elseif output then
-        local resp = vim.fn.json_decode(output)
+  local cb = function(output, stderr)
+    if stderr and not utils.is_blank(stderr) then
+      utils.error(stderr)
+    elseif output then
+      local resp = vim.fn.json_decode(output)
 
-        local obj = get_obj(resp)
-        local new_state = obj.state
+      local obj = get_obj(resp)
+      local new_state = obj.state
 
-        if desired_state ~= new_state then
-          return
-        end
-
-        buffer.node.state = new_state
-
-        local updated_state = utils.get_displayed_state(buffer:isIssue(), new_state, obj.stateReason)
-        writers.write_state(bufnr, updated_state:upper(), buffer.number)
-        writers.write_details(bufnr, obj, true)
-        utils.info("Issue state changed to: " .. updated_state)
+      if desired_state ~= new_state then
+        return
       end
-    end,
+
+      buffer.node.state = new_state
+
+      local updated_state = utils.get_displayed_state(buffer:isIssue(), new_state, obj.stateReason)
+      writers.write_state(bufnr, updated_state:upper(), buffer.number)
+      writers.write_details(bufnr, obj, true)
+      utils.info("Issue state changed to: " .. updated_state)
+    end
+  end
+
+  gh.graphql {
+    query = query,
+    fields = fields,
+    opts = {
+      cb = cb,
+    },
   }
 end
 

--- a/lua/octo/gh/graphql.lua
+++ b/lua/octo/gh/graphql.lua
@@ -539,6 +539,46 @@ M.update_issue_state_mutation = [[
   }
 ]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.renamed_title_event .. fragments.referenced_event
 
+-- https://docs.github.com/en/graphql/reference/mutations#reopenissue
+M.reopen_issue_mutation = [[
+mutation($issueId: ID!) {
+  reopenIssue(input: {
+    issueId: $issueId
+  }) {
+    issue {
+      ...IssueInformationFragment
+      participants(first:10) {
+        nodes {
+          login
+        }
+      }
+      ...ReactionGroupsFragment
+      comments(first: 100) {
+        nodes {
+          id
+          body
+          createdAt
+          ...ReactionGroupsFragment
+          author {
+            login
+          }
+          viewerDidAuthor
+        }
+      }
+      labels(first: 20) {
+        ...LabelConnectionFragment
+      }
+      assignees(first: 20) {
+        ...AssigneeConnectionFragment
+      }
+      timelineItems(last: 100) {
+        ...IssueTimelineItemsConnectionFragment
+      }
+    }
+  }
+}
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.renamed_title_event .. fragments.referenced_event
+
 -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#updatepullrequest
 M.update_pull_request_mutation = [[
   mutation {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Issues that were closed with NOT_PLANNED or DUPLICATE were not able to be reopened as a
specific mutation was required

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Closes #723

### Describe how you did it

Add GraphQL mutation and separate out in reopen case.

### Describe how to verify it

Close an issue with NOT_PLANNED status and reopen it.

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
