### PR TITLE
Fix gh pr checkout by added the SSH_AUTH_SOCK env variable

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -26,6 +26,7 @@ local env_vars = {
   http_proxy = vim.env["http_proxy"],
   https_proxy = vim.env["https_proxy"],
   no_proxy = vim.env["no_proxy"],
+  SSH_AUTH_SOCK = vim.env["SSH_AUTH_SOCK"],
 }
 
 local function get_env()


### PR DESCRIPTION
### Describe what this PR does / why we need it

There is some instances where you can't checkout into a PR using GH PR checkout and We need to attach SSH_AUTH_SOCK to the gh initializer variables.

https://github.com/pwntester/octo.nvim/issues/831

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
