### PR TITLE
Add helper to display all hightlight groups

### DIFF
--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -228,4 +228,59 @@ function M.create_highlight(rgb_hex, options)
   return highlight_name
 end
 
+local function display_highlight_groups(groups)
+  -- Check if input is a table
+  if type(groups) ~= "table" then
+    print "Please provide a table of highlight group names"
+    return
+  end
+
+  local example_text = "Sample Text"
+
+  local format_str = "%-30s %-10s %-10s %-10s %-10s %-10s %s"
+  -- print(string.format(format_str, "Group", "fg", "bg", "bold", "italic", "underline", "Example"))
+  -- print(string.rep("-", 86 + #example_text))
+  vim.api.nvim_echo({
+    { string.format(format_str, "Group", "fg", "bg", "bold", "italic", "underline", "Example"), "None" },
+  }, false, {})
+  vim.api.nvim_echo({
+    { string.rep("-", 86 + #example_text), "None" },
+  }, false, {})
+
+  for _, group_name in ipairs(groups) do
+    local hl = vim.api.nvim_get_hl(0, { name = group_name, link = false })
+    if hl then
+      local fg = hl.fg and string.format("#%06x", hl.fg) or "none"
+      local bg = hl.bg and string.format("#%06x", hl.bg) or "none"
+      local bold = hl.bold and "yes" or "no"
+      local italic = hl.italic and "yes" or "no"
+      local underline = hl.underline and "yes" or "no"
+
+      -- Create a sample text with the highlight applied
+      local output = string.format(format_str, group_name, fg, bg, bold, italic, underline, "")
+
+      -- Output the sample with syntax highlighting in a separate line
+      vim.api.nvim_echo({
+        { output, "None" },
+        { example_text, group_name },
+      }, false, {})
+    else
+      vim.api.nvim_echo(
+        { { string.format(format_str, group_name, "not found", "", "", "", "", ""), "None" } },
+        false,
+        {}
+      )
+    end
+  end
+end
+
+function M.octo_highlight_groups()
+  local groups = {}
+  for v, _ in pairs(get_hl_groups()) do
+    table.insert(groups, "Octo" .. v)
+  end
+
+  display_highlight_groups(groups)
+end
+
 return M

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -43,7 +43,7 @@ local function get_hl_groups()
     PurpleFloat = { fg = colors.purple, bg = float_bg },
     YellowFloat = { fg = colors.yellow, bg = float_bg },
     BlueFloat = { fg = colors.blue, bg = float_bg },
-    GreyFloat = { fg = colors.grey, bg = float_bg },
+    GreyFloat = { bg = float_bg },
 
     BubbleGreen = { fg = colors.grey, bg = colors.dark_green },
     BubbleRed = { fg = colors.grey, bg = colors.dark_red },
@@ -228,14 +228,14 @@ function M.create_highlight(rgb_hex, options)
   return highlight_name
 end
 
-local function display_highlight_groups(groups)
+local function display_highlight_groups(groups, example_text)
   -- Check if input is a table
   if type(groups) ~= "table" then
     print "Please provide a table of highlight group names"
     return
   end
 
-  local example_text = "Sample Text"
+  example_text = example_text or "Sample Text"
 
   local format_str = "%-30s %-10s %-10s %-10s %-10s %-10s %s"
   -- print(string.format(format_str, "Group", "fg", "bg", "bold", "italic", "underline", "Example"))
@@ -274,13 +274,13 @@ local function display_highlight_groups(groups)
   end
 end
 
-function M.octo_highlight_groups()
+function M.octo_highlight_groups(example_text)
   local groups = {}
   for v, _ in pairs(get_hl_groups()) do
     table.insert(groups, "Octo" .. v)
   end
 
-  display_highlight_groups(groups)
+  display_highlight_groups(groups, example_text)
 end
 
 return M


### PR DESCRIPTION

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

```lua
require "octo.ui.colors".octo_highlight_groups("Example text")
```

```
Group                          fg         bg         bold       italic     underline  Example
--------------------------------------------------------------------------------------------------
OctoBubbleDelimiterGrey        #2a354c    none       no         no         no         Example text
OctoFilePanelTitle             #58a6ff    none       yes        no         no         Example text
OctoFilePanelCounter           #6f42c1    none       yes        no         no         Example text
OctoViewer                     #000000    #58a6ff    no         no         no         Example text
OctoEditable                   none       #3c3836    no         no         no         Example text
OctoStrikethrough              #2a354c    none       no         no         no         Example text
OctoNormalFloat                #ffffff    none       no         no         no         Example text
OctoGreen                      #238636    none       no         no         no         Example text
OctoRed                        #da3633    none       no         no         no         Example text
OctoPurple                     #6f42c1    none       no         no         no         Example text
OctoYellow                     #d3c846    none       no         no         no         Example text
OctoBlue                       #58a6ff    none       no         no         no         Example text
OctoGrey                       #2a354c    none       no         no         no         Example text
OctoGreenFloat                 #238636    #3c3836    no         no         no         Example text
OctoRedFloat                   #da3633    #3c3836    no         no         no         Example text
OctoPurpleFloat                #6f42c1    #3c3836    no         no         no         Example text
OctoYellowFloat                #d3c846    #3c3836    no         no         no         Example text
OctoBlueFloat                  #58a6ff    #3c3836    no         no         no         Example text
OctoGreyFloat                  none       #3c3836    no         no         no         Example text
OctoBubbleGreen                #2a354c    #238636    no         no         no         Example text
OctoBubbleRed                  #2a354c    #da3633    no         no         no         Example text
OctoBubblePurple               #ffffff    #6f42c1    no         no         no         Example text
OctoBubbleYellow               #2a354c    #d3c846    no         no         no         Example text
OctoBubbleBlue                 #2a354c    #0366d6    no         no         no         Example text
OctoBubbleGrey                 #ffffff    #2a354c    no         no         no         Example text
OctoBubbleDelimiterGreen       #238636    none       no         no         no         Example text
OctoBubbleDelimiterRed         #da3633    none       no         no         no         Example text
OctoBubbleDelimiterPurple      #6f42c1    none       no         no         no         Example text
OctoBubbleDelimiterYellow      #d3c846    none       no         no         no         Example text
OctoBubbleDelimiterBlue        #0366d6    none       no         no         no         Example text
```

> [!TIP]
>
> Make sure that `require "octo.ui.colors".setup()` is called before using the function.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

- **add a helper function to display hl groups**
- **dont use grey on grey**


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
