### PR TITLE
fix: properly check for null buffer loaded state on review open

### DIFF
--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -497,19 +497,28 @@ end
 function M._get_null_buffer()
   local msg = "Loading ..."
   local bn = M._null_buffer[msg]
-  if not bn or vim.api.nvim_buf_is_loaded(bn) then
-    local nbn = vim.api.nvim_create_buf(false, false)
-    vim.api.nvim_buf_set_lines(nbn, 0, -1, false, { msg })
-    local bufname = utils.path_join { "octo", "null" }
-    vim.api.nvim_buf_set_option(nbn, "modified", false)
-    vim.api.nvim_buf_set_option(nbn, "modifiable", false)
-    local ok = pcall(vim.api.nvim_buf_set_name, nbn, bufname)
-    if not ok then
-      utils.wipe_named_buffer(bufname)
-      vim.api.nvim_buf_set_name(nbn, bufname)
-    end
-    M._null_buffer[msg] = nbn
+
+  if bn and vim.api.nvim_buf_is_valid(bn) then
+    -- Null buffer already exists and is loaded
+    return bn
   end
+
+  -- Create the null buffer
+  local nbn = vim.api.nvim_create_buf(false, false)
+
+  vim.api.nvim_buf_set_lines(nbn, 0, -1, false, { msg })
+  local bufname = utils.path_join { "octo", "null" }
+  vim.api.nvim_buf_set_option(nbn, "modified", false)
+  vim.api.nvim_buf_set_option(nbn, "modifiable", false)
+
+  local ok = pcall(vim.api.nvim_buf_set_name, nbn, bufname)
+  if not ok then
+    utils.wipe_named_buffer(bufname)
+    vim.api.nvim_buf_set_name(nbn, bufname)
+  end
+
+  M._null_buffer[msg] = nbn
+
   return M._null_buffer[msg]
 end
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fixes a lua error that happened this way

1. Open review
2. Close review
3. Delete null buffer (for example using `<cmd>%bd!|e#|bd!#<cr>`)
4. Open review
5. See this error

```lua
 Error executing vim.schedule lua callback: ...neovim-plugins/octo.nvim/lua/octo/reviews/file-entry.lua:492: Invalid buffer id: 6
 stack traceback:
         [C]: in function 'nvim_win_set_buf'
         ...neovim-plugins/octo.nvim/lua/octo/reviews/file-entry.lua:492: in function 'load_null_buffer'
         ...neovim-plugins/octo.nvim/lua/octo/reviews/file-entry.lua:485: in function 'load_null_buffers'
         ...ume/neovim-plugins/octo.nvim/lua/octo/reviews/layout.lua:247: in function 'file_safeguard'
         ...ume/neovim-plugins/octo.nvim/lua/octo/reviews/layout.lua:57: in function 'open'
         ...laume/neovim-plugins/octo.nvim/lua/octo/reviews/init.lua:190: in function 'initiate'
         ...laume/neovim-plugins/octo.nvim/lua/octo/reviews/init.lua:123: in function 'callback'
         ...laume/neovim-plugins/octo.nvim/lua/octo/reviews/init.lua:75: in function 'cb'
         .../guillaume/neovim-plugins/octo.nvim/lua/octo/gh/init.lua:164: in function ''
         vim/_editor.lua: in function <vim/_editor.lua:0>
```



### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
