### PR TITLE
fix: fix 'edit' actions documented arguments

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -829,9 +829,9 @@ function M.get_repo_number_from_varargs(...)
     repo = M.get_remote_name()
     number = tonumber(args[1])
   elseif args.n == 2 then
-    -- eg: Octo issue pwntester/octo.nvim 1
-    repo = args[1]
-    number = tonumber(args[2])
+    -- eg: Octo issue 1 pwntester/octo.nvim
+    repo = args[2]
+    number = tonumber(args[1])
   else
     M.error "Unexpected arguments"
     return


### PR DESCRIPTION
Docs only change. 
Seems like arguments for pr.edit and pr.issue were backwards. 

---
At some point the documentation for editing and issue and a pr drafted
    from the code.
    
    Update `get_repo_number_from_varargs` to reflect the documentation.
    The documentation says `Octo pr [number] {repo}`
    
    However, the code expected `Octo pr {repo} [number]`.
    Fix this confusion by conforming to the documentation.
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
