### PR TITLE
Changes colors.setup call from setup() to update_layout_for_current_file

### DIFF
--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -42,7 +42,6 @@ function M.setup(user_config)
   autocmds.setup()
   commands.setup()
   gh.setup()
-  colors.setup()
 end
 
 function M.update_layout_for_current_file()
@@ -50,6 +49,7 @@ function M.update_layout_for_current_file()
   local thisfile = vim.api.nvim_buf_get_name(bufnr)
   local relative_path = vim.fn.fnamemodify(thisfile, ":~:.")
   local review = reviews.get_current_review()
+  colors.setup()
   if review == nil then
     return
   end


### PR DESCRIPTION
### Describe what this PR does / why we need it
Color configuration being done inside the `setup` function is causing the following issue, when performed alongside some color scheme configurations:

![image](https://github.com/user-attachments/assets/4407829d-bcd7-49f6-b262-94af86965c49)

### Does this pull request fix one issue?
Fixes #1010 

### Describe how you did it
Changed the `colors.setup` call from the setup call to autocmd.

### Describe how to verify it
Configure a color scheme and check if the error is present in the initialization.

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
