### PR TITLE
feat: fix error when trying to open a review while it is already opened

### DIFF
--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -451,9 +451,15 @@ function M._create_buffer(opts)
     -- vim.fn.bufadd creates the buffer as unlisted by default
     vim.api.nvim_buf_set_option(bufnr, "buflisted", true)
   else
-    bufnr = vim.api.nvim_create_buf(false, false)
     local bufname =
       string.format("octo://%s/review/%s/file/%s/%s", opts.repo, current_review.id, string.upper(opts.split), opts.path)
+    local existing_bufnr = utils.find_named_buffer(bufname)
+    if existing_bufnr then
+      -- Buffer already exists, most likely because review is already opened
+      return existing_bufnr
+    end
+
+    bufnr = vim.api.nvim_create_buf(false, false)
     vim.api.nvim_buf_set_name(bufnr, bufname)
     if opts.binary then
       vim.api.nvim_buf_set_option(bufnr, "modifiable", true)


### PR DESCRIPTION
Error was

```lua
Error executing vim.schedule lua callback: ...neovim-plugins/octo.nvim/lua/octo/reviews/file-entry.lua:457: Failed to rename buffer
stack traceback:
        [C]: in function 'nvim_buf_set_name'
        ...neovim-plugins/octo.nvim/lua/octo/reviews/file-entry.lua:457: in function '_create_buffer'
        ...neovim-plugins/octo.nvim/lua/octo/reviews/file-entry.lua:273: in function 'load_buffers'
        ...ume/neovim-plugins/octo.nvim/lua/octo/reviews/layout.lua:123: in function 'set_current_file'
        ...ume/neovim-plugins/octo.nvim/lua/octo/reviews/layout.lua:145: in function 'update_files'
        ...laume/neovim-plugins/octo.nvim/lua/octo/reviews/init.lua:149: in function 'set_files_and_select_first'
        ...laume/neovim-plugins/octo.nvim/lua/octo/reviews/init.lua:193: in function 'callback'
        ...neovim-plugins/octo.nvim/lua/octo/model/pull-request.lua:122: in function 'cb'
        .../guillaume/neovim-plugins/octo.nvim/lua/octo/gh/init.lua:164: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

It was due to use trying to create a new buffer when showing a diff with the exact same path as an already existing one.

I think this is not the long term fix, long term fix should be for us to just redirect the user to the existing review tab, but I dont want to get into a big refactor ahead of what was discussed in #815