### PR TITLE
fix: handle reference timeline event without actor

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -1390,6 +1390,10 @@ local write_reference_commit = function(bufnr, commit)
 end
 
 function M.write_referenced_event(bufnr, item)
+  if utils.is_blank(item.actor) then
+    return
+  end
+
   local vt = {}
   local conf = config.values
   table.insert(vt, { conf.timeline_marker .. " ", "OctoTimelineMarker" })


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

When another item is referenced, there will be a timeline item without information. This imposes a catch to not error out
when the item doesn't have an actor


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
