### PR TITLE
fix: disable cursorline due to Neovim bug

### DIFF
--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -51,6 +51,7 @@ FileEntry.__index = FileEntry
 FileEntry.winopts = {
   foldmethod = "diff",
   foldlevel = 0,
+  cursorlineopt = "number", -- disable cursorline due to Neovim bug https://github.com/neovim/neovim/issues/9800
 }
 
 ---FileEntry constructor


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This disables the cursorline `line` option because of an upstream bug in Neovim core.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Related to https://github.com/neovim/neovim/issues/9800

### Describe how you did it

### Describe how to verify it

**before**

<img width="252" alt="before" src="https://github.com/user-attachments/assets/29989fc2-e867-4f88-908d-5bcc61d8e549" />

**after**

<img width="256" alt="after" src="https://github.com/user-attachments/assets/dd94347a-667b-414e-b4ff-18dc4ab999d8" />


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
