### PR TITLE
Pass table to format templated endpoint

### DIFF
--- a/lua/tests/plenary/gh_spec.lua
+++ b/lua/tests/plenary/gh_spec.lua
@@ -109,6 +109,74 @@ describe("insert_args:", function()
   end)
 end)
 
+local tables_have_same_elements = function(t1, t2)
+  if #t1 ~= #t2 then
+    return false
+  end
+  for _, v in ipairs(t1) do
+    if not vim.tbl_contains(t2, v) then
+      return false
+    end
+  end
+  for _, v in ipairs(t2) do
+    if not vim.tbl_contains(t1, v) then
+      return false
+    end
+  end
+  return true
+end
+
+local assert_tables_have_same_elements = function(t1, t2)
+  assert(
+    tables_have_same_elements(t1, t2),
+    string.format("Expected tables to have the same elements:\n%s\n%s", vim.inspect(t1), vim.inspect(t2))
+  )
+end
+
+describe("REST API args", function()
+  it("no args", function()
+    local actual = gh.create_rest_args(nil, {})
+    eq(actual, nil)
+  end)
+  it("Endpoint is required", function()
+    local actual = gh.create_rest_args(nil, { format = { owner = "pwntester" }, json = "id", jq = ".id" })
+    eq(actual, nil)
+  end)
+  it("Returns table with untouched endpoint", function()
+    local actual = gh.create_rest_args("GET", {
+      "repos/pwntester/octo.nvim/pulls",
+      jq = ".[].number",
+      paginate = true,
+    })
+    assert_tables_have_same_elements(actual, {
+      "api",
+      "--method",
+      "GET",
+      "repos/pwntester/octo.nvim/pulls",
+      "--jq",
+      ".[].number",
+      "--paginate",
+    })
+  end)
+  it("Returns table with formated endpoint", function()
+    local actual = gh.create_rest_args("GET", {
+      "repos/{owner}/{name}/pulls",
+      format = { owner = "pwntester", name = "octo.nvim" },
+      jq = ".[].number",
+      paginate = true,
+    })
+    assert_tables_have_same_elements(actual, {
+      "api",
+      "--method",
+      "GET",
+      "repos/pwntester/octo.nvim/pulls",
+      "--jq",
+      ".[].number",
+      "--paginate",
+    })
+  end)
+end)
+
 describe("CLI commands", function()
   it("gh.<something> returns table", function()
     local commands = {

--- a/lua/tests/plenary/gh_spec.lua
+++ b/lua/tests/plenary/gh_spec.lua
@@ -174,7 +174,8 @@ describe("REST API args", function()
       ".[].number",
       "--paginate",
     })
-
+  end)
+end)
 
 describe("create_graphql_opts:", function()
   local query = "example query"


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Closes #821

Use the `format` parameter to format a templated endpoint string

```lua
local gh = require "octo.gh"

local endpoint = "/repos/{owner}/{repo}/issues/{issue_number}"

local opts = { cb = gh.create_callback {} }

gh.api.get { 
  endpoint, 
  format = { owner = "pwntester", repo = "octo.nvim", issue_number = 1 },
  jq = "{ title, body, author: .user.login }",
  opts = opts,
}
```

However, the `format` parameter is not required. If it is not provided, the endpoint string is used as is (current behavior).

```lua
local gh = require "octo.gh"

local endpoint = "/repos/pwntester/octo.nvim/issues/1"

local opts = { cb = gh.create_callback {} }

gh.api.get { 
  endpoint, 
  jq = "{ title, body, author: .user.login }",
  opts = opts,
}
```

CC: @ldelossa


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt