### PR TITLE
Catch stderr on pr checkout

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -466,18 +466,17 @@ function M.in_pr_branch(pr)
 end
 
 function M.checkout_pr(pr_number)
-  if not Job then
-    return
-  end
-  Job:new({
-    enable_recording = true,
-    command = "gh",
+  gh.run {
     args = { "pr", "checkout", pr_number },
-    on_exit = vim.schedule_wrap(function()
-      local output = vim.fn.system "git branch --show-current"
-      M.info("Switched to " .. output)
-    end),
-  }):start()
+    cb = function(stdout, stderr)
+      if stderr and not M.is_blank(stderr) then
+        M.error(stderr)
+      elseif stdout then
+        local output = vim.fn.system "git branch --show-current"
+        M.info("Switched to " .. output)
+      end
+    end,
+  }
 end
 
 ---@class CheckoutPrSyncOpts


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Uses gh.run to capture the output and stderr in order to display error on failure


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Closes #759

### Describe how you did it


### Describe how to verify it

Use `:Octo pr checkout` from a PR buffer in different cases.


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
