### PR TITLE
Pass repo to notification picker

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -457,8 +457,16 @@ function M.setup()
       end,
     },
     notification = {
-      list = function()
-        picker.notifications()
+      list = function(repo)
+        local opts = {}
+
+        if repo then
+          opts.repo = repo
+        elseif config.values.notifications.current_repo_only then
+          opts.repo = utils.get_remote_name()
+        end
+
+        picker.notifications(opts)
       end,
     },
   }

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -1208,10 +1208,6 @@ function M.notifications(opts)
   opts = opts or {}
   local cfg = octo_config.values
 
-  if cfg.notifications.current_repo_only then
-    opts.repo = utils.get_remote_name()
-  end
-
   local endpoint = "/notifications"
   if opts.repo then
     local owner, name = utils.split_repo(opts.repo)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This change allows user to also pass a repo to the notification list command. 

`:Octo notification list pwntester/octo.nvim` would subset to any of the notifications from the repo `pwntester/octo.nvim`

This still respects the config.notification.current_repo_only configuration setting.

It allow for users with this configuration to use the picker programatically as well: 

```lua
local picker = require "octo.picker"

local opts = {
  repo = "pwntester/octo.nvim",
}
picker.notification(opts)
```

> [!NOTE]
> 
> Using `:Octo notification` directly will have all notifications regardless of user configuration.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Move the repo logic outside of the picker and into the command.lua file

### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt