### PR TITLE
fix: reloading an modifiable octo buffer may cause a runtime error

### DIFF
--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -111,9 +111,12 @@ function M.load_buffer(opts)
     vim.api.nvim_buf_call(bufnr, function()
       M.create_buffer(kind, obj, repo, false)
 
+      -- get size of newly created buffer
+      local lines = vim.api.nvim_buf_line_count(bufnr)
+
       -- One to the left
       local new_cursor_pos = {
-        cursor_pos[1],
+        math.min(cursor_pos[1], lines),
         math.max(0, cursor_pos[2] - 1),
       }
       vim.api.nvim_win_set_cursor(0, new_cursor_pos)


### PR DESCRIPTION
fix: reloading an modifiable octo buffer may cause a runtime error
    
    Fixes: #811
    
    ```
    Error executing vim.schedule lua callback: ...hare/nvim/site/pack/deps/opt/octo.nvim/lua/octo/init.lua:111: Error executing lua: .
    ..hare/nvim/site/pack/deps/opt/octo.nvim/lua/octo/init.lua:119: Cursor position outside buffer
    stack traceback:
            [C]: in function 'nvim_win_set_cursor'
            ...hare/nvim/site/pack/deps/opt/octo.nvim/lua/octo/init.lua:119: in function <...hare/nvim/site/pack/deps/opt/octo.nvim/lu
    a/octo/init.lua:111>
            [C]: in function 'nvim_buf_call'
            ...hare/nvim/site/pack/deps/opt/octo.nvim/lua/octo/init.lua:111: in function 'cb'
            ...hare/nvim/site/pack/deps/opt/octo.nvim/lua/octo/init.lua:150: in function 'cb'
            ...e/nvim/site/pack/deps/opt/octo.nvim/lua/octo/gh/init.lua:163: in function ''
            vim/_editor.lua: in function <vim/_editor.lua:0>
    stack traceback:
            [C]: in function 'nvim_buf_call'
            ...hare/nvim/site/pack/deps/opt/octo.nvim/lua/octo/init.lua:111: in function 'cb'
            ...hare/nvim/site/pack/deps/opt/octo.nvim/lua/octo/init.lua:150: in function 'cb'
            ...e/nvim/site/pack/deps/opt/octo.nvim/lua/octo/gh/init.lua:163: in function ''
            vim/_editor.lua: in function <vim/_editor.lua:0>
    
    ```
    
    The above runtime error can occur when an Octo buffer is modified and
    then a reload command is used.
    
    The issue occurs when capturing the initial cursor position before
    reload of the Octo buffer.
    
    The initial cursor position may be in an invalid position in the current
    Octo buffer by the time the reloaded buffer is loaded int.
    
    Simply get the lines of the newly loaded buffer and only cursor reset at
    the minimum valid row position.
    
    The real-world reason to fix this is to avoid a subtly but possibly
    annoying runtime error when the user performs "Octo comment add" in an
    issue buffer and then reloads the buffer without submitting the comment.

### Describe what this PR does / why we need it

Fixes a runtime error when reloading modified Octo buffers

### Does this pull request fix one issue?

Fixes: #811

### Describe how you did it

 Simply get the lines of the newly loaded buffer and only cursor reset at
    the minimum valid row position.
    
The real-world reason to fix this is to avoid a subtly but possibly
    annoying runtime error when the user performs "Octo comment add" in an
    issue buffer and then reloads the buffer without submitting the comment.

### Describe how to verify it

Ensured cursor reset works both when Octo buffer is not modified and when modified (add a couple new lines to Octo buffer before reload). 

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
