### PR TITLE
Improve buffer behavior after thread creation

### DIFF
--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -55,7 +55,7 @@ function M.setup()
       group = "octo_autocmds",
       pattern = { "*" },
       callback = function()
-        require("octo.reviews.thread-panel").show_review_threads()
+        require("octo.reviews.thread-panel").show_review_threads(false)
       end,
     })
   end

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -339,7 +339,7 @@ function M.setup()
         end
       end,
       thread = function()
-        require("octo.reviews.thread-panel").show_review_threads { jump_to_buffer = true }
+        require("octo.reviews.thread-panel").show_review_threads(true)
       end,
     },
     gist = {

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -367,7 +367,7 @@ function M.setup()
         if current_review and utils.in_diff_window() then
           current_review:add_comment(false)
         else
-          M.add_comment()
+          M.add_pr_issue_or_review_thread_comment()
         end
       end,
       delete = function()
@@ -561,8 +561,8 @@ function M.octo(object, action, ...)
   end
 end
 
---- Adds a new comment to an issue/PR
-function M.add_comment()
+--- Adds a new comment to an issue/PR or a review thread
+function M.add_pr_issue_or_review_thread_comment()
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
   if not buffer then

--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -80,7 +80,7 @@ return {
     require("octo.navigation").prev_comment()
   end,
   add_comment = function()
-    require("octo.commands").add_comment()
+    require("octo.commands").add_pr_issue_or_review_thread_comment()
   end,
   add_suggestion = function()
     require("octo.commands").add_suggestion()

--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -144,7 +144,7 @@ end
 ---@param split OctoSplit
 ---@return integer
 function FileEntry:get_alternative_win(split)
-  if split == "left" then
+  if split:lower() == "left" then
     return self.right_winid
   end
 
@@ -155,7 +155,7 @@ end
 ---@param split OctoSplit
 ---@return integer
 function FileEntry:get_alternative_buf(split)
-  if split == "left" then
+  if split:lower() == "left" then
     return self.right_bufid
   end
 
@@ -166,7 +166,7 @@ end
 ---@param split OctoSplit
 ---@return integer
 function FileEntry:get_win(split)
-  if split == "left" then
+  if split:lower() == "left" then
     return self.left_winid
   end
 
@@ -177,7 +177,7 @@ end
 ---@param split OctoSplit
 ---@return integer
 function FileEntry:get_buf(split)
-  if split == "left" then
+  if split:lower() == "left" then
     return self.left_bufid
   end
 

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -6,6 +6,7 @@ local graphql = require "octo.gh.graphql"
 local thread_panel = require "octo.reviews.thread-panel"
 local window = require "octo.ui.window"
 local utils = require "octo.utils"
+local ReviewThread = require("octo.reviews.thread").ReviewThread
 
 ---@alias ReviewLevel "COMMIT" | "PR"
 
@@ -389,49 +390,22 @@ function Review:add_comment(isSuggestion)
       commit_abbrev = self.layout.right:abbrev()
     end
     local threads = {
-      {
-        originalStartLine = line1,
-        originalLine = line2,
-        path = file.path,
-        isOutdated = false,
-        isResolved = false,
-        diffSide = split,
-        isCollapsed = false,
-        id = default_id,
-        comments = {
-          nodes = {
-            {
-              id = default_id,
-              author = { login = vim.g.octo_viewer },
-              state = "PENDING",
-              replyTo = vim.NIL,
-              url = vim.NIL,
-              diffHunk = diff_hunk,
-              createdAt = os.date "!%FT%TZ",
-              originalCommit = { oid = commit, abbreviatedOid = commit_abbrev },
-              body = " ",
-              viewerCanUpdate = true,
-              viewerCanDelete = true,
-              viewerDidAuthor = true,
-              pullRequestReview = { id = self.id },
-              reactionGroups = {
-                { content = "THUMBS_UP", users = { totalCount = 0 } },
-                { content = "THUMBS_DOWN", users = { totalCount = 0 } },
-                { content = "LAUGH", users = { totalCount = 0 } },
-                { content = "HOORAY", users = { totalCount = 0 } },
-                { content = "CONFUSED", users = { totalCount = 0 } },
-                { content = "HEART", users = { totalCount = 0 } },
-                { content = "ROCKET", users = { totalCount = 0 } },
-                { content = "EYES", users = { totalCount = 0 } },
-              },
-            },
-          },
-        },
+      ReviewThread:stub {
+        line1 = line1,
+        line2 = line2,
+        file_path = file.path,
+        split = split,
+        diff_hunk = diff_hunk,
+        commit = commit,
+        commit_abbrev = commit_abbrev,
+        review_id = self.id,
       },
     }
 
-    -- TODO: if there are threads for that line, there should be a buffer already showing them
-    -- or maybe not if the user is very quick
+    -- Make sure review thread panel is visible if not already
+    -- The thread panel could be hidden if user has `reviews.auto_show_threads` set to false in their config
+    -- or, less likely, if the add comment command is invoked before the autocmd has concluded,
+    thread_panel.show_review_threads(false)
     local thread_buffer = thread_panel.create_thread_buffer(threads, pr.repo, pr.number, split, file.path)
     if thread_buffer then
       table.insert(file.associated_bufs, thread_buffer.bufnr)

--- a/lua/octo/reviews/thread-panel.lua
+++ b/lua/octo/reviews/thread-panel.lua
@@ -4,8 +4,9 @@ local vim = vim
 
 local M = {}
 
-function M.show_review_threads(params)
-  local params = params or {}
+---Show review threads under cursor if there are any
+---@param jump_to_buffer boolean
+function M.show_review_threads(jump_to_buffer)
   -- This function is called from a very broad CursorHold event
   -- Check if we are in a diff buffer and otherwise return early
   local bufnr = vim.api.nvim_get_current_buf()
@@ -77,7 +78,7 @@ function M.show_review_threads(params)
           end
         end, { buffer = thread_buffer.bufnr })
 
-        if params.jump_to_buffer then
+        if jump_to_buffer then
           vim.api.nvim_set_current_win(alt_win)
         end
         vim.api.nvim_buf_call(thread_buffer.bufnr, function()
@@ -108,7 +109,7 @@ function M.hide_thread_buffer(split, file)
 end
 
 ---Create a thread buffer
----@param threads any
+---@param threads ReviewThread[]
 ---@param repo any
 ---@param number any
 ---@param side any

--- a/lua/octo/reviews/thread.lua
+++ b/lua/octo/reviews/thread.lua
@@ -1,0 +1,83 @@
+local M = {}
+
+---@class ReviewComment
+--- https://docs.github.com/en/graphql/reference/objects#pullrequestreviewcomment
+---@field id string
+---@field author { login: string }
+---@field state string
+---@field replyTo any
+---@field url any
+---@field diffHunk string
+---@field createdAt string
+---@field originalCommit { oid: string, abbreviatedOid: string }
+---@field body string
+---@field viewerCanUpdate boolean
+---@field viewerCanDelete boolean
+---@field viewerDidAuthor boolean
+---@field pullRequestReview { id: string }
+---@field reactionGroups { content: string, users: { totalCount: number } }[]
+
+---@class ReviewThread
+--- https://docs.github.com/en/graphql/reference/objects#pullrequestreviewthread
+---@field originalStartLine number
+---@field originalLine number
+---@field path string
+---@field isOutdated boolean
+---@field isResolved boolean
+---@field diffSide string
+---@field isCollapsed boolean
+---@field id string
+---@field comments { nodes: ReviewComment[] }
+
+local default_id = -1
+
+local ReviewThread = {}
+ReviewThread.__index = ReviewThread
+
+---ReviewThread stub representing a new comment thread.
+---@return ReviewThread
+function ReviewThread:stub(opts)
+  return {
+    originalStartLine = opts.line1,
+    originalLine = opts.line2,
+    path = opts.file_path,
+    isOutdated = false,
+    isResolved = false,
+    diffSide = opts.split,
+    isCollapsed = false,
+    id = default_id,
+    comments = {
+      nodes = {
+        {
+          id = default_id,
+          author = { login = vim.g.octo_viewer },
+          state = "PENDING",
+          replyTo = vim.NIL,
+          url = vim.NIL,
+          diffHunk = opts.diff_hunk,
+          createdAt = os.date "!%FT%TZ",
+          originalCommit = { oid = opts.commit, abbreviatedOid = opts.commit_abbrev },
+          body = " ",
+          viewerCanUpdate = true,
+          viewerCanDelete = true,
+          viewerDidAuthor = true,
+          pullRequestReview = { id = opts.review_id },
+          reactionGroups = {
+            { content = "THUMBS_UP", users = { totalCount = 0 } },
+            { content = "THUMBS_DOWN", users = { totalCount = 0 } },
+            { content = "LAUGH", users = { totalCount = 0 } },
+            { content = "HOORAY", users = { totalCount = 0 } },
+            { content = "CONFUSED", users = { totalCount = 0 } },
+            { content = "HEART", users = { totalCount = 0 } },
+            { content = "ROCKET", users = { totalCount = 0 } },
+            { content = "EYES", users = { totalCount = 0 } },
+          },
+        },
+      },
+    },
+  }
+end
+
+M.ReviewThread = ReviewThread
+
+return M


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Fix error `gh: Could not resolve to a node with the global id of '-1'` when creating a comment from a thread buffer that was just used to create a new thread without closing it first

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
- Improved review typing
- Improved behavior of `Octo comment add` by ensuring the thread buffer was visible, and therefore that existing comment had been loaded, BEFORE trying to create a new comment
- Fixed the error of creating a new comment in a fresh thread, which was caused by the octo-buffer thread metadata not being updated with ids of created thread after the gh api

### Describe how to verify it
- Open a review
- On a line without a comment, run `Octo comment add`
- Save a new comment
- Re-run `Octo comment add` to add a reply to the comment you just created
- See the comment being registered without error, when the error `gh: Could not resolve to a node with the global id of '-1'` would previously be shown

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
