### PR TITLE
fix: make comment ranges work

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -33,7 +33,7 @@ end
 function M.setup()
   vim.api.nvim_create_user_command("Octo", function(opts)
     require("octo.commands").octo(unpack(opts.fargs))
-  end, { complete = require("octo.completion").octo_command_complete, nargs = "*" })
+  end, { complete = require("octo.completion").octo_command_complete, nargs = "*", range = true })
   local conf = config.values
 
   local card_commands

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1570,8 +1570,8 @@ function M.get_lines_from_context(calling_context)
     line_number_start = vim.fn.line "."
     line_number_end = line_number_start
   elseif calling_context == "visual" then
-    line_number_start = vim.fn.line "v"
-    line_number_end = vim.fn.line "."
+    line_number_start = vim.fn.line "'<"
+    line_number_end = vim.fn.line "'>"
   elseif calling_context == "motion" then
     line_number_start = vim.fn.getpos("'[")[2]
     line_number_end = vim.fn.getpos("']")[2]


### PR DESCRIPTION
Previous to this comment highlighting several lines and running the command "Octo comment add" would never result in a multi-line comment.

This is seemingly because as soon as you enter the command line with ':' Neovim is switched back into normal mode and the "v" and "." attributes to `vim.fn.line` no longer register for the line range.

Instead, we can use the explicit start and end marks for a selected range to capture the currently selected range despite being in normal mode at time of command run.

It is now possible to highlight several lines in a review and then call "Octo comment add" to create a multi-line comment. 

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
