### PR TITLE
add a callback helper function

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -112,6 +112,24 @@ function M.setup()
   }):start()
 end
 
+--- Create a callback function for the job
+function M.create_callback(opts)
+  opts = opts or {}
+
+  local utils = require "octo.utils"
+
+  opts.success = opts.success or utils.info
+  opts.failure = opts.failure or utils.error
+
+  return function(output, stderr)
+    if stderr and not utils.is_blank(stderr) then
+      opts.failure(stderr)
+    elseif output then
+      opts.success(output)
+    end
+  end
+end
+
 function M.run(opts)
   if not Job then
     return
@@ -148,6 +166,7 @@ function M.run(opts)
       table.insert(opts.args, header)
     end
   end
+
   local job = Job:new {
     enable_recording = true,
     command = config.values.gh_cmd,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Use with any function that uses gh.run

```lua
local gh = require "octo.gh"

--- gh.run itself
local args = ...

local success_case = function(output)
    vim.print(output)
end

gh.run {
  args = args,
  cb = gh.create_callback { success = success_case }
}

--- Any GitHub CLI command
local cb = gh.create_callback()

gh.pr.list { opts = { cb = cb } }

--- Any GitHub GraphQL query
local query = [[
query {
  viewer {
    login
  }
}
]]

local success = function(login)
    vim.notify("Hello, " .. login)
end
local cb = gh.create_callback { success = success }

gh.api.graphql { 
  query = query, 
  jq = ".data.viewer.login",
  opts = {
    cb = cb,
  }
}
```


Closes #764 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt