### PR TITLE
fix: Escape hyphen in ssh_aliases and check for nil in author.user 

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -1347,7 +1347,7 @@ function M.write_commit_event(bufnr, item)
       item.commit.committer.user.login,
       item.commit.committer.user.login == vim.g.octo_viewer and "OctoUserViewer" or "OctoUser",
     })
-  elseif item.commit.author ~= vim.NIL then
+  elseif item.commit.author ~= vim.NIL and item.commit.author.user ~= vim.NIL then
     table.insert(vt, {
       item.commit.author.user.login,
       item.commit.author.user.login == vim.g.octo_viewer and "OctoUserViewer" or "OctoUser",

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -221,6 +221,7 @@ function M.parse_remote_url(url, aliases)
   end
 
   for alias, rhost in pairs(aliases) do
+    alias = alias:gsub("%-", "%%-")
     host = host:gsub("^" .. alias .. "$", rhost, 1)
   end
   if not M.is_blank(host) and not M.is_blank(repo) then

--- a/lua/tests/plenary/utils_spec.lua
+++ b/lua/tests/plenary/utils_spec.lua
@@ -67,3 +67,55 @@ describe("Utils escape_char(): ", function()
     eq(expected, this.escape_char(input))
   end)
 end)
+
+describe("Utils parse_remote_url(): ", function()
+  it("Should replace remote url with alias", function()
+    local ssh_aliases = {
+      ["github.com-work"] = "github.com",
+    }
+    local url = "git@github.com-work:pwntester/octo.nvim.git"
+
+    local expected = {
+      host = "github.com",
+      repo = "pwntester/octo.nvim",
+    }
+
+    eq(expected, this.parse_remote_url(url, ssh_aliases))
+  end)
+
+  it("Should replace multiple hyphens in remote url with alias", function()
+    local ssh_aliases = {
+      ["github.com-octo-work"] = "github.com",
+    }
+    local url = "git@github.com-octo-work:pwntester/octo.nvim.git"
+
+    local expected = {
+      host = "github.com",
+      repo = "pwntester/octo.nvim",
+    }
+
+    eq(expected, this.parse_remote_url(url, ssh_aliases))
+  end)
+
+  it("Should not replace remote url with alias", function()
+    local url = "git@github.com-work:pwntester/octo.nvim.git"
+    local expected = {
+      host = "github.com-work",
+      repo = "pwntester/octo.nvim",
+    }
+
+    eq(expected, this.parse_remote_url(url, {}))
+  end)
+
+  it("Should keep the original url", function()
+    local ssh_aliases = {
+      ["github.com-work"] = "github.com",
+    }
+    local url = "git@github.com:pwntester/octo.nvim.git"
+    local expected = {
+      host = "github.com",
+      repo = "pwntester/octo.nvim",
+    }
+    eq(expected, this.parse_remote_url(url, ssh_aliases))
+  end)
+end)


### PR DESCRIPTION
### Describe what this PR does / why we need it

This change fixes the issue where the hyphen in the ssh_aliases replacement is not escaped. This causes the replacement to fail when the alias contains a hyphen.

The second change is related to issue #838, where the check for nil values are not working as expected. I have added a check for nil to author.user.

### Does this pull request fix one issue?

Fixes #836
Fixes #838

### Describe how you did it

In parse_remote_url function, I have added a `%` before the hyphen in the ssh_aliases replacement.

In write_commit_event function, I have added a check for nil to author.user.

### Describe how to verify it

Test with an ssh alias that contains a hyphen, for example github.com-work
Test with a nil value for author.user

### Special notes for reviews

Little changes

### Checklist

- [X] Passing tests and linting standards
- [X] Documentation updates in README.md and doc/octo.txt