### PR TITLE
BUG: allow for sync and gh.api calls

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -373,7 +373,7 @@ local rest = function(method, opts)
     return
   end
 
-  run {
+  return run {
     args = args,
     mode = run_opts.mode,
     cb = run_opts.cb,


### PR DESCRIPTION
This was causing issues with calls like 

```lua

local output = gh.api { -- gh.api.get / gh.api.post / gh.api.put / gh.api.delete
  ...
  opts = { mode = "sync" },
}
```

The `output` would always be `nil`

