### PR TITLE
Add `Octo parent edit` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 |    | search                                                 | Search discussions |
 | parent   | add                                           | Add a parent issue to current issue |  
 |          | remove                                           | Remove the parent issue to current issue |  
+|          | edit                                           | Edit the parent issue to current issue |
 
 
 0. `[repo]`: If repo is not provided, it will be derived from `<cwd>/.git/config`.

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -102,6 +102,7 @@ See |octo-command-examples| for examples.
 
   add                   Add a parent to the current issue
   remove                Remove the parent from the current issue
+  edit                  Edit the parent of the current issue
 
 
 :Octo repo [action]                             *octo-commands-repo*

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -245,6 +245,17 @@ function M.setup()
       end,
     },
     parent = {
+      edit = M.within_issue(function(buffer)
+        local parent = buffer.node.parent
+
+        if utils.is_blank(parent) then
+          utils.error "No parent issue found"
+          return
+        end
+
+        local uri = string.format("octo://%s/issue/%s", buffer.repo, parent.number)
+        vim.cmd.edit(uri)
+      end),
       remove = M.within_issue(function(buffer)
         local parent = buffer.node.parent
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Following https://github.com/pwntester/octo.nvim/pull/952, this allows the user to access the parent with the `Octo parent edit` command. 
Use <C-o> to go back to the previous buffer.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

- **add `Octo parent edit` command**
- **add documentation for the command**

### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
