### PR TITLE
Feat: repo specific notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ require"octo".setup({
     },
     always_select_remote_on_create = false -- always give prompt to select base remote repo when creating PRs
   },
+  notifications = {
+    current_repo = false,                  -- show notifications for current repo only
+  },
   file_panel = {
     size = 10,                             -- changed files panel rows
     use_icons = true                       -- use web-devicons in file panel (if false, nvim-web-devicons does not need to be installed)

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ require"octo".setup({
     always_select_remote_on_create = false -- always give prompt to select base remote repo when creating PRs
   },
   notifications = {
-    current_repo = false,                  -- show notifications for current repo only
+    current_repo_only = false,             -- show notifications for current repo only
   },
   file_panel = {
     size = 10,                             -- changed files panel rows

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -44,7 +44,7 @@ local M = {}
 ---@field order_by OctoConfigOrderBy
 
 ---@class OctoConfigNotifications
----@field current_repo boolean
+---@field current_repo_only boolean
 
 ---@class OctoConfigPR
 ---@field order_by OctoConfigOrderBy
@@ -155,7 +155,7 @@ function M.get_default_values()
       },
     },
     notifications = {
-      current_repo = false,
+      current_repo_only = false,
     },
     reviews = {
       auto_show_threads = true,
@@ -436,6 +436,14 @@ function M.validate_config()
     validate_type(config.pull_requests.always_select_remote_on_create, "always_select_remote_on_create", "boolean")
   end
 
+  local function validate_notifications()
+    if not validate_type(config.notifications, "notifications", "table") then
+      err("notifications", "Expected notifications to be a table")
+      return
+    end
+    validate_type(config.notifications.current_repo_only, "notifications.current_repo_only", "boolean")
+  end
+
   local function validate_mappings()
     -- TODO(jarviliam): Validate each keymap
     if not validate_type(config.mappings, "mappings", "table") then
@@ -486,6 +494,7 @@ function M.validate_config()
     validate_issues()
     validate_reviews()
     validate_pull_requests()
+    validate_notifications()
     if validate_type(config.file_panel, "file_panel", "table") then
       validate_type(config.file_panel.size, "file_panel.size", "number")
       validate_type(config.file_panel.use_icons, "file_panel.use_icons", "boolean")

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -43,6 +43,9 @@ local M = {}
 ---@class OctoConfigDiscussions
 ---@field order_by OctoConfigOrderBy
 
+---@class OctoConfigNotifications
+---@field current_repo boolean
+
 ---@class OctoConfigPR
 ---@field order_by OctoConfigOrderBy
 ---@field always_select_remote_on_create boolean
@@ -91,6 +94,7 @@ local M = {}
 ---@field mappings { [OctoMappingsWindow]: OctoMappingsList}
 ---@field mappings_disable_default boolean
 ---@field discussions OctoConfigDiscussions
+---@field notifications OctoConfigNotifications
 
 --- Returns the default octo config values
 ---@return OctoConfig
@@ -149,6 +153,9 @@ function M.get_default_values()
         field = "CREATED_AT",
         direction = "DESC",
       },
+    },
+    notifications = {
+      current_repo = false,
     },
     reviews = {
       auto_show_threads = true,

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -657,7 +657,7 @@ function M.gen_from_octo_actions(width)
 end
 
 function M.gen_from_notification(opts)
-  opts = opts or { show_repo = false }
+  opts = opts or { show_repo_info = false }
   local make_display = function(entry)
     if not entry then
       return nil
@@ -678,7 +678,7 @@ function M.gen_from_notification(opts)
       { width = math.min(#entry.obj.subject.title, 100) },
     }
 
-    if not opts.show_repo then
+    if not opts.show_repo_info then
       table.remove(columns, 3)
       table.remove(items, 3)
     end

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -656,7 +656,8 @@ function M.gen_from_octo_actions(width)
   end
 end
 
-function M.gen_from_notification()
+function M.gen_from_notification(opts)
+  opts = opts or { show_repo = false }
   local make_display = function(entry)
     if not entry then
       return nil
@@ -670,15 +671,21 @@ function M.gen_from_notification()
       { string.sub(entry.obj.repository.full_name, 1, 50), "TelescopeResultsNumber" },
       { string.sub(entry.obj.subject.title, 1, 100) },
     }
+    local items = {
+      { width = 2 },
+      { width = 6 },
+      { width = math.min(#entry.obj.repository.full_name, 50) },
+      { width = math.min(#entry.obj.subject.title, 100) },
+    }
+
+    if not opts.show_repo then
+      table.remove(columns, 3)
+      table.remove(items, 3)
+    end
 
     local displayer = entry_display.create {
       separator = " ",
-      items = {
-        { width = 2 },
-        { width = 6 },
-        { width = math.min(#entry.obj.repository.full_name, 50) },
-        { width = math.min(#entry.obj.subject.title, 100) },
-      },
+      items = items,
     }
 
     return displayer(columns)

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -1208,7 +1208,7 @@ function M.notifications(opts)
   opts = opts or {}
   local cfg = octo_config.values
 
-  if cfg.notifications.current_repo then
+  if cfg.notifications.current_repo_only then
     opts.repo = utils.get_remote_name()
   end
 

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -1241,7 +1241,7 @@ function M.notifications(opts)
             finder = finders.new_table {
               results = resp,
               entry_maker = entry_maker.gen_from_notification {
-                show_repo = not opts.repo,
+                show_repo_info = not opts.repo,
               },
             },
             sorter = conf.generic_sorter(opts),

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -1233,7 +1233,7 @@ function M.notifications(opts)
         local resp = vim.json.decode(output)
 
         if #resp == 0 then
-          utils.error "There are no notifications"
+          utils.info "There are no notifications"
           return
         end
 

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -1213,12 +1213,11 @@ function M.notifications(opts)
   end
 
   local endpoint = "/notifications"
-  opts.prompt_title = "Github Notifications"
   if opts.repo then
     local owner, name = utils.split_repo(opts.repo)
     endpoint = string.format("/repos/%s/%s/notifications", owner, name)
-    opts.prompt_title = string.format("%s Notifications", opts.repo)
   end
+  opts.prompt_title = opts.repo and string.format("%s Notifications", opts.repo) or "Github Notifications"
 
   opts.preview_title = ""
   opts.results_title = ""


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This allows the user to choose between all notifications and notifications for the current repository only.

The default is all notifications which is the current behavior.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

1. Add configuration option
2. Use configuration option in the notification picker to toggle between the repo specific notifications and all notifications

### Describe how to verify it

Use `:Octo notification list` with configuration before and after

### Special notes for reviews

Only for the telescope picker as that is only one with notifications implemented

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
