### PR TITLE
feat: improve visibility of selected entry in review file panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,43 +476,76 @@ Octo provides a built-in omnifunc completion for issues, PRs and users that you 
 
 ## 🎨 Colors
 
-| Highlight Group             | Defaults to     |
-| --------------------------- | --------------- |
-| _OctoDirty_                 | ErrorMsg        |
-| _OctoIssueTitle_            | PreProc         |
-| _OctoIssueId_               | Question        |
-| _OctoEmpty_                 | Comment         |
-| _OctoFloat_                 | NormalNC        |
-| _OctoDate_                  | Comment         |
-| _OctoSymbol_                | Comment         |
-| _OctoTimelineItemHeading_   | Comment         |
-| _OctoDetailsLabel_          | Title           |
-| _OctoMissingDetails_        | Comment         |
-| _OctoDetailsValue_          | Identifier      |
-| _OctoDiffHunkPosition_      | NormalFloat     |
-| _OctoCommentLine_           | TabLineSel      |
-| _OctoEditable_              | NormalFloat bg  |
-| _OctoViewer_                | GitHub color    |
-| _OctoBubble_                | NormalFloat     |
-| _OctoBubbleGreen_           | GitHub color    |
-| _OctoBubbleRed_             | GitHub color    |
-| _OctoUser_                  | OctoBubble      |
-| _OctoUserViewer_            | OctoViewer      |
-| _OctoReaction_              | OctoBubble      |
-| _OctoReactionViewer_        | OctoViewer      |
-| _OctoPassingTest_           | GitHub color    |
-| _OctoFailingTest_           | GitHub color    |
-| _OctoPullAdditions_         | GitHub color    |
-| _OctoPullDeletions_         | GitHub color    |
-| _OctoPullModifications_     | GitHub color    |
-| _OctoStateOpen_             | GitHub color    |
-| _OctoStateClosed_           | GitHub color    |
-| _OctoStateMerge_            | GitHub color    |
-| _OctoStatePending_          | GitHub color    |
-| _OctoStateApproved_         | OctoStateOpen   |
-| _OctoStateChangesRequested_ | OctoStateClosed |
-| _OctoStateCommented_        | Normal          |
-| _OctoStateDismissed_        | OctoStateClosed |
+| Highlight Group                   | Linked To          |
+|-----------------------------------|--------------------|
+| _OctoNormal_                      | Normal             |
+| _OctoCursorLine_                  | CursorLine         |
+| _OctoVertSplit_                   | VertSplit          |
+| _OctoSignColumn_                  | Normal             |
+| _OctoStatusColumn_                | SignColumn         |
+| _OctoStatusLine_                  | StatusLine         |
+| _OctoStatusLineNC_                | StatusLineNC       |
+| _OctoEndOfBuffer_                 | EndOfBuffer        |
+| _OctoFilePanelFileName_           | NormalFront        |
+| _OctoFilePanelSelectedFile_       | Type               |
+| _OctoFilePanelPath_               | Comment            |
+| _OctoStatusAdded_                 | OctoGreen          |
+| _OctoStatusUntracked_             | OctoGreen          |
+| _OctoStatusModified_              | OctoBlue           |
+| _OctoStatusRenamed_               | OctoBlue           |
+| _OctoStatusCopied_                | OctoBlue           |
+| _OctoStatusTypeChange_            | OctoBlue           |
+| _OctoStatusUnmerged_              | OctoBlue           |
+| _OctoStatusUnknown_               | OctoYellow         |
+| _OctoStatusDeleted_               | OctoRed            |
+| _OctoStatusBroken_                | OctoRed            |
+| _OctoDirty_                       | OctoRed            |
+| _OctoIssueId_                     | NormalFloat        |
+| _OctoIssueTitle_                  | PreProc            |
+| _OctoFloat_                       | NormalFloat        |
+| _OctoTimelineItemHeading_         | Comment            |
+| _OctoTimelineMarker_              | Identifier         |
+| _OctoSymbol_                      | Comment            |
+| _OctoDate_                        | Comment            |
+| _OctoDetailsLabel_                | Title              |
+| _OctoDetailsValue_                | Identifier         |
+| _OctoMissingDetails_              | Comment            |
+| _OctoEmpty_                       | NormalFloat        |
+| _OctoBubble_                      | NormalFloat        |
+| _OctoUser_                        | OctoBubble         |
+| _OctoUserViewer_                  | OctoViewer         |
+| _OctoReaction_                    | OctoBubble         |
+| _OctoReactionViewer_              | OctoViewer         |
+| _OctoPassingTest_                 | OctoGreen          |
+| _OctoFailingTest_                 | OctoRed            |
+| _OctoPullAdditions_               | OctoGreen          |
+| _OctoPullDeletions_               | OctoRed            |
+| _OctoPullModifications_           | OctoGrey           |
+| _OctoStateOpen_                   | OctoGreen          |
+| _OctoStateClosed_                 | OctoRed            |
+| _OctoStateCompleted_              | OctoPurple         |
+| _OctoStateNotPlanned_             | OctoGrey           |
+| _OctoStateDraft_                  | OctoGrey           |
+| _OctoStateMerge_                  | OctoPurple         |
+| _OctoStatePending_                | OctoYellow         |
+| _OctoStateApproved_               | OctoGreen          |
+| _OctoStateChangesRequested_       | OctoRed            |
+| _OctoStateDismissed_              | OctoRed            |
+| _OctoStateCommented_              | OctoBlue           |
+| _OctoStateSubmitted_              | OctoGreen          |
+| _OctoStateOpenBubble_             | OctoBubbleGreen    |
+| _OctoStateClosedBubble_           | OctoBubbleRed      |
+| _OctoStateMergedBubble_           | OctoBubblePurple   |
+| _OctoStatePendingBubble_          | OctoBubbleYellow   |
+| _OctoStateApprovedBubble_         | OctoBubbleGreen    |
+| _OctoStateChangesRequestedBubble_ | OctoBubbleRed    |
+| _OctoStateDismissedBubble_        | OctoBubbleRed      |
+| _OctoStateCommentedBubble_        | OctoBubbleBlue     |
+| _OctoStateSubmittedBubble_        | OctoBubbleGreen    |
+| _OctoStateOpenFloat_              | OctoGreenFloat     |
+| _OctoStateClosedFloat_            | OctoRedFloat       |
+| _OctoStateMergedFloat_            | OctoPurpleFloat    |
+| _OctoStateDraftFloat_             | OctoGreyFloat      |
 
 The term `GitHub color` refers to the colors used in the WebUI.
 The (addition) `viewer` means the user of the plugin or more precisely the user authenticated via the `gh` CLI tool used to retrieve the data from GitHub.

--- a/lua/octo/reviews/file-panel.lua
+++ b/lua/octo/reviews/file-panel.lua
@@ -28,7 +28,7 @@ FilePanel.winopts = {
   foldenable = false,
   spell = false,
   wrap = false,
-  cursorline = false,
+  cursorline = true,
   signcolumn = "yes",
   foldmethod = "manual",
   foldcolumn = "0",
@@ -38,7 +38,6 @@ FilePanel.winopts = {
   winhl = table.concat({
     "EndOfBuffer:OctoEndOfBuffer",
     "Normal:OctoNormal",
-    --'CursorLine:OctoCursorLine',
     "VertSplit:OctoVertSplit",
     "SignColumn:OctoNormal",
     "StatusLine:OctoStatusLine",
@@ -183,7 +182,14 @@ function FilePanel:highlight_file(file)
     if f == file then
       pcall(vim.api.nvim_win_set_cursor, self.winid, { i + header_size, 0 })
       vim.api.nvim_buf_clear_namespace(self.bufid, constants.OCTO_FILE_PANEL_NS, 0, -1)
-      vim.api.nvim_buf_add_highlight(self.bufid, constants.OCTO_FILE_PANEL_NS, "CursorLine", i + header_size - 1, 0, -1)
+      vim.api.nvim_buf_add_highlight(
+        self.bufid,
+        constants.OCTO_FILE_PANEL_NS,
+        "OctoFilePanelSelectedFile",
+        i + header_size - 1,
+        0,
+        -1
+      )
     end
   end
 end
@@ -198,8 +204,6 @@ function FilePanel:highlight_prev_file()
     if f == cur then
       local line = utils.clamp(i + header_size - 1, header_size + 1, #self.files + header_size)
       pcall(vim.api.nvim_win_set_cursor, self.winid, { line, 0 })
-      vim.api.nvim_buf_clear_namespace(self.bufid, constants.OCTO_FILE_PANEL_NS, 0, -1)
-      vim.api.nvim_buf_add_highlight(self.bufid, constants.OCTO_FILE_PANEL_NS, "CursorLine", line - 1, 0, -1)
     end
   end
 end
@@ -214,8 +218,6 @@ function FilePanel:highlight_next_file()
     if f == cur then
       local line = utils.clamp(i + header_size + 1, header_size, #self.files + header_size)
       pcall(vim.api.nvim_win_set_cursor, self.winid, { line, 0 })
-      vim.api.nvim_buf_clear_namespace(self.bufid, constants.OCTO_FILE_PANEL_NS, 0, -1)
-      vim.api.nvim_buf_add_highlight(self.bufid, constants.OCTO_FILE_PANEL_NS, "CursorLine", line - 1, 0, -1)
     end
   end
 end

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -79,6 +79,7 @@ local function get_hl_links()
     StatusLineNC = "StatusLineNC",
     EndOfBuffer = "EndOfBuffer",
     FilePanelFileName = "NormalFront",
+    FilePanelSelectedFile = "Type",
     FilePanelPath = "Comment",
     StatusAdded = "OctoGreen",
     StatusUntracked = "OctoGreen",
@@ -153,7 +154,9 @@ function M.setup()
   end
 
   for from, to in pairs(get_hl_links()) do
-    vim.cmd("hi def link Octo" .. from .. " " .. to)
+    if vim.fn.hlexists("Octo" .. from) == 0 then
+      vim.cmd("hi def link Octo" .. from .. " " .. to)
+    end
   end
 end
 


### PR DESCRIPTION
- Remove nocursorline because I find it very hard to spot my cursor in the review file panel, and add a more visible highlight to the selected entry
- Add hl group for selected entry in file panel
- Update readme list of hl groups
- Make sure we dont override user defined groups

### Before
![image](https://github.com/user-attachments/assets/b504a066-86aa-442f-a02e-39dc4982ea8a)

### After
![image](https://github.com/user-attachments/assets/08954df1-2434-4bc9-b7c1-d0cc3e543ddc)


I took inspiration from diffview, where it looks like this:
![image](https://github.com/user-attachments/assets/5c92fb66-9fb7-42aa-b77c-40f2e6b65eb8)

[Diffview](https://github.com/sindrets/diffview.nvim/blob/4516612fe98ff56ae0415a259ff6361a89419b0a/lua/diffview/hl.lua#L444) uses the `Type` native (?) hl group and it looked nice on my config, so I went with it.
I'm a bit of a dummy in terms of hl groups, let me know if we can do this better.
