### PR TITLE
fix(colors): `get_fg()` was getting `fg` but `ctermfg`

### DIFF
--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -3,22 +3,8 @@ local vim = vim
 
 local M = {}
 
-local function get_hl_attr(hl_group_name, attr)
-  local id = vim.api.nvim_get_hl_id_by_name(hl_group_name)
-  if not id then
-    return
-  end
-
-  local value = vim.fn.synIDattr(id, attr)
-  if not value or value == "" then
-    return
-  end
-
-  return value
-end
-
 local function get_fg(hl_group_name)
-  return get_hl_attr(hl_group_name, "fg")
+  return vim.api.nvim_get_hl(0, { name = hl_group_name }).fg
 end
 
 local function get_colors()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This PR fixes the internal `get_fg()` helper from `colors` module.

The existing helper was not fetching the `fg` (`guifg` in highlight command) attribute but the `ctermfg` which is not compatible using `vim.api.nvim_get_hl()` (it's an integer that need to be passed as `ctermfg` parameter, not `fg`, but was silently working with the highlight command).
Also, `synIDattr()` + `nvim_get_hl_id_by_name()` was almost always returning a value, even if no hl_group was found.

### Does this pull request fix one issue?
Fixes #1056 

(I provided a fix to his config, bug it allowed me to spot this issues when no color scheme is loaded)

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

I used the dedicated `vim.api.nvim_get_hl()` API which doesn't silently fallback on `ctermfg`.
It results in the `get_fg()` returning the real `fg` for the given highlight and returning `nil` when there is no `fg` for this highlight.
Now [the `get_fg "<HlGroup>" or colors.xxx` statements in `get_hl_groups()`](https://github.com/pwntester/octo.nvim/blob/master/lua/octo/ui/colors.lua#L62-L64) properly works.


### Describe how to verify it
Try to load Octo without a `colorscheme` and this PR, it fails which the exact error from #1056.
Then try with this PR, it don't fail anymore.

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
