### PR TITLE
fix(colors): use lua api to set highlights and initialize colors once (fix #1010)

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -10,7 +10,6 @@ local window = require "octo.ui.window"
 local writers = require "octo.ui.writers"
 local utils = require "octo.utils"
 local config = require "octo.config"
-local colors = require "octo.ui.colors"
 local vim = vim
 
 -- a global variable where command handlers can access the details of the last
@@ -902,11 +901,6 @@ function M.process_varargs(repo, ...)
 end
 
 function M.octo(object, action, ...)
-  if not _G.octo_colors_loaded then
-    colors.setup()
-    _G.octo_colors_loaded = true
-  end
-
   if not object then
     if config.values.enable_builtin then
       M.commands.actions()

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -19,7 +19,6 @@ local vim = vim
 
 _G.octo_repo_issues = {}
 _G.octo_buffers = {}
-_G.octo_colors_loaded = false
 
 local M = {}
 
@@ -35,6 +34,7 @@ function M.setup(user_config)
     return
   end
 
+  colors.setup()
   signs.setup()
   picker.setup()
   completion.setup()
@@ -49,7 +49,6 @@ function M.update_layout_for_current_file()
   local thisfile = vim.api.nvim_buf_get_name(bufnr)
   local relative_path = vim.fn.fnamemodify(thisfile, ":~:.")
   local review = reviews.get_current_review()
-  colors.setup()
   if review == nil then
     return
   end

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -59,13 +59,13 @@ local function get_hl_groups()
     BubbleDelimiterBlue = { fg = colors.dark_blue },
     BubbleDelimiterGrey = { fg = colors.grey },
 
-    FilePanelTitle = { fg = get_fg "Directory" or colors.blue, gui = "bold" },
-    FilePanelCounter = { fg = get_fg "Identifier" or colors.purple, gui = "bold" },
+    FilePanelTitle = { fg = get_fg "Directory" or colors.blue, bold = true },
+    FilePanelCounter = { fg = get_fg "Identifier" or colors.purple, bold = true },
     NormalFloat = { fg = get_fg "Normal" or colors.white },
     Viewer = { fg = colors.black, bg = colors.blue },
     Editable = { bg = float_bg },
-    Strikethrough = { fg = colors.grey, gui = "strikethrough" },
-    Underline = { fg = colors.white, gui = "underline" },
+    Strikethrough = { fg = colors.grey, strikethrough = true },
+    Underline = { fg = colors.white, underline = true },
   }
 end
 
@@ -113,8 +113,8 @@ local function get_hl_links()
     FailingTest = "OctoRed",
     PullAdditions = "OctoGreen",
     PullDeletions = "OctoRed",
-    DiffstatAdditions = "OctoGreen ",
-    DiffstatDeletions = "OctoRed ",
+    DiffstatAdditions = "OctoGreen",
+    DiffstatDeletions = "OctoRed",
     DiffstatNeutral = "OctoGrey",
 
     StateOpen = "OctoGreen",
@@ -148,17 +148,13 @@ local function get_hl_links()
 end
 
 function M.setup()
-  for name, v in pairs(get_hl_groups()) do
-    local fg = v.fg and " guifg=" .. v.fg or ""
-    local bg = v.bg and " guibg=" .. v.bg or ""
-    local gui = v.gui and " gui=" .. v.gui or ""
-    local cmd = "hi def Octo" .. name .. fg .. bg .. gui
-    vim.cmd(cmd)
+  for name, hl in pairs(get_hl_groups()) do
+    vim.api.nvim_set_hl(0, "Octo" .. name, hl)
   end
 
   for from, to in pairs(get_hl_links()) do
     if vim.fn.hlexists("Octo" .. from) == 0 then
-      vim.cmd("hi def link Octo" .. from .. " " .. to)
+      vim.api.nvim_set_hl(0, "Octo" .. from, { link = to })
     end
   end
 end
@@ -212,7 +208,7 @@ function M.create_highlight(rgb_hex, options)
     -- Create the highlight
     highlight_name = make_highlight_name(rgb_hex, mode)
     if mode == "foreground" then
-      vim.cmd(string.format("highlight %s guifg=#%s", highlight_name, rgb_hex))
+      vim.api.nvim_set_hl(0, highlight_name, { fg = "#" .. rgb_hex })
     else
       local r, g, b = rgb_hex:sub(1, 2), rgb_hex:sub(3, 4), rgb_hex:sub(5, 6)
       r, g, b = tonumber(r, 16), tonumber(g, 16), tonumber(b, 16)
@@ -222,7 +218,7 @@ function M.create_highlight(rgb_hex, options)
       else
         fg_color = "ffffff"
       end
-      vim.cmd(string.format("highlight %s guifg=#%s guibg=#%s", highlight_name, fg_color, rgb_hex))
+      vim.api.nvim_set_hl(0, highlight_name, { fg = "#" .. fg_color, bg = "#" .. rgb_hex })
     end
     HIGHLIGHT_CACHE[cache_key] = highlight_name
   end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This PR removes the echoed highlight that occurs on some setups and improves colors setup performances

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #1010

### Describe how you did it

- replace `vim.cmd` calls by native `vim.api.nvim_set_hl()` calls as they are faster, and they avoid the string transformation for each highlight
- ensure that colors initialization is called once instead of each time a buffer or a command is executed (noticed with debug printing), and before `signs.setup()` which seemed to be triggering the `OctoEditable xxx cleared` because `colors.setup()` was redefining some already in use highlights

### Describe how to verify it

I currently use it (the echo `OctoEditable xxx cleared` was breaking with some plugins).
Also I was able to reproduce the issue 100% of times and with this PR I am not able anymore.

My reproducible setup was:
- just run nvim, the message was triggered once
- each time I was opening a buffer, the message was triggered.

Also, I noticed last week that depending on the theme/colorscheme, the message may be triggered differently. My hypothesis is that it depends on whether your theme set a transparent background or not (enabling the floating windows transparency on the `solarized-osaka` theme triggered the message a lot more)

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
