### PR TITLE
Add `:Octo discussion search` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Octo issue edit 1
 Octo issue list createdBy=pwntester
 Octo issue list neovim/neovim labels=bug,help\ wanted states=OPEN
 Octo search assignee:pwntester is:pr
+Octo search is:discussion repo:pwntester/octo.nvim category:"Show and Tell"
 ```
 
 ## 📋 PR reviews

--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 |    | mark                                                 | Mark the discussion comment as answer |
 |    | unmark                                                 | Unmark the discussion comment as answer |
 |    | reopen                                                 | Reopen the current discussion |
+|    | search                                                 | Search discussions |
 
 
 0. `[repo]`: If repo is not provided, it will be derived from `<cwd>/.git/config`.

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 |          | commit                                            | Pick a specific commit to review                                                                                                                       |
 |          | close                                             | Close the review window and return to the PR                                                                                                           |
 | actions  |                                                   | Lists all available Octo actions                                                                                                                       |
-| search   | <query>                                           | Search GitHub for issues and PRs matching the [query](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) |
+| search   | <query>                                           | Search GitHub for issues and PRs matching the [query](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) or Discussions with `is:discussion`|
 | run      | list                                              | List workflow runs                                                                                                                                     |
 | notification | list                                          | Shows current unread notifications |
 | discussion   | list [repo]                                          | List open discussions for current or specified repo |

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -95,6 +95,7 @@ See |octo-command-examples| for examples.
   mark                  Mark the discussion comment as answered
   unmark                Mark the discussion comment as unanswered
   reopen                Reopen the discussion
+  search                Live discussion search.
 
 
 :Octo repo [action]                             *octo-commands-repo*

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -198,7 +198,9 @@ See |octo-command-examples| for examples.
   
 :Octo search [query]                            *octo-commands-search*
 
-  Search GitHub for issues and PRs matching the query (https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests)
+  Search GitHub for issues and PRs matching the query (https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) or Discussions 
+  by the query
+  (https://docs.github.com/en/search-github/searching-on-github/searching-discussions) and including `is:discussion`
 
 COMMAND EXAMPLES                                *octo-command-examples*
 >

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1,7 +1,6 @@
 local constants = require "octo.constants"
 local navigation = require "octo.navigation"
 local gh = require "octo.gh"
-local mutations = require "octo.gh.mutations"
 local graphql = require "octo.gh.graphql"
 local queries = require "octo.gh.queries"
 local mutations = require "octo.gh.mutations"
@@ -138,6 +137,11 @@ function M.setup()
             },
           },
         }
+      end,
+      search = function(...)
+        local args = table.pack(...)
+        local prompt = table.concat(args, " ")
+        picker.search { prompt = prompt, type = "DISCUSSION" }
       end,
       close = function()
         local buffer = utils.get_current_buffer()

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -141,6 +141,8 @@ function M.setup()
       search = function(...)
         local args = table.pack(...)
         local prompt = table.concat(args, " ")
+        local repo = utils.get_remote_name()
+        prompt = "repo:" .. repo .. " " .. prompt
         picker.search { prompt = prompt, type = "DISCUSSION" }
       end,
       close = function()

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2197,9 +2197,15 @@ end
 
 function M.search(...)
   local args = table.pack(...)
-  picker.search {
-    prompt = table.concat(args, " "),
-  }
+  local prompt = table.concat(args, " ")
+
+  local type = "ISSUE"
+  if string.match(prompt, "is:discussion") then
+    type = "DISCUSSION"
+    prompt = string.gsub(prompt, "is:discussion", "")
+  end
+
+  picker.search { prompt = prompt, type = type }
 end
 
 M.within_issue = function(cb)

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -357,10 +357,13 @@ query($prompt: String!, $type: SearchType = ISSUE) {
         isDraft
         repository { nameWithOwner }
       }
+      ... on Discussion {
+        ...DiscussionInfoFragment
+      }
     }
   }
 }
-]]
+]] .. fragments.discussion_info
 
 M.discussions = [[
 query(

--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -6,7 +6,7 @@ local vim = vim
 
 local M = {}
 
-function M.gen_from_discussions(max_number)
+function M.gen_from_discussion(max_number)
   local make_display = function(entry)
     if not entry then
       return nil

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -547,6 +547,21 @@ end
 
 function M.search(opts)
   opts = opts or {}
+  opts.type = opts.type or "ISSUE"
+
+  local settings = opts.type == "ISSUE"
+      and {
+        previewer = previewers.issue,
+        entry_maker = entry_maker.gen_from_issue,
+        entry_maker_static = function(width)
+          return entry_maker.gen_from_issue(width, true)
+        end,
+      }
+    or {
+      previewer = previewers.discussion,
+      entry_maker = entry_maker.gen_from_discussion,
+    }
+
   local cfg = octo_config.values
   if type(opts.prompt) == "string" then
     opts.prompt = { opts.prompt }
@@ -572,9 +587,10 @@ function M.search(opts)
         if val then
           _prompt = string.format("%s %s", val, _prompt)
         end
+
         local output = gh.api.graphql {
           query = queries.search,
-          fields = { prompt = _prompt },
+          fields = { prompt = _prompt, type = opts.type },
           jq = ".data.search.nodes",
           opts = { mode = "sync" },
         }
@@ -585,13 +601,13 @@ function M.search(opts)
   end
   local finder = finders.new_dynamic {
     fn = requester(),
-    entry_maker = entry_maker.gen_from_issue(width),
+    entry_maker = settings.entry_maker(width),
   }
   if opts.static then
     local results = requester() ""
     finder = finders.new_table {
       results = results,
-      entry_maker = entry_maker.gen_from_issue(width, true),
+      entry_maker = settings.entry_maker_static(width),
     }
   end
   opts.preview_title = opts.preview_title or ""
@@ -601,7 +617,7 @@ function M.search(opts)
     .new(opts, {
       finder = finder,
       sorter = conf.generic_sorter(opts),
-      previewer = previewers.issue.new(opts),
+      previewer = settings.previewer.new(opts),
       attach_mappings = function(_, map)
         action_set.select:replace(replace)
         map("i", cfg.picker_config.mappings.open_in_browser.lhs, open_in_browser())
@@ -1367,7 +1383,7 @@ function M.discussions(opts)
       .new(opts, {
         finder = finders.new_table {
           results = discussions,
-          entry_maker = entry_maker.gen_from_discussions(max_number),
+          entry_maker = entry_maker.gen_from_discussion(max_number),
         },
         sorter = conf.generic_sorter(opts),
         previewer = previewers.discussion.new(opts),


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This adds the `:Octo discussion search` command. It defaults to the current repo

`Octo search` can also be used to search discussions but `is:discussion` needs to be added to the search query.

For example, `Octo search is:discussion repo:pwntester/octo.nvim category:"Show and Tell"`

### Describe how you did it

- **add discussion information to search**
- **implement for the telescope picker**
- **add the command**
- **add documentation for the command**
- **default to the current repo**