### PR TITLE
fix: use user command lines ranges

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -11,6 +11,15 @@ local config = require "octo.config"
 local colors = require "octo.ui.colors"
 local vim = vim
 
+-- a global variable where command handlers can access the details of the last
+-- command ran.
+--
+-- this came into existence since some commands like "comment add" need to
+-- understand the line range the comment should be created on.
+-- this is problematic without the command options as you exit visual mode when
+-- enterting the command line.
+OctoLastCmdOpts = nil
+
 local M = {}
 
 local get_current_buffer = function()
@@ -32,7 +41,9 @@ end
 
 function M.setup()
   vim.api.nvim_create_user_command("Octo", function(opts)
+    OctoLastCmdOpts = opts
     require("octo.commands").octo(unpack(opts.fargs))
+    OctoLastCmdOpts = nil
   end, { complete = require("octo.completion").octo_command_complete, nargs = "*", range = true })
   local conf = config.values
 
@@ -536,6 +547,7 @@ function M.octo(object, action, ...)
       utils.error(action and "Incorrect action: " .. action or "No action specified")
       return
     end
+
     res = pcall(a, ...)
     if not res then
       utils.error(action and "Failed action: " .. action)

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -329,8 +329,15 @@ function Review:add_comment(isSuggestion)
     return
   end
 
-  -- get visual selected line range
+  -- get visual selected line range, used if coming from a keymap where current
+  -- mode can be evaluated.
   local line1, line2 = utils.get_lines_from_context "visual"
+  -- if we came from the command line the command options will provide line
+  -- range
+  if OctoLastCmdOpts ~= nil then
+    line1 = OctoLastCmdOpts.line1
+    line2 = OctoLastCmdOpts.line2
+  end
 
   local comment_ranges, current_bufnr
   if split == "RIGHT" then

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1642,8 +1642,8 @@ function M.get_lines_from_context(calling_context)
     line_number_start = vim.fn.line "."
     line_number_end = line_number_start
   elseif calling_context == "visual" then
-    line_number_start = vim.fn.line "'<"
-    line_number_end = vim.fn.line "'>"
+    line_number_start = vim.fn.line "v"
+    line_number_end = vim.fn.line "."
   elseif calling_context == "motion" then
     line_number_start = vim.fn.getpos("'[")[2]
     line_number_end = vim.fn.getpos("']")[2]


### PR DESCRIPTION
This PR is in response to: https://github.com/pwntester/octo.nvim/pull/807#discussion_r1929894670

This is a follow to making line selections work via the command line.

The crux of the confusion with this is that entering the command line from any other mode then normal, exits that mode, and enters normal mode.

Octo was trying to determine a selected line range, retroactively, when adding review comments. However, this doesn't really work since if you highlight a line, then want to run the comment add command, you exit visual mode. All 'state' related to visual mode and visual line rages are greedy and never 'reset' to 0 when visual mode is exited.

The "right" way that Vim intends you to figure out if a user command is being ran with a visual selection is by using the options dictionary provided to the command.

Octo has a object/action lookup mechanism which hides this user command options dictionary from the handlers.

This commit tries to fix the above issue without change how every single object/action is called by creating a global variable `OctoLastCmdOpts` which caches the last command's options. This can be used to gather the line range in which teh command was called.

Ideally, the object/action function dispatch function is updated to pass the user-command dictionary to all command handlers, but this is a larger change.

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
