### PR TITLE
consolidate copy url

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,6 +13,8 @@ assignees: ''
 
 - nvim version:
 - octo.nvim commit hash: 
+- GitHub CLI version:
 - OS:
+
 
 ### Anything else we need to know?

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2236,8 +2236,7 @@ function M.copy_url()
     url = utils.get_remote_url()
   end
 
-  vim.fn.setreg("+", url, "c")
-  utils.info("Copied URL '" .. url .. "' to the system clipboard (+ register)")
+  utils.copy_url(url)
 end
 
 function M.actions()

--- a/lua/octo/pickers/fzf-lua/pickers/gists.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/gists.lua
@@ -91,8 +91,7 @@ return function(opts)
       ["ctrl-y"] = function(selected)
         local entry = formatted_gists[selected[1]]
         local url = string.format("https://gist.github.com/%s", entry.gist.name)
-        vim.fn.setreg("+", url, "c")
-        utils.info("Copied '" .. url .. "' to the system clipboard (+ register)")
+        utils.copy_url(url)
       end,
     },
   })

--- a/lua/octo/pickers/fzf-lua/pickers/utils.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/utils.lua
@@ -108,9 +108,7 @@ end
 ---
 ---@param entry table
 function M.copy_url(entry)
-  local url = entry.obj.url
-  vim.fn.setreg("+", url, "c")
-  utils.info("Copied '" .. url .. "' to the system clipboard (+ register)")
+  utils.copy_url(entry.obj.url)
 end
 
 ---@param s string

--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -108,8 +108,7 @@ M.issues = function(opts)
             end,
             copy_url = function(_picker, item)
               local url = item.url
-              vim.fn.setreg("+", url, "c")
-              utils.info("Copied '" .. url .. "' to the system clipboard (+ register)")
+              utils.copy_url(url)
             end,
           },
         }
@@ -188,9 +187,7 @@ function M.pull_requests(opts)
               navigation.open_in_browser(item.kind, item.repository.nameWithOwner, item.number)
             end,
             copy_url = function(_picker, item)
-              local url = item.url
-              vim.fn.setreg("+", url, "c")
-              utils.info("Copied '" .. url .. "' to the system clipboard (+ register)")
+              utils.copy_url(item.url)
             end,
             check_out_pr = function(_picker, _item)
               M.not_implemented()
@@ -286,9 +283,7 @@ function M.notifications(opts)
               navigation.open_in_browser(item.kind, item.repository.full_name, item.subject.number)
             end,
             copy_url = function(_picker, item)
-              local url = item.url
-              vim.fn.setreg("+", url, "c")
-              utils.info("Copied '" .. url .. "' to the system clipboard (+ register)")
+              utils.copy_url(item.url)
             end,
             mark_notification_read = function(picker, item)
               local url = string.format("/notifications/threads/%s", item.id)

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -117,9 +117,7 @@ end
 local function copy_url()
   return function(prompt_bufnr)
     local entry = action_state.get_selected_entry(prompt_bufnr)
-    local url = entry.obj.url
-    vim.fn.setreg("+", url, "c")
-    utils.info("Copied '" .. url .. "' to the system clipboard (+ register)")
+    copy_url(entry.obj.url)
   end
 end
 

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1798,7 +1798,8 @@ end
 M.copy_url = function(url, register)
   register = register or "+"
   vim.fn.setreg(register, url, "c")
-  M.info("Copied '" .. url .. "' to the system clipboard (+ register)")
+  local message = register ~= "+" and "(" .. register .. " register)" or "to the system clipboard (+ register)"
+  M.info("Copied '" .. url .. "' " .. message)
 end
 
 M.input = function(opts)

--- a/lua/octo/workflow_runs.lua
+++ b/lua/octo/workflow_runs.lua
@@ -362,8 +362,7 @@ local keymaps = {
   end,
   [mappings.copy_url.lhs] = function(api)
     local url = api.current_wf.url
-    vim.fn.setreg("+", url, "c")
-    utils.info("Copied URL '" .. url .. "' to the system clipboard (+ register)")
+    utils.copy_url(url)
   end,
 }
 


### PR DESCRIPTION
Whole bunch of the same that is done with the `utils.copy_url` function

https://github.com/pwntester/octo.nvim/blob/064a71581dbd9b50b289cdb9910a4d124326164f/lua/octo/utils.lua?plain=1#L1798-L1802

- **add GitHub CLI version to bug template**
- **conslidate the copy_url**