### PR TITLE
fix: fzf-lua previwer (#784)

### DIFF
--- a/lua/octo/pickers/fzf-lua/previewers.lua
+++ b/lua/octo/pickers/fzf-lua/previewers.lua
@@ -38,8 +38,8 @@ function M.bufferPreviewer:gen_winopts()
 end
 
 function M.bufferPreviewer:update_border(title)
-  self.win:update_title(title)
-  self.win:update_scrollbar()
+  self.win:update_preview_title(title)
+  self.win:update_preview_scrollbar()
 end
 
 M.issue = function(formatted_issues)
@@ -159,7 +159,7 @@ M.search = function()
 
     self:set_preview_buf(tmpbuf)
     -- self:update_border(number.." "..description)
-    self.win:update_scrollbar()
+    self.win:update_preview_scrollbar()
   end
 
   return previewer
@@ -387,7 +387,7 @@ M.issue_template = function(formatted_templates)
 
     self:set_preview_buf(tmpbuf)
     self:update_border(entry.value)
-    self.win:update_scrollbar()
+    self.win:update_preview_scrollbar()
   end
 
   return previewer


### PR DESCRIPTION
This PR fixes #784 

The latest version of fzf-lua has updated the api, update_title and update_scrollbar are now called update_previewer_title and update_previewer_scrollbar respectively.
