### PR TITLE
revert: "fix: fix 'edit' actions documented arguments (#826)"

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -840,9 +840,9 @@ function M.get_repo_number_from_varargs(...)
     repo = M.get_remote_name()
     number = tonumber(args[1])
   elseif args.n == 2 then
-    -- eg: Octo issue 1 pwntester/octo.nvim
-    repo = args[2]
-    number = tonumber(args[1])
+    -- eg: Octo issue pwntester/octo.nvim 1
+    repo = args[1]
+    number = tonumber(args[2])
   else
     M.error "Unexpected arguments"
     return


### PR DESCRIPTION
### Describe what this PR does / why we need it

An error opening a PR from the picker was introduced in #826.
This reverts commit 781545b926d9b8db37f149022eb349739ed5ca33.

### Does this pull request fix one issue?

Fixes #841

### Describe how you did it

`git revert HEAD`

### Describe how to verify it

The error no longer occurs

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
