### PR TITLE
Add user and repo completion with repo: argLead

### DIFF
--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -364,6 +364,23 @@ query($prompt: String!, $type: SearchType = ISSUE) {
       ... on Discussion {
         ...DiscussionInfoFragment
       }
+      ... on Repository {
+        __typename
+        name
+        nameWithOwner
+        description
+        url
+      }
+      ... on Organization {
+        __typename
+        login
+        name
+        url
+      }
+      ... on User {
+        __typename
+        login
+      }
     }
   }
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Upon searches with repo:, the user or organization can be searched with <Tab> until there is a "/". 
After, the repositories for that owner will be shown as completion

https://github.com/user-attachments/assets/8b57d805-bb0b-44d3-9a0c-15dece411a32

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

- **add repo, user, and organization information**
- **add logic for repo:**


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
