### PR TITLE
fix(typos,indent): indent files with stylua and fix typos

### DIFF
--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -285,7 +285,7 @@ FAQ                                             *octo-faq*
 How can I disable bubbles for XYZ?~
 
   Each text-object that makes use of a bubble (except labels) do use their own
-  highlight group that linkes per default to the main bubble highlight group.
+  highlight group that links per default to the main bubble highlight group.
   To disable most bubbles at once you can simply link `OctoBubble` to
   `Normal`. To only disable them for a certain plain do the same for the
   specific sub-group (e.g. `OctoUser`).

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -995,7 +995,7 @@ function M.create_pr(is_draft)
       utils.error "Aborting PR creation"
       return
     elseif remote_idx > #remotes then
-      utils.error "Invaild index."
+      utils.error "Invalid index."
       return
     end
     repo = remotes[remote_idx].repo

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -457,8 +457,8 @@ function M.validate_config()
     validate_type(config.snippet_context_lines, "snippet_context_lines", "number")
     validate_type(config.timeout, "timeout", "number")
     validate_type(config.default_to_projects_v2, "default_to_projects_v2", "boolean")
-    if validate_type(config.suppress_missing_scope, "supress_missing_scope", "table") then
-      validate_type(config.suppress_missing_scope.projects_v2, "supress_missing_scope.projects_v2", "boolean")
+    if validate_type(config.suppress_missing_scope, "suppress_missing_scope", "table") then
+      validate_type(config.suppress_missing_scope.projects_v2, "suppress_missing_scope.projects_v2", "boolean")
     end
     validate_type(config.gh_cmd, "gh_cmd", "string")
     validate_type(config.gh_env, "gh_env", { "table", "function" })

--- a/lua/octo/constants.lua
+++ b/lua/octo/constants.lua
@@ -21,7 +21,7 @@ M.NO_BODY_MSG = "No description provided."
 
 M.LONG_ISSUE_PATTERN = "([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(%d+)"
 M.SHORT_ISSUE_PATTERN = "[^%w%d]+#(%d+)"
-M.SHORT_ISSUE_LINE_BEGGINING_PATTERN = "^#(%d+)"
+M.SHORT_ISSUE_LINE_BEGINNING_PATTERN = "^#(%d+)"
 M.URL_ISSUE_PATTERN = "[htps]+://[^/]+/([^/]+/[^/]+)/([pulisue]+)/(%d+)"
 
 M.USER_PATTERN = "@([%w-]+)"

--- a/lua/octo/date.lua
+++ b/lua/octo/date.lua
@@ -60,7 +60,7 @@ end
 local function mod(n, d)
   return n - d * floor(n / d)
 end
--- is `str` in string list `tbl`, `ml` is the minimun len
+-- is `str` in string list `tbl`, `ml` is the minimum len
 local function inlist(str, tbl, ml, tn)
   local sl = len(str)
   if sl < (ml or 0) then
@@ -373,20 +373,25 @@ end
 function strwalker:aimchr()
   return "\n" .. self.s .. "\n" .. rep(".", self.e - 1) .. "^"
 end
+
 function strwalker:finish()
   return self.i > self.c
 end
+
 function strwalker:back()
   self.i = self.e
   return self
 end
+
 function strwalker:restart()
   self.i, self.e = 1, 1
   return self
 end
+
 function strwalker:match(s)
   return (find(self.s, s, self.i))
 end
+
 function strwalker:__call(s, f) -- print("strwalker:__call "..s..self:aimchr())
   local is, ie
   is, ie, self[1], self[2], self[3], self[4], self[5] = find(self.s, s, self.i)
@@ -398,6 +403,7 @@ function strwalker:__call(s, f) -- print("strwalker:__call "..s..self:aimchr())
     return self
   end
 end
+
 local function date_parse(str)
   local y, m, d, h, r, s, z, w, u, j, e, x, c, dn, df
   local sw = newstrwalker(gsub(gsub(str, "(%b())", ""), "^(%s*)", "")) -- remove comment, trim leading space
@@ -597,6 +603,7 @@ function dobj:getdate()
   local y, m, d = breakdaynum(self.daynum)
   return y, m + 1, d
 end
+
 function dobj:gettime()
   return breakdayfrc(self.dayfrc)
 end
@@ -609,6 +616,7 @@ end
 function dobj:getyearday()
   return yearday(self.daynum) + 1
 end
+
 function dobj:getweekday()
   return weekday(self.daynum) + 1
 end -- in lua weekday is sunday = 1, monday = 2 ...
@@ -617,26 +625,33 @@ function dobj:getyear()
   local r, _, _ = breakdaynum(self.daynum)
   return r
 end
+
 function dobj:getmonth()
   local _, r, _ = breakdaynum(self.daynum)
   return r + 1
 end -- in lua month is 1 base
+
 function dobj:getday()
   local _, _, r = breakdaynum(self.daynum)
   return r
 end
+
 function dobj:gethours()
   return mod(floor(self.dayfrc / TICKSPERHOUR), HOURPERDAY)
 end
+
 function dobj:getminutes()
   return mod(floor(self.dayfrc / TICKSPERMIN), MINPERHOUR)
 end
+
 function dobj:getseconds()
   return mod(floor(self.dayfrc / TICKSPERSEC), SECPERMIN)
 end
+
 function dobj:getfracsec()
   return mod(floor(self.dayfrc / TICKSPERSEC), SECPERMIN) + (mod(self.dayfrc, TICKSPERSEC) / TICKSPERSEC)
 end
+
 function dobj:getticks(u)
   local x = mod(self.dayfrc, TICKSPERSEC)
   return u and ((x * u) / TICKSPERSEC) or x
@@ -658,16 +673,20 @@ end
 function dobj:getisoweekday()
   return mod(weekday(self.daynum) - 1, 7) + 1
 end -- sunday = 7, monday = 1 ...
+
 function dobj:getisoweeknumber()
   return (isowy(self.daynum))
 end
+
 function dobj:getisoyear()
   return isoy(self.daynum)
 end
+
 function dobj:getisodate()
   local w, y = isowy(self.daynum)
   return y, w, self:getisoweekday()
 end
+
 function dobj:setisoyear(y, w, d)
   local cy, cw, cd = self:getisodate()
   if y then
@@ -690,6 +709,7 @@ end
 function dobj:setisoweekday(d)
   return self:setisoyear(nil, nil, d)
 end
+
 function dobj:setisoweeknumber(w, d)
   return self:setisoyear(nil, w, d)
 end
@@ -716,6 +736,7 @@ end
 function dobj:setmonth(m, d)
   return self:setyear(nil, m, d)
 end
+
 function dobj:setday(d)
   return self:setyear(nil, nil, d)
 end
@@ -734,9 +755,11 @@ end
 function dobj:setminutes(m, s, t)
   return self:sethours(nil, m, s, t)
 end
+
 function dobj:setseconds(s, t)
   return self:sethours(nil, nil, s, t)
 end
+
 function dobj:setticks(t)
   return self:sethours(nil, nil, nil, t)
 end
@@ -744,15 +767,19 @@ end
 function dobj:spanticks()
   return (self.daynum * TICKSPERDAY + self.dayfrc)
 end
+
 function dobj:spanseconds()
   return (self.daynum * TICKSPERDAY + self.dayfrc) / TICKSPERSEC
 end
+
 function dobj:spanminutes()
   return (self.daynum * TICKSPERDAY + self.dayfrc) / TICKSPERMIN
 end
+
 function dobj:spanhours()
   return (self.daynum * TICKSPERDAY + self.dayfrc) / TICKSPERHOUR
 end
+
 function dobj:spandays()
   return (self.daynum * TICKSPERDAY + self.dayfrc) / TICKSPERDAY
 end
@@ -800,18 +827,23 @@ end
 function dobj:adddays(n)
   return dobj_adddayfrc(self, n, TICKSPERDAY, 1)
 end
+
 function dobj:addhours(n)
   return dobj_adddayfrc(self, n, TICKSPERHOUR, HOURPERDAY)
 end
+
 function dobj:addminutes(n)
   return dobj_adddayfrc(self, n, TICKSPERMIN, MINPERDAY)
 end
+
 function dobj:addseconds(n)
   return dobj_adddayfrc(self, n, TICKSPERSEC, SECPERDAY)
 end
+
 function dobj:addticks(n)
   return dobj_adddayfrc(self, n, 1, TICKSPERDAY)
 end
+
 local tvspec = {
   -- Abbreviated weekday name (Sun)
   ["%a"] = function(self)
@@ -995,6 +1027,7 @@ function dobj:fmt0(str)
     return (f and f(self)) or x
   end))
 end
+
 function dobj:fmt(str)
   str = str or self.fmtstr or fmtstr
   return self:fmt0((gmatch(str, "${%w+}")) and (gsub(str, "${%w+}", function(x)
@@ -1010,6 +1043,7 @@ function dobj.__lt(a, b)
     return (a.daynum < b.daynum)
   end
 end
+
 function dobj.__le(a, b)
   if a.daynum == b.daynum then
     return (a.dayfrc <= b.dayfrc)
@@ -1017,22 +1051,27 @@ function dobj.__le(a, b)
     return (a.daynum <= b.daynum)
   end
 end
+
 function dobj.__eq(a, b)
   return (a.daynum == b.daynum) and (a.dayfrc == b.dayfrc)
 end
+
 function dobj.__sub(a, b)
   local d1, d2 = date_getdobj(a), date_getdobj(b)
   local d0 = d1 and d2 and date_new(d1.daynum - d2.daynum, d1.dayfrc - d2.dayfrc)
   return d0 and d0:normalize()
 end
+
 function dobj.__add(a, b)
   local d1, d2 = date_getdobj(a), date_getdobj(b)
   local d0 = d1 and d2 and date_new(d1.daynum + d2.daynum, d1.dayfrc + d2.dayfrc)
   return d0 and d0:normalize()
 end
+
 function dobj.__concat(a, b)
   return tostring(a) .. tostring(b)
 end
+
 function dobj:__tostring()
   return self:fmt()
 end
@@ -1126,20 +1165,24 @@ function date.fmt(str)
   end
   return fmtstr
 end
+
 function date.daynummin(n)
   DAYNUM_MIN = (n and n < DAYNUM_MAX) and n or DAYNUM_MIN
   return n and DAYNUM_MIN or date_new(DAYNUM_MIN, 0):normalize()
 end
+
 function date.daynummax(n)
   DAYNUM_MAX = (n and n > DAYNUM_MIN) and n or DAYNUM_MAX
   return n and DAYNUM_MAX or date_new(DAYNUM_MAX, 0):normalize()
 end
+
 function date.ticks(t)
   if t then
     setticks(t)
   end
   return TICKSPERSEC
 end
+
 --#end -- not DATE_OBJECT_AFX
 
 local tm = osdate("!*t", 0)

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -283,7 +283,7 @@ end
 
 ---Accumulates all the taggable users into a single list that
 --gets set as a buffer variable `taggable_users`. If this list of users
----is needed syncronously, this function will need to be refactored.
+---is needed synchronously, this function will need to be refactored.
 ---The list of taggable users should contain:
 --  - The PR author
 --  - The authors of all the existing comments

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -113,7 +113,7 @@ function M.gen_from_issue(max_number, print_repo)
     elseif kind == "pull_request" then
       filename = utils.get_pull_request_uri(obj.number, obj.repository.nameWithOwner)
     else
-      filename = utils.get_discussion_uri(obj.number, obj.respository.nameWithOwner)
+      filename = utils.get_discussion_uri(obj.number, obj.repository.nameWithOwner)
     end
 
     return {

--- a/lua/octo/reviews/thread-panel.lua
+++ b/lua/octo/reviews/thread-panel.lua
@@ -99,7 +99,7 @@ function M.hide_thread_buffer(split, file)
   if vim.api.nvim_win_is_valid(alt_win) and vim.api.nvim_buf_is_valid(alt_buf) then
     local current_alt_bufnr = vim.api.nvim_win_get_buf(alt_win)
     if current_alt_bufnr ~= alt_buf then
-      -- if we are not showing the corresponging alternative diff buffer, do so
+      -- if we are not showing the corresponding alternative diff buffer, do so
       vim.api.nvim_win_set_buf(alt_win, alt_buf)
 
       -- show the diff

--- a/lua/octo/ui/bubbles.lua
+++ b/lua/octo/ui/bubbles.lua
@@ -2,7 +2,7 @@ local config = require "octo.config"
 local colors = require "octo.ui.colors"
 
 -- A Bubble in the UI is used to make certain elements to visually stand-out.
--- Sometimes they are also called Chips in WebUI framworks. After all they wrap
+-- Sometimes they are also called Chips in WebUI frameworks. After all they wrap
 -- some content (usually text and icons) in a bubble kind-of-shape with a colorful
 -- background. The bubble shape gets especially defined by the outer delimiters.
 -- An examplary usage in this plugin are for label assigned to an issue.

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -916,7 +916,7 @@ function M.write_thread_snippet(bufnr, diffhunk, start_line, comment_start, comm
     snippet_end = #side_lines
   end
   if not snippet_start then
-    -- could not find comment sart line in the diff hunk,
+    -- could not find comment start line in the diff hunk,
     -- defaulting to last diff hunk line - 3
     snippet_start = #side_lines - 3
   end
@@ -1338,11 +1338,11 @@ function M.write_commit_event(bufnr, item)
   table.insert(vt, { conf.timeline_marker .. " ", "OctoTimelineMarker" })
   table.insert(vt, { "EVENT: ", "OctoTimelineItemHeading" })
   if item.commit.committer.user ~= vim.NIL then
-    -- local commiter_bubble = bubbles.make_user_bubble(
+    -- local committer_bubble = bubbles.make_user_bubble(
     --   item.commit.committer.user.login,
     --   item.commit.committer.user.login == vim.g.octo_viewer
     -- )
-    -- vim.list_extend(vt, commiter_bubble)
+    -- vim.list_extend(vt, committer_bubble)
     table.insert(vt, {
       item.commit.committer.user.login,
       item.commit.committer.user.login == vim.g.octo_viewer and "OctoUserViewer" or "OctoUser",

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -515,7 +515,7 @@ function M.get_upstream_branch_from_config(pr)
     return ""
   end
 
-  -- split merge_config to key, value with space delimeter
+  -- split merge_config to key, value with space delimiter
   local merge_config_kv = vim.split(merge_config, "%s+")
   -- use > 2 since there maybe some garbage white space at the end of the map.
   if #merge_config_kv < 2 then
@@ -1033,7 +1033,7 @@ function M.extract_issue_at_cursor(current_repo)
     end
   end
   if not repo or not number then
-    number = M.extract_pattern_at_cursor(constants.SHORT_ISSUE_LINE_BEGGINING_PATTERN)
+    number = M.extract_pattern_at_cursor(constants.SHORT_ISSUE_LINE_BEGINNING_PATTERN)
     if number then
       repo = current_repo
     end
@@ -1071,7 +1071,7 @@ function M.text_wrap(text, width)
       local word = words[l]
       -- If the word is longer than an entire line:
       if #word > width then
-        -- In case the word is longer than multible lines:
+        -- In case the word is longer than multiple lines:
         while #word > width do
           -- Fit as much as possible
           table.insert(line, word:sub(0, widthLeft))


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

When I was going through snacks, I found out there were typos everywhere. SO I just fixed them. Thats all. And used stylua to format.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Using typos cli, I found all typos, then fixed them one by one.

### Describe how to verify it

Well, look through diff.

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt