### PR TITLE
refactor!: update deprecated highlight VertSplit to WinSeparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ Also,you can use [`cmp-emoji`](https://github.com/hrsh7th/cmp-emoji) or [`blink-
 |-----------------------------------|--------------------|
 | _OctoNormal_                      | Normal             |
 | _OctoCursorLine_                  | CursorLine         |
-| _OctoVertSplit_                   | VertSplit          |
+| _OctoWinSeparator_                | WinSeparator       |
 | _OctoSignColumn_                  | Normal             |
 | _OctoStatusColumn_                | SignColumn         |
 | _OctoStatusLine_                  | StatusLine         |
@@ -564,7 +564,7 @@ Also,you can use [`cmp-emoji`](https://github.com/hrsh7th/cmp-emoji) or [`blink-
 | _OctoStateMergedBubble_           | OctoBubblePurple   |
 | _OctoStatePendingBubble_          | OctoBubbleYellow   |
 | _OctoStateApprovedBubble_         | OctoBubbleGreen    |
-| _OctoStateChangesRequestedBubble_ | OctoBubbleRed    |
+| _OctoStateChangesRequestedBubble_ | OctoBubbleRed      |
 | _OctoStateDismissedBubble_        | OctoBubbleRed      |
 | _OctoStateCommentedBubble_        | OctoBubbleBlue     |
 | _OctoStateSubmittedBubble_        | OctoBubbleGreen    |

--- a/lua/octo/reviews/file-panel.lua
+++ b/lua/octo/reviews/file-panel.lua
@@ -38,7 +38,7 @@ FilePanel.winopts = {
   winhl = table.concat({
     "EndOfBuffer:OctoEndOfBuffer",
     "Normal:OctoNormal",
-    "VertSplit:OctoVertSplit",
+    "WinSeparator:OctoWinSeparator",
     "SignColumn:OctoNormal",
     "StatusLine:OctoStatusLine",
     "StatusLineNC:OctoStatuslineNC",

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -72,7 +72,7 @@ local function get_hl_links()
   return {
     Normal = "Normal",
     CursorLine = "CursorLine",
-    VertSplit = "VertSplit",
+    WinSeparator = "WinSeparator",
     SignColumn = "Normal",
     StatusColumn = "SignColumn",
     StatusLine = "StatusLine",


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

`hl-VertSplit` is deprecated in Neovim core. Help advises to use `hl-WinSeparator` instead. This is a breaking change because of the rename.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

### Describe how to verify it

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
