### PR TITLE
Safely get the user for the commit header

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -1436,9 +1436,10 @@ local write_commit_header = function(bufnr, commits)
     table.insert(vt, { conf.timeline_marker .. " ", "OctoTimelineMarker" })
     table.insert(vt, { "EVENT: ", "OctoTimelineItemHeading" })
   end
+  local first_user = get_author(first_item)
   table.insert(vt, {
-    first_item.commit.author.user.login,
-    first_item.commit.author.user.login == vim.g.octo_viewer and "OctoUserViewer" or "OctoUser",
+    first_user,
+    first_user == vim.g.octo_viewer and "OctoUserViewer" or "OctoUser",
   })
   if n_authors > 1 then
     table.insert(


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Safely get the user for the commit header

Hi @nekowasabi, can you take a look at this a see if it fixes your issue


Some good searches to try out

`:Octo search is:pr involves:ghost`
`:Octo search is:pr author:ghost`

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Closes #1012

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt