### PR TITLE
feat: implement `issue_templates` picker for snacks provider

### DIFF
--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -311,7 +311,7 @@ end
 
 function M.issue_templates(templates, cb)
   if not templates or #templates == 0 then
-    utils.error("No templates found")
+    utils.error "No templates found"
     return
   end
 
@@ -333,13 +333,13 @@ function M.issue_templates(templates, cb)
 
     local item = ctx.item
     if not item or not item.template or not item.template.body then
-      ctx.preview:set_lines({ "No template body available" })
+      ctx.preview:set_lines { "No template body available" }
       return
     end
 
     local lines = vim.split(item.template.body, "\n")
     ctx.preview:set_lines(lines)
-    ctx.preview:highlight({ ft = "markdown" })
+    ctx.preview:highlight { ft = "markdown" }
   end
 
   Snacks.picker.pick {
@@ -366,8 +366,8 @@ function M.issue_templates(templates, cb)
         if type(cb) == "function" then
           cb(item.template)
         end
-      end
-    }
+      end,
+    },
   }
 end
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Implements a picker using the snacks provider for picking issue templates, which is used when creating issues.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

Nothing special here.

### Describe how to verify it

Set `picker = "snacks"` and run `:Octo issue create`

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt

No documentation changes needed.
