### PR TITLE
allow for gh run commands as well as previous run function

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -347,6 +347,7 @@ local create_subcommand = function(command)
 
   setmetatable(subcommand, {
     __call = function(_, opts)
+      --- Allow for backwards compatibility with the old API gh.run { ... }
       if command == "run" then
         return run(opts)
       end

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -141,7 +141,7 @@ end
 ---Run a gh command
 ---@param opts RunOpts
 ---@return string[]|nil
-function M.run(opts)
+local function run(opts)
   if not Job then
     return
   end
@@ -284,7 +284,7 @@ end
 ---@return table|nil
 function M.graphql(opts)
   local run_opts = opts.opts or {}
-  return M.run {
+  return run {
     args = create_graphql_args(opts.query, opts.fields, opts.paginate, opts.slurp, opts.jq),
     mode = run_opts.mode,
     cb = run_opts.cb,
@@ -305,7 +305,7 @@ local rest = function(method, opts)
   opts.opts = nil
   args = M.insert_args(args, opts)
 
-  M.run {
+  run {
     args = args,
     mode = run_opts.mode,
     cb = run_opts.cb,
@@ -346,6 +346,11 @@ local create_subcommand = function(command)
   subcommand.command = command
 
   setmetatable(subcommand, {
+    __call = function(_, opts)
+      if command == "run" then
+        return run(opts)
+      end
+    end,
     __index = function(t, key)
       return function(opts)
         opts = opts or {}
@@ -360,7 +365,7 @@ local create_subcommand = function(command)
         opts.opts = nil
         args = M.insert_args(args, opts, { ["_"] = "-" })
 
-        return M.run {
+        return run {
           args = args,
           mode = run_opts.mode,
           cb = run_opts.cb,


### PR DESCRIPTION
The function `gh.run` didn't allow for using the subcommands of GitHub CLI's `run` (Dynamic subcommands from #810)

This change allows for both. For example, `gh.run { args = { "pr", "list" } }` is backwards compatible. 

But `gh.run.list {}`, `gh.run.view { number }`, etc is now also possible.