### PR TITLE
fix: set valid highlight for OctoFilePanelFileName

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ Also,you can use [`cmp-emoji`](https://github.com/hrsh7th/cmp-emoji) or [`blink-
 | _OctoStatusLine_                  | StatusLine         |
 | _OctoStatusLineNC_                | StatusLineNC       |
 | _OctoEndOfBuffer_                 | EndOfBuffer        |
-| _OctoFilePanelFileName_           | NormalFront        |
+| _OctoFilePanelFileName_           | NormalFloat        |
 | _OctoFilePanelSelectedFile_       | Type               |
 | _OctoFilePanelPath_               | Comment            |
 | _OctoStatusAdded_                 | OctoGreen          |

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -61,7 +61,7 @@ local function get_hl_groups()
 
     FilePanelTitle = { fg = get_fg "Directory" or colors.blue, gui = "bold" },
     FilePanelCounter = { fg = get_fg "Identifier" or colors.purple, gui = "bold" },
-    NormalFront = { fg = get_fg "Normal" or colors.white },
+    NormalFloat = { fg = get_fg "Normal" or colors.white },
     Viewer = { fg = colors.black, bg = colors.blue },
     Editable = { bg = float_bg },
     Strikethrough = { fg = colors.grey, gui = "strikethrough" },
@@ -78,7 +78,7 @@ local function get_hl_links()
     StatusLine = "StatusLine",
     StatusLineNC = "StatusLineNC",
     EndOfBuffer = "EndOfBuffer",
-    FilePanelFileName = "NormalFront",
+    FilePanelFileName = "NormalFloat",
     FilePanelSelectedFile = "Type",
     FilePanelPath = "Comment",
     StatusAdded = "OctoGreen",

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -345,7 +345,7 @@ function M.write_reactions(bufnr, reaction_groups, line)
       local icon = utils.reaction_map[group.content]
       local bubble = bubbles.make_reaction_bubble(icon, group.viewerHasReacted)
       vim.list_extend(reactions_vt, bubble)
-      table.insert(reactions_vt, { " " .. group.users.totalCount .. " ", "NormalFront" })
+      table.insert(reactions_vt, { " " .. group.users.totalCount .. " ", "NormalFloat" })
     end
   end
   M.write_virtual_text(bufnr, constants.OCTO_REACTIONS_VT_NS, line - 1, reactions_vt)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

I cannot find any info on `hl-NormalFront`. I assume it's a typo and should be `hl-NormalFloat`

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

### Describe how to verify it

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
