### PR TITLE
fix(panel): set cursorlineopt to line

### DIFF
--- a/lua/octo/reviews/file-panel.lua
+++ b/lua/octo/reviews/file-panel.lua
@@ -29,6 +29,7 @@ FilePanel.winopts = {
   spell = false,
   wrap = false,
   cursorline = true,
+  cursorlineopt = "line",
   signcolumn = "yes",
   foldmethod = "manual",
   foldcolumn = "0",


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Octo's panel sets the `'cursorline'` option, but it wouldn't show up if users had `'cursorlineopt'` globally configured to `"number"`, since the option `'number'` is disabled.

### Does this pull request fix one issue?

NONE

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Added the new option for the panel

### Describe how to verify it

Should be straightforward, but if you wanna make sure, try setting  `'cursorlineopt'` globally to `"number"`


### Special notes for reviews

---

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
