### PR TITLE
Use info only on pr ready command success

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1334,10 +1334,12 @@ local change_to_ready = function(opts)
     undo = opts.undo,
     opts = {
       cb = gh.create_callback {
-        success = function(output)
+        -- There seems to be something wrong with the CLI output. It comes back as stderr
+        failure = function(output)
           utils.info(output)
           writers.write_state(bufnr)
         end,
+        success = utils.error,
       },
     },
   }

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -247,10 +247,10 @@ function M.setup()
         M.pr_checks()
       end,
       ready = function()
-        M.pr_ready_for_review()
+        M.gh_pr_ready { undo = false }
       end,
       draft = function()
-        M.pr_draft()
+        M.gh_pr_ready { undo = true }
       end,
       search = function(repo, ...)
         local opts = M.process_varargs(repo, ...)
@@ -1322,7 +1322,7 @@ end
 --- Change PR state to ready for review or draft
 --- @param opts table
 --- @field undo boolean Whether to undo from ready to draft
-local change_to_ready = function(opts)
+M.gh_pr_ready = function(opts)
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
   if not buffer or not buffer:isPullRequest() then
@@ -1344,14 +1344,6 @@ local change_to_ready = function(opts)
       },
     },
   }
-end
-
-function M.pr_ready_for_review()
-  change_to_ready { undo = false }
-end
-
-function M.pr_draft()
-  change_to_ready { undo = true }
 end
 
 function M.pr_checks()

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1326,6 +1326,7 @@ local change_to_ready = function(opts)
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
   if not buffer or not buffer:isPullRequest() then
+    utils.error "Not a PR buffer"
     return
   end
 

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1319,9 +1319,11 @@ function M.save_pr(opts)
   end
 end
 
---- Change PR state to ready for review or draft
---- @param opts table
+--- @class PRReadyOpts
 --- @field undo boolean Whether to undo from ready to draft
+
+--- Change PR state to ready for review or draft
+--- @param opts PRReadyOpts
 M.gh_pr_ready = function(opts)
   local bufnr = vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]


### PR DESCRIPTION
Bit odd. The std_err seems to be returned regardless of the success of the command. 