### PR TITLE
fix: follow parameter order change from #826

### DIFF
--- a/lua/octo/pickers/fzf-lua/entry_maker.lua
+++ b/lua/octo/pickers/fzf-lua/entry_maker.lua
@@ -10,9 +10,9 @@ function M.gen_from_issue(issue_table)
   local kind = issue_table.__typename == "Issue" and "issue" or "pull_request"
   local filename
   if kind == "issue" then
-    filename = utils.get_issue_uri(issue_table.repository.nameWithOwner, issue_table.number)
+    filename = utils.get_issue_uri(issue_table.number, issue_table.repository.nameWithOwner)
   else
-    filename = utils.get_pull_request_uri(issue_table.repository.nameWithOwner, issue_table.number)
+    filename = utils.get_pull_request_uri(issue_table.number, issue_table.repository.nameWithOwner)
   end
   return {
     filename = filename,

--- a/lua/octo/pickers/fzf-lua/pickers/utils.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/utils.lua
@@ -64,7 +64,7 @@ function M.open(command, entry)
   elseif command == "tab" then
     vim.cmd [[:tab sb %]]
   end
-  utils.get(entry.kind, entry.repo, entry.value)
+  utils.get(entry.kind, entry.value, entry.repo)
 end
 
 --[[

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -109,11 +109,11 @@ function M.gen_from_issue(max_number, print_repo)
 
     local filename
     if kind == "issue" then
-      filename = utils.get_issue_uri(obj.repository.nameWithOwner, obj.number)
+      filename = utils.get_issue_uri(obj.number, obj.repository.nameWithOwner)
     elseif kind == "pull_request" then
-      filename = utils.get_pull_request_uri(obj.repository.nameWithOwner, obj.number)
+      filename = utils.get_pull_request_uri(obj.number, obj.repository.nameWithOwner)
     else
-      filename = utils.get_discussion_uri(obj.respository.nameWithOwner, obj.number)
+      filename = utils.get_discussion_uri(obj.number, obj.respository.nameWithOwner)
     end
 
     return {

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -77,7 +77,7 @@ local function open(command)
       vim.cmd [[:tab sb %]]
     end
     if selection then
-      utils.get(selection.kind, selection.repo, selection.value)
+      utils.get(selection.kind, selection.value, selection.repo)
     end
   end
 end


### PR DESCRIPTION
This is an alternative to #842


### Describe what this PR does / why we need it

#826 changed the order of parameters of the `:Octo` command to be inline with the documentation. However, the order of the parameters used by the `fzf-lua` picker wasn't changed

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #841 because of a regression introduced in #826


### Describe how you did it

Change the parameter order just like on #826

### Describe how to verify it

`:Octo pr list` and choosing a PR while using `fzf-lua`  or `telescope` as picker will no longer result in errors


### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
