### PR TITLE
refactor: switch remaining `vim.fn.json_...` calls to `vim.json`

### DIFF
--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -25,7 +25,7 @@ local function get_filter(opts, kind)
         -- string
         val = opts[value]
       end
-      val = vim.fn.json_encode(val)
+      val = vim.json.encode(val)
       val = string.gsub(val, '"OPEN"', "OPEN")
       val = string.gsub(val, '"CLOSED"', "CLOSED")
       val = string.gsub(val, '"MERGED"', "MERGED")

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -63,7 +63,7 @@ function Review:populate_threads(callback)
         if stderr and not utils.is_blank(stderr) then
           utils.error(stderr)
         elseif output then
-          local resp = vim.fn.json_decode(output)
+          local resp = vim.json.decode(output)
           callback(resp)
         end
       end,

--- a/lua/octo/workflow_runs.lua
+++ b/lua/octo/workflow_runs.lua
@@ -526,7 +526,7 @@ local function update_job_details(id)
           vim.api.nvim_err_writeln(stderr)
           utils.error("Failed to get workflow run for " .. id)
         elseif output then
-          job_details = vim.fn.json_decode(output)
+          job_details = vim.json.decode(output)
           M.wf_cache[id] = job_details
           M.current_wf = job_details
           M.tree = generate_workflow_tree(job_details)
@@ -661,7 +661,7 @@ local function get_workflow_runs_sync(opts)
     vim.api.nvim_err_writeln(stderr)
     utils.error "Failed to get workflow runs"
   elseif output then
-    local json = vim.fn.json_decode(output)
+    local json = vim.json.decode(output)
     for _, value in ipairs(json) do
       local status = value.status == "queued" and icons.pending
         or value.status == "in_progress" and icons.in_progress


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

I noticed that a few `vim.fn.json_...` calls remain in the codebase while most of them already use the newer `vim.json` API. Not sure if something else needs to be done here.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

### Describe how to verify it

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
