### PR TITLE
fix: allow pr checkout from non-default repository

### DIFF
--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -177,7 +177,7 @@ function Review:initiate(opts)
   if conf.use_local_fs and not utils.in_pr_branch(pr) then
     local choice = vim.fn.confirm("Currently not in PR branch, would you like to checkout?", "&Yes\n&No", 2)
     if choice == 1 then
-      utils.checkout_pr_sync { pr_number = pr.number, timeout = conf.timeout }
+      utils.checkout_pr_sync { repo = pr.repo, pr_number = pr.number, timeout = conf.timeout }
     end
   end
 

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -552,6 +552,7 @@ function M.checkout_pr(pr_number)
 end
 
 ---@class CheckoutPrSyncOpts
+---@field repo string
 ---@field pr_number number
 ---@field timeout number
 
@@ -564,7 +565,7 @@ function M.checkout_pr_sync(opts)
   Job:new({
     enable_recording = true,
     command = "gh",
-    args = { "pr", "checkout", opts.pr_number },
+    args = { "pr", "checkout", opts.pr_number, "--repo", opts.repo },
     on_exit = vim.schedule_wrap(function()
       local output = vim.fn.system "git branch --show-current"
       M.info("Switched to " .. output)


### PR DESCRIPTION
Fixes: #828

When working in a mulit-remote pull requests may come from separate repositories.

Octo currently lets you list and view PRs from a configurable repository.
However, when it comes to checking out a review branch, it only looks at the current default repository via `gh cli`.

This change simply provides the PR's repository string to `gh pr checkout` command so non-default repository branches can be checked out as well.

Prior to this commit if you did something like `Octo pr edit 1234 owner/repo-b` where `repo-b` is not the default repository and tried to start a review, the PR branch would not be checked out, since its in the non-default repository.

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
