### PR TITLE
Make graphql closer to cli

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -256,27 +256,41 @@ M.insert_args = function(args, options, replace)
   return args
 end
 
+---@class GraphQLOpts
+---@field query string|nil
+---@field fields table|nil
+---@field paginate boolean|nil
+---@field slurp boolean|nil
+---@field F table|nil field
+---@field f table|nil raw-field
+---@field jq string|nil
+
 ---Create the arguments for the graphql query
----@param query string the graphql query
----@param fields table key value pairs for graphql query
----@param paginate boolean whether to paginate the results
----@param slurp boolean whether to slurp the results
----@param jq string the jq query to apply to the results
----@return table
-local create_graphql_args = function(query, fields, paginate, slurp, jq)
+---@param opts GraphQLOpts
+---@return table|nil
+M.create_graphql_args = function(opts)
   local args = { "api", "graphql" }
 
-  local opts = {
-    f = {
-      query = query,
-    },
-    F = fields,
-    paginate = paginate,
-    slurp = slurp,
-    jq = jq,
-  }
+  -- add query to the existing raw-field
+  local f = opts.f or {}
+  local query = opts.query or f.query
+  if not query then
+    return
+  end
+  opts.query = nil
 
-  return M.insert_args(args, opts)
+  f.query = query
+  opts.f = f
+
+  -- Join F and fields together
+  local F = opts.F or {}
+  local fields = opts.fields or {}
+
+  opts.fields = nil
+
+  opts.F = vim.tbl_extend("force", F, fields)
+
+  return M.insert_args(args, opts, { ["_"] = "-" })
 end
 
 --- The gh.api commands
@@ -286,9 +300,20 @@ M.api = {}
 ---@param opts table the options for the graphql query
 ---@return table|nil
 function M.api.graphql(opts)
+  opts = opts or {}
   local run_opts = opts.opts or {}
+
+  opts.opts = nil
+  local args = M.create_graphql_args(opts)
+
+  if not args then
+    local utils = require "octo.utils"
+    utils.error "Provide query directly or in the f table."
+    return
+  end
+
   return run {
-    args = create_graphql_args(opts.query, opts.fields, opts.paginate, opts.slurp, opts.jq),
+    args = args,
     mode = run_opts.mode,
     cb = run_opts.cb,
     stream_cb = run_opts.stream_cb,

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -268,9 +268,7 @@ end
 ---Create the arguments for the graphql query
 ---@param opts GraphQLOpts
 ---@return table|nil
-M.create_graphql_args = function(opts)
-  local args = { "api", "graphql" }
-
+M.create_graphql_opts = function(opts)
   -- add query to the existing raw-field
   local f = opts.f or {}
   local query = opts.query or f.query
@@ -290,7 +288,7 @@ M.create_graphql_args = function(opts)
 
   opts.F = vim.tbl_extend("force", F, fields)
 
-  return M.insert_args(args, opts, { ["_"] = "-" })
+  return opts
 end
 
 --- The gh.api commands
@@ -304,13 +302,16 @@ function M.api.graphql(opts)
   local run_opts = opts.opts or {}
 
   opts.opts = nil
-  local args = M.create_graphql_args(opts)
+  local graphql_opts = M.create_graphql_opts(opts)
 
-  if not args then
+  if not graphql_opts then
     local utils = require "octo.utils"
     utils.error "Provide query directly or in the f table."
     return
   end
+
+  local args = { "api", "graphql" }
+  args = M.insert_args(args, graphql_opts, { ["_"] = "-" })
 
   return run {
     args = args,

--- a/lua/tests/plenary/gh_spec.lua
+++ b/lua/tests/plenary/gh_spec.lua
@@ -109,6 +109,43 @@ describe("insert_args:", function()
   end)
 end)
 
+describe("create_graphql_opts:", function()
+  local query = "example query"
+  local login = "pwntester"
+  local repo = "octo.nvim"
+
+  it("query added to f", function()
+    local actual = gh.create_graphql_opts {
+      query = query,
+      f = { login = login },
+    }
+    eq(actual.f.query, query)
+    eq(actual.query, nil)
+    --- Stays the same
+    eq(actual.f.login, login)
+  end)
+
+  it("fields appended to F", function()
+    local actual = gh.create_graphql_opts {
+      query = query,
+      fields = { login = login },
+      F = { repo = repo },
+    }
+    eq(actual.F.login, login)
+    eq(actual.F.repo, repo)
+    eq(actual.fields, nil)
+  end)
+
+  it("other fields stay", function()
+    local actual = gh.create_graphql_opts {
+      query = query,
+      raw_field = { login = login },
+      F = { repo = repo },
+    }
+    eq(actual.raw_field.login, login)
+  end)
+end)
+
 describe("CLI commands", function()
   it("gh.<something> returns table", function()
     local commands = {

--- a/lua/tests/plenary/gh_spec.lua
+++ b/lua/tests/plenary/gh_spec.lua
@@ -130,6 +130,13 @@ describe("create_graphql_opts:", function()
     eq(actual.jq, jq)
   end)
 
+  it("query is required", function()
+    local actual = gh.create_graphql_opts {
+      f = { login = login },
+    }
+    eq(actual, nil)
+  end)
+
   it("query added to f", function()
     local actual = gh.create_graphql_opts {
       query = query,

--- a/lua/tests/plenary/gh_spec.lua
+++ b/lua/tests/plenary/gh_spec.lua
@@ -113,6 +113,22 @@ describe("create_graphql_opts:", function()
   local query = "example query"
   local login = "pwntester"
   local repo = "octo.nvim"
+  local jq = ".data.user.login"
+
+  it("previous behavior", function()
+    local actual = gh.create_graphql_opts {
+      query = query,
+      fields = { login = login, repo = repo },
+      jq = jq,
+    }
+
+    eq(actual.f.query, query)
+    eq(actual.query, nil)
+    eq(actual.F.login, login)
+    eq(actual.F.repo, repo)
+    eq(actual.fields, nil)
+    eq(actual.jq, jq)
+  end)
 
   it("query added to f", function()
     local actual = gh.create_graphql_opts {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This allows use of graphql API to be a bit closer to the CLI

For instance, `gh api graphql -f query=<query> -F login=<login> -F repo=<repo>` is :

```lua
local gh = require "octo.gh"

gh.api.graphql {
  f = { query = query },  
  F = { login = login, repo = repo }, 
}
```

The previous behavior still exists: 

```lua
gh.api.graphql {
  query = query, 
  fields = { login = login, repo = repo },
}
```


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
