### PR TITLE
`Octo pr checkout` uses picker when not in Octo buffer

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -205,6 +205,11 @@ function M.setup()
         local bufnr = vim.api.nvim_get_current_buf()
         local buffer = octo_buffers[bufnr]
         if not buffer or not buffer:isPullRequest() then
+          picker.prs {
+            cb = function(selected)
+              utils.checkout_pr(selected.obj.number)
+            end,
+          }
           return
         end
         if not utils.in_pr_repo() then

--- a/lua/octo/pickers/fzf-lua/pickers/prs.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/prs.lua
@@ -12,11 +12,21 @@ local function checkout_pull_request(entry)
   utils.checkout_pr(entry.obj.number)
 end
 
+local function not_implemented()
+  utils.error "Not implemented yet"
+end
+
 return function(opts)
   opts = opts or {}
   if not opts.states then
     opts.states = "OPEN"
   end
+
+  if opts.cb ~= nil then
+    not_implemented()
+    return
+  end
+
   local filter = picker_utils.get_filter(opts, "pull_request")
   if utils.is_blank(opts.repo) then
     opts.repo = utils.get_remote_name()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

When not in a Octo buffer, the command will use the PR picker to select a PR to checkout.


https://github.com/user-attachments/assets/422fa43e-5c25-40d4-ab01-64fbbe54b121



### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Very easy following #803

### Describe how to verify it

1. Open a non-Octo buffer
2. Run `:Octo pr checkout`

### Special notes for reviews

Only works for telescope

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
