### PR TITLE
Create CLI command builder with metatable

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -187,27 +187,31 @@ end
 ---@return table the updated args table
 M.insert_args = function(args, options)
   for key, value in pairs(options) do
-    local flag = create_flag(key)
-
-    if type(value) == "table" then
-      for k, v in pairs(value) do
-        if type(v) == "table" then
-          for _, vv in ipairs(v) do
-            table.insert(args, flag)
-            table.insert(args, k .. "[]=" .. vv)
-          end
-        else
-          table.insert(args, flag)
-          table.insert(args, k .. "=" .. v)
-        end
-      end
-    elseif type(value) == "boolean" then
-      if value then
-        table.insert(args, flag)
-      end
-    else
-      table.insert(args, flag)
+    if type(key) == "number" then
       table.insert(args, value)
+    else
+      local flag = create_flag(key)
+
+      if type(value) == "table" then
+        for k, v in pairs(value) do
+          if type(v) == "table" then
+            for _, vv in ipairs(v) do
+              table.insert(args, flag)
+              table.insert(args, k .. "[]=" .. vv)
+            end
+          else
+            table.insert(args, flag)
+            table.insert(args, k .. "=" .. v)
+          end
+        end
+      elseif type(value) == "boolean" then
+        if value then
+          table.insert(args, flag)
+        end
+      else
+        table.insert(args, flag)
+        table.insert(args, value)
+      end
     end
   end
 

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -279,6 +279,9 @@ local create_subcommand = function(command)
           args = args,
           mode = run_opts.mode,
           cb = run_opts.cb,
+          stream_cb = run_opts.stream_cb,
+          headers = run_opts.headers,
+          hostname = run_opts.hostname,
         }
       end
     end,

--- a/lua/tests/plenary/gh_spec.lua
+++ b/lua/tests/plenary/gh_spec.lua
@@ -73,3 +73,34 @@ describe("insert_args:", function()
     eq(args, expected)
   end)
 end)
+
+describe("CLI commands", function()
+  it("gh.<something> returns table", function()
+    local commands = {
+      "issue",
+      "pr",
+      "repo",
+      "gist",
+      "random",
+    }
+
+    for _, command in ipairs(commands) do
+      local actual = gh[command]
+      eq(actual.command, command)
+      assert.is_table(actual)
+    end
+  end)
+  it("gh.<something>.<another-thing> is a function", function()
+    local subcommands = {
+      "list",
+      "view",
+      "develop",
+      "create",
+      "random",
+    }
+    for _, subcommand in ipairs(subcommands) do
+      local actual = gh.issue[subcommand]
+      assert.is_function(actual)
+    end
+  end)
+end)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This adds a metatable to the octo.gh module which allows for building commands more closely to the CLI commands.

For instance, 

```lua
local gh = require "octo.gh"

local print_response = function(stdout, stderr)
  vim.print(stdout)
  vim.print(stderr)
end
local opts = {
  cb = print_response
}

-- gh auth status -a
gh.auth.status { 
  a = true,
  opts = opts,
}

-- gh issue list --json author,labels
gh.issue.list {
  json = "author,labels",
  opts = opts,
}

-- gh pr list --search "is:merged -label:no releasenotes"
gh.pr.list {
  search = 'is:merged -label:"no releasenotes"',
  opts = opts,
}

-- gh pr view 810 --json author,labels,title,url
gh.pr.view {
  810, 
  json = "author,labels,title,url",
  opts = opts,
}
```

> [!NOTE]
>
> Anything in the `opts` table will be passed to the `run` function

> [!NOTE]
>
> There is no validation that happens on the commands. If someone has extensions installed, They will be able to be used
> `gh.milestone.list` will work if the extension is installed
> `gh.copilot.explain { "How to install nvim" }` if the copilot extension is installed

> [!WARNING]
>
> Commands like `gh.run.list` will not work due to it being used by the module already...

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Have a metatable for the `octo.gh` module that allows for building commands more closely to the CLI commands.

### Describe how to verify it

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt