### PR TITLE
Provider snacks search

### DIFF
--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -379,6 +379,9 @@ query($prompt: String!, $type: SearchType = ISSUE, $last: Int = 100) {
       }
       ... on Discussion {
         __typename
+        category {
+          name
+        }
         ...DiscussionInfoFragment
       }
       ... on Repository {

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -378,6 +378,7 @@ query($prompt: String!, $type: SearchType = ISSUE, $last: Int = 100) {
         repository { nameWithOwner }
       }
       ... on Discussion {
+        __typename
         ...DiscussionInfoFragment
       }
       ... on Repository {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This PR implements the search functionality for the snacks picker. 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #1046

### Describe how you did it

I looked at previous implementations as well as the implementations for telescope and fzf-lua.

I also modified some of the queries to retrieve some information that was useful for displaying and checking the items in the search, but I'm not sure if you'd prefer some alternative?

### Describe how to verify it

Try setting `picker = "snacks"` and run

```
:Octo issue search
:Octo pr search
:Octo discussion search
:Octo search <query>
```

### Special notes for reviews

This PR does not yet implement `:Octo repo search`. I found that this was working for the telescope picker but that it wasn't listed anywhere. I tried to implement it but I couldn't wrap my head around how the snacks picker deals with this kind of live search. Maybe someone else can step in?

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
