### PR TITLE
Add colors to `Octo pr changes` and improve width

### DIFF
--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -161,14 +161,16 @@ function M.gen_from_git_commits()
   end
 end
 
-function M.gen_from_git_changed_files()
+function M.gen_from_git_changed_files(opts)
+  opts = opts or {}
+
   local displayer = entry_display.create {
     separator = " ",
     items = {
-      { width = 8 },
+      { width = 7 },
       { width = string.len "modified" },
-      { width = 5 },
-      { width = 5 },
+      { width = #tostring(opts.max_additions) + 1 },
+      { width = #tostring(opts.max_deletions) + 1 },
       { remaining = true },
     },
   }

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -473,6 +473,18 @@ function M.changed_files()
         utils.error(stderr)
       elseif output then
         local results = vim.json.decode(output)
+
+        local max_additions = -1
+        local max_deletions = -1
+        for _, result in ipairs(results) do
+          if result.additions > max_additions then
+            max_additions = result.additions
+          end
+          if result.deletions > max_deletions then
+            max_deletions = result.deletions
+          end
+        end
+
         pickers
           .new({}, {
             prompt_title = false,
@@ -480,7 +492,10 @@ function M.changed_files()
             preview_title = false,
             finder = finders.new_table {
               results = results,
-              entry_maker = entry_maker.gen_from_git_changed_files(),
+              entry_maker = entry_maker.gen_from_git_changed_files {
+                max_additions = max_additions,
+                max_deletions = max_deletions,
+              },
             },
             sorter = conf.generic_sorter {},
             previewer = previewers.changed_files.new { repo = buffer.repo, number = buffer.number },

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -110,6 +110,8 @@ local function get_hl_links()
     ReactionViewer = "OctoViewer",
     PassingTest = "OctoGreen",
     FailingTest = "OctoRed",
+    PullAdditions = "OctoGreen",
+    PullDeletions = "OctoRed",
     DiffstatAdditions = "OctoGreen ",
     DiffstatDeletions = "OctoRed ",
     DiffstatNeutral = "OctoGrey",


### PR DESCRIPTION
- **add the forgotten colors**
- **get max numbers**
- **use the max value to determine width**

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

The telescope picker for `pr changes` was missing the colors and the width is now dynamic based on the results.

