### PR TITLE
allow for arbitrary callback in label pickers

### DIFF
--- a/lua/octo/pickers/fzf-lua/pickers/assigned_labels.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/assigned_labels.lua
@@ -4,7 +4,10 @@ local graphql = require "octo.gh.graphql"
 local picker_utils = require "octo.pickers.fzf-lua.pickers.utils"
 local utils = require "octo.utils"
 
-return function(cb)
+return function(opts)
+  opts = opts or {}
+  local cb = opts.cb
+
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
 

--- a/lua/octo/pickers/fzf-lua/pickers/labels.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/labels.lua
@@ -4,15 +4,15 @@ local graphql = require "octo.gh.graphql"
 local picker_utils = require "octo.pickers.fzf-lua.pickers.utils"
 local utils = require "octo.utils"
 
-return function(cb)
-  local bufnr = vim.api.nvim_get_current_buf()
-  local buffer = octo_buffers[bufnr]
+return function(opts)
+  opts = opts or {}
 
-  if not buffer then
-    return
-  end
+  local cb = opts.cb
 
-  local query = graphql("labels_query", buffer.owner, buffer.name)
+  opts.repo = opts.repo or utils.get_remote_name()
+  local owner, name = utils.split_repo(opts.repo)
+
+  local query = graphql("labels_query", owner, name)
 
   local get_contents = function(fzf_cb)
     gh.run {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This allows for some more flexibility

For instance: 

```lua 
local picker = require "octo.picker"

picker.labels {
  cb = function(labels)
    vim.notify("The selected labels are: " .. vim.inspect(labels))
  end
}
```

> [!IMPORTANT]
>
> This will only affect those that are using the pickers directly

TODO: 

- [x] Change the API for the fzf picker as well

Any thoughts on this?


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt