### PR TITLE
Add graphqlrc file

### DIFF
--- a/.graphqlrc
+++ b/.graphqlrc
@@ -1,0 +1,2 @@
+# Latest schema from GitHub
+schema: https://docs.github.com/public/fpt/schema.docs.graphql


### PR DESCRIPTION
This file is used by graphql lsp server to provider completion and information from the GitHub schema
