### PR TITLE
Add `:Octo discussion close` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,8 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 |    | create [repo]                                          | Create discussion for current or specified repo |
 |    | reload                                                 | Reload the current discussion buffer |
 |    | close                                                 | Close the discussion |
+|    | mark                                                 | Mark the discussion comment as answer |
+|    | unmark                                                 | Unmark the discussion comment as answer |
 
 
 0. `[repo]`: If repo is not provided, it will be derived from `<cwd>/.git/config`.

--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 | discussion   | list [repo]                                          | List open discussions for current or specified repo |
 |    | create [repo]                                          | Create discussion for current or specified repo |
 |    | reload                                                 | Reload the current discussion buffer |
+|    | close                                                 | Close the discussion |
+
 
 0. `[repo]`: If repo is not provided, it will be derived from `<cwd>/.git/config`.
 

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -91,6 +91,7 @@ See |octo-command-examples| for examples.
                           <C-y>   Copy URL to system clipboard.
   create [repo]         Creates a new discussion for the current or specified repo.
   reload                Reload discussion. Same as doing `e!`.
+  close                 Close the discussion
 
 
 :Octo repo [action]                             *octo-commands-repo*

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -92,6 +92,8 @@ See |octo-command-examples| for examples.
   create [repo]         Creates a new discussion for the current or specified repo.
   reload                Reload discussion. Same as doing `e!`.
   close                 Close the discussion
+  mark                  Mark the discussion comment as answered
+  unmark                Mark the discussion comment as unanswered
 
 
 :Octo repo [action]                             *octo-commands-repo*

--- a/lua/octo/gh/mutations.lua
+++ b/lua/octo/gh/mutations.lua
@@ -1069,4 +1069,14 @@ mutation($issue_id: ID!) {
 }
 ]]
 
+M.close_discussion = [[
+mutation($discussion_id: ID!, $reason: DiscussionCloseReason) {
+  closeDiscussion(input: {discussionId: $discussion_id, reason: $reason}) {
+    discussion {
+      id
+    }
+  }
+}
+]]
+
 return M


### PR DESCRIPTION

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This allows users to close a discussion with `:Octo discussion close`

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

- **add the required mutation**
- **add the command**
- **add the command to documentation**
- **add documentation for mark and unmark**

### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
