### PR TITLE
Add `Octo comment reply` and `<leader>cr` mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ require"octo".setup({
       remove_label = { lhs = "<localleader>ld", desc = "remove label" },
       goto_issue = { lhs = "<localleader>gi", desc = "navigate to a local repo issue" },
       add_comment = { lhs = "<localleader>ca", desc = "add comment" },
+      add_reply = { lhs = "<localleader>cr", desc = "add reply" },
       delete_comment = { lhs = "<localleader>cd", desc = "delete comment" },
       next_comment = { lhs = "]c", desc = "go to next comment" },
       prev_comment = { lhs = "[c", desc = "go to previous comment" },
@@ -283,6 +284,7 @@ require"octo".setup({
       remove_label = { lhs = "<localleader>ld", desc = "remove label" },
       goto_issue = { lhs = "<localleader>gi", desc = "navigate to a local repo issue" },
       add_comment = { lhs = "<localleader>ca", desc = "add comment" },
+      add_reply = { lhs = "<localleader>cr", desc = "add reply" },
       delete_comment = { lhs = "<localleader>cd", desc = "delete comment" },
       next_comment = { lhs = "]c", desc = "go to next comment" },
       prev_comment = { lhs = "[c", desc = "go to previous comment" },
@@ -302,6 +304,7 @@ require"octo".setup({
     review_thread = {
       goto_issue = { lhs = "<localleader>gi", desc = "navigate to a local repo issue" },
       add_comment = { lhs = "<localleader>ca", desc = "add comment" },
+      add_reply = { lhs = "<localleader>cr", desc = "add reply" },
       add_suggestion = { lhs = "<localleader>sa", desc = "add suggestion" },
       delete_comment = { lhs = "<localleader>cd", desc = "delete comment" },
       next_comment = { lhs = "]c", desc = "go to next comment" },
@@ -416,7 +419,8 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 |          | suggest                                            | Add a new suggestion                                                                                                                                  |
 |          | delete                                            | Delete a comment                                                                                                                                       |
 |          | url                                            | Copies the URL of the current comment to the system clipboard                                                                                          |
-| thread   | resolve                                           | Mark a review thread as resolved                                                                                                                       |
+|          | reply                                            | Add comment as a reply to the current comment | 
+ | thread   | resolve                                           | Mark a review thread as resolved                                                                                                                       |
 |          | unresolve                                         | Mark a review thread as unresolved                                                                                                                     |
 | label    | add [label]                                       | Add a label from available label menu                                                                                                                  |
 |          | remove [label]                                    | Remove a label                                                                                                                                         |

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -130,6 +130,7 @@ See |octo-command-examples| for examples.
   delete                Delete a comment.
   url                   Copies the URL of the current comment to the system 
                         clipboard.
+  reply                 Reply to a comment.
 
 
 :Octo thread [action]                           *octo-commands-thread*

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -607,6 +607,7 @@ function M.setup()
 
         current_review:add_comment(true)
       end,
+      reply = M.add_pr_issue_or_review_thread_comment_reply,
       url = function()
         local buffer = utils.get_current_buffer()
 
@@ -953,7 +954,8 @@ function M.octo(object, action, ...)
 end
 
 --- Adds a new comment to an issue/PR or a review thread
-function M.add_pr_issue_or_review_thread_comment()
+function M.add_pr_issue_or_review_thread_comment(body)
+  body = body or " "
   local buffer = utils.get_current_buffer()
 
   if not buffer then
@@ -965,7 +967,7 @@ function M.add_pr_issue_or_review_thread_comment()
     id = -1,
     author = { login = vim.g.octo_viewer },
     createdAt = os.date "!%FT%TZ",
-    body = " ",
+    body = body,
     viewerCanUpdate = true,
     viewerCanDelete = true,
     viewerDidAuthor = true,
@@ -1046,6 +1048,33 @@ function M.add_pr_issue_or_review_thread_comment()
 
   -- drop undo history
   utils.clear_history()
+end
+
+local format_reply = function(body)
+  local lines = vim.split(body, "\n")
+  local reply = ""
+  for _, line in ipairs(lines) do
+    reply = reply .. "> " .. line .. "\n"
+  end
+  reply = reply .. "\n"
+
+  return reply
+end
+
+M.add_pr_issue_or_review_thread_comment_reply = function()
+  local buffer = utils.get_current_buffer()
+
+  if not buffer then
+    return
+  end
+
+  local comment = buffer:get_comment_at_cursor()
+  if not comment then
+    utils.error "The cursor does not seem to be located at any comment"
+    return
+  end
+
+  M.add_pr_issue_or_review_thread_comment(format_reply(comment.body))
 end
 
 function M.delete_comment()

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -239,6 +239,7 @@ function M.get_default_values()
       discussion = {
         copy_url = { lhs = "<C-y>", desc = "copy url to system clipboard" },
         add_comment = { lhs = "<localleader>ca", desc = "add comment" },
+        add_reply = { lhs = "<localleader>cr", desc = "add reply" },
         delete_comment = { lhs = "<localleader>cd", desc = "delete comment" },
         add_label = { lhs = "<localleader>la", desc = "add label" },
         remove_label = { lhs = "<localleader>ld", desc = "remove label" },
@@ -276,6 +277,7 @@ function M.get_default_values()
         remove_label = { lhs = "<localleader>ld", desc = "remove label" },
         goto_issue = { lhs = "<localleader>gi", desc = "navigate to a local repo issue" },
         add_comment = { lhs = "<localleader>ca", desc = "add comment" },
+        add_reply = { lhs = "<localleader>cr", desc = "add reply" },
         delete_comment = { lhs = "<localleader>cd", desc = "delete comment" },
         next_comment = { lhs = "]c", desc = "go to next comment" },
         prev_comment = { lhs = "[c", desc = "go to previous comment" },
@@ -312,6 +314,7 @@ function M.get_default_values()
         remove_label = { lhs = "<localleader>ld", desc = "remove label" },
         goto_issue = { lhs = "<localleader>gi", desc = "navigate to a local repo issue" },
         add_comment = { lhs = "<localleader>ca", desc = "add comment" },
+        add_reply = { lhs = "<localleader>cr", desc = "add reply" },
         delete_comment = { lhs = "<localleader>cd", desc = "delete comment" },
         next_comment = { lhs = "]c", desc = "go to next comment" },
         prev_comment = { lhs = "[c", desc = "go to previous comment" },
@@ -331,6 +334,7 @@ function M.get_default_values()
       review_thread = {
         goto_issue = { lhs = "<localleader>gi", desc = "navigate to a local repo issue" },
         add_comment = { lhs = "<localleader>ca", desc = "add comment" },
+        add_reply = { lhs = "<localleader>cr", desc = "add reply" },
         add_suggestion = { lhs = "<localleader>sa", desc = "add suggestion" },
         delete_comment = { lhs = "<localleader>cd", desc = "delete comment" },
         next_comment = { lhs = "]c", desc = "go to next comment" },

--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -82,6 +82,9 @@ return {
   add_comment = function()
     require("octo.commands").add_pr_issue_or_review_thread_comment()
   end,
+  add_reply = function()
+    require("octo.commands").add_pr_issue_or_review_thread_comment_reply()
+  end,
   add_suggestion = function()
     require("octo.commands").add_suggestion()
   end,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Support for quote replying the comment that the cursor is currently on.

