### PR TITLE
add REST API functions and metatable for get

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -285,7 +285,11 @@ end
 
 local rest = function(method, opts)
   local run_opts = opts.opts or {}
-  local args = { "api", "--method", method }
+  local args = { "api" }
+  if method ~= nil then
+    table.insert(args, "--method")
+    table.insert(args, method)
+  end
 
   opts.opts = nil
   args = M.insert_args(args, opts)
@@ -318,7 +322,7 @@ M.api = {
 
 setmetatable(M.api, {
   __call = function(_, opts)
-    return M.api.get(opts)
+    return rest(nil, opts)
   end,
 })
 

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -204,7 +204,7 @@ end
 ---Insert the options into the args table
 ---@param args table the arguments table
 ---@param options table the options to insert
----@param replace table key value pairs to replace in the key of the options
+---@param replace table|nil key value pairs to replace in the key of the options
 ---@return table the updated args table
 M.insert_args = function(args, options, replace)
   replace = replace or {}
@@ -283,9 +283,44 @@ function M.graphql(opts)
   }
 end
 
+local rest = function(method, opts)
+  local run_opts = opts.opts or {}
+  local args = { "api", "--method", method }
+
+  opts.opts = nil
+  args = M.insert_args(args, opts)
+
+  M.run {
+    args = args,
+    mode = run_opts.mode,
+    cb = run_opts.cb,
+    stream_cb = run_opts.stream_cb,
+    headers = run_opts.headers,
+    hostname = run_opts.hostname,
+  }
+end
+
 M.api = {
   graphql = M.graphql,
+  get = function(opts)
+    return rest("GET", opts)
+  end,
+  post = function(opts)
+    return rest("POST", opts)
+  end,
+  patch = function(opts)
+    return rest("PATCH", opts)
+  end,
+  delete = function(opts)
+    return rest("DELETE", opts)
+  end,
 }
+
+setmetatable(M.api, {
+  __call = function(_, opts)
+    return M.api.get(opts)
+  end,
+})
 
 local create_subcommand = function(command)
   local subcommand = {}


### PR DESCRIPTION
Convenience wrapper around the REST API

```lua
local gh = require "octo.gh"

local opts = { cb = gh.create_callback() }

gh.api { -- or gh.api.get
  "/notifications",
  opts = opts,
}
```
This would be the same as `gh api /notifications` with the CLI

Other available methods are: 

- `gh.api.post`
- `gh.api.patch`
- `gh.api.delete`

User can still specify the method if `gh.api` is used, e.g. `gh.api { "/notifications", method = "GET" }`

Closes #751