### PR TITLE
feat(snacks): enhance picker configuration and actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ require"octo".setup({
       merge_pr = { lhs = "<C-r>", desc = "merge pull request" },
     },
     snacks = {                                -- snacks specific config
-      actions = {                             -- custom actions for specific snacks pickers
+      actions = {                             -- custom actions for specific snacks pickers (array of tables)
         issues = {                            -- actions for the issues picker
-          -- ["<leader>a"] = function(picker, item) print("Issue action:", vim.inspect(item)) end,
+          -- { name = "my_issue_action", fn = function(picker, item) print("Issue action:", vim.inspect(item)) end, lhs = "<leader>a", desc = "My custom issue action" },
         },
         pull_requests = {                     -- actions for the pull requests picker
-          -- ["<leader>b"] = function(picker, item) print("PR action:", vim.inspect(item)) end,
+          -- { name = "my_pr_action", fn = function(picker, item) print("PR action:", vim.inspect(item)) end, lhs = "<leader>b", desc = "My custom PR action" },
         },
         notifications = {},                   -- actions for the notifications picker
         issue_templates = {},                 -- actions for the issue templates picker

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ require"octo".setup({
   default_merge_method = "commit",         -- default merge method which should be used for both `Octo pr merge` and merging from picker, could be `commit`, `rebase` or `squash`
   default_delete_branch = false,           -- whether to delete branch when merging pull request with either `Octo pr merge` or from picker (can be overridden with `delete`/`nodelete` argument to `Octo pr merge`)
   ssh_aliases = {},                        -- SSH aliases. e.g. `ssh_aliases = {["github.com-work"] = "github.com"}`. The key part will be interpreted as an anchored Lua pattern.
-  picker = "telescope",                    -- or "fzf-lua"
+  picker = "telescope",                    -- or "fzf-lua" or "snacks"
   picker_config = {
     use_emojis = false,                    -- only used by "fzf-lua" picker for now
     mappings = {                           -- mappings for the pickers
@@ -127,6 +127,11 @@ require"octo".setup({
       copy_url = { lhs = "<C-y>", desc = "copy url to system clipboard" },
       checkout_pr = { lhs = "<C-o>", desc = "checkout pull request" },
       merge_pr = { lhs = "<C-r>", desc = "merge pull request" },
+    },
+    snacks = {                             -- snacks specific config
+      actions = {                          -- custom actions for the snacks picker
+        -- ["<leader>a"] = function(picker, item) print(vim.inspect(item)) end,
+      },
     },
   },
   comment_icon = "▎",                      -- comment marker

--- a/README.md
+++ b/README.md
@@ -128,9 +128,18 @@ require"octo".setup({
       checkout_pr = { lhs = "<C-o>", desc = "checkout pull request" },
       merge_pr = { lhs = "<C-r>", desc = "merge pull request" },
     },
-    snacks = {                             -- snacks specific config
-      actions = {                          -- custom actions for the snacks picker
-        -- ["<leader>a"] = function(picker, item) print(vim.inspect(item)) end,
+    snacks = {                                -- snacks specific config
+      actions = {                             -- custom actions for specific snacks pickers
+        issues = {                            -- actions for the issues picker
+          -- ["<leader>a"] = function(picker, item) print("Issue action:", vim.inspect(item)) end,
+        },
+        pull_requests = {                     -- actions for the pull requests picker
+          -- ["<leader>b"] = function(picker, item) print("PR action:", vim.inspect(item)) end,
+        },
+        notifications = {},                   -- actions for the notifications picker
+        issue_templates = {},                 -- actions for the issue templates picker
+        search = {},                          -- actions for the search picker
+        -- ... add actions for other pickers as needed
       },
     },
   },

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -24,6 +24,16 @@ local M = {}
 ---@field mappings OctoPickerMappings
 ---@field snacks OctoPickerConfigSnacks -- Snacks specific config
 
+---@class OctoSnacksActions
+---@field issues table<string, function>
+---@field pull_requests table<string, function>
+---@field notifications table<string, function>
+---@field issue_templates table<string, function>
+---@field search table<string, function>
+
+---@class OctoPickerConfigSnacks
+---@field actions OctoSnacksActions
+
 ---@class OctoConfigColors
 ---@field white string
 ---@field grey string
@@ -138,7 +148,13 @@ function M.get_default_values()
         merge_pr = { lhs = "<C-r>", desc = "merge pull request" },
       },
       snacks = {
-        actions = {},
+        actions = {
+          issues = {},
+          pull_requests = {},
+          notifications = {},
+          issue_templates = {},
+          search = {},
+        },
       },
     },
     default_remote = { "upstream", "origin" },
@@ -497,8 +513,16 @@ function M.validate_config()
     -- Snacks specific validation
     if validate_type(config.picker_config.snacks, "picker_config.snacks", "table") then
       if validate_type(config.picker_config.snacks.actions, "picker_config.snacks.actions", "table") then
-        for key, action in pairs(config.picker_config.snacks.actions) do
-          validate_type(action, string.format("picker_config.snacks.actions['%s']", key), "function")
+        for picker_type, actions in pairs(config.picker_config.snacks.actions) do
+          if validate_type(actions, string.format("picker_config.snacks.actions.%s", picker_type), "table") then
+            for key, action in pairs(actions) do
+              validate_type(
+                action,
+                string.format("picker_config.snacks.actions.%s['%s']", picker_type, key),
+                "function"
+              )
+            end
+          end
         end
       end
     end

--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -6,8 +6,6 @@ local octo_config = require "octo.config"
 local navigation = require "octo.navigation"
 local Snacks = require "snacks"
 
-local Snacks = require "snacks"
-
 local M = {}
 
 local function get_filter(opts, kind)
@@ -97,7 +95,7 @@ M.issues = function(opts)
         actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.issues or {})
 
         Snacks.picker.pick {
-          title = opts.preview_title or "Issues",
+          title = opts.preview_title or "",
           items = issues,
           format = function(item, _)
             ---@type snacks.picker.Highlight[]

--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -183,7 +183,7 @@ function M.pull_requests(opts)
         actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.pull_requests or {})
 
         Snacks.picker.pick {
-          title = opts.preview_title or "Pull Requests",
+          title = opts.preview_title or "",
           items = pull_requests,
           format = function(item, _)
             ---@type snacks.picker.Highlight[]
@@ -291,7 +291,7 @@ function M.notifications(opts)
         actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.notifications or {})
 
         Snacks.picker.pick {
-          title = opts.preview_title or "Notifications",
+          title = opts.preview_title or "",
           items = safe_notifications,
           format = function(item, _)
             ---@type snacks.picker.Highlight[]
@@ -365,7 +365,7 @@ function M.issue_templates(templates, cb)
   actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.issue_templates or {})
 
   Snacks.picker.pick {
-    title = "Issue Templates",
+    title = "Issue templates",
     items = formatted_templates,
     format = function(item)
       if type(item) ~= "table" then
@@ -462,7 +462,7 @@ function M.search(opts)
     actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.search or {})
 
     Snacks.picker.pick {
-      title = opts.preview_title or "Search Results",
+      title = opts.preview_title or "GitHub Search Results",
       items = search_results,
       format = function(item, _)
         local a = Snacks.picker.util.align

--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -83,19 +83,46 @@ M.issues = function(opts)
           issue.kind = issue.__typename:lower()
         end
 
-        local actions = {
-          open_in_browser = function(_picker, item)
+        -- Prepare actions and keys for Snacks
+        local final_actions = {}
+        local final_keys = {}
+        local default_mode = { "n", "i" }
+
+        -- Process custom actions from config array
+        local custom_actions_defined = {} -- Keep track of names defined by user
+        if cfg.picker_config.snacks and cfg.picker_config.snacks.actions and cfg.picker_config.snacks.actions.issues then
+          for _, action_item in ipairs(cfg.picker_config.snacks.actions.issues) do
+            if action_item.name and action_item.fn then
+              final_actions[action_item.name] = action_item.fn
+              custom_actions_defined[action_item.name] = true
+              if action_item.lhs then
+                final_keys[action_item.lhs] = { action_item.name, mode = action_item.mode or default_mode }
+              end
+            end
+          end
+        end
+
+        -- Add default actions/keys if not overridden by name or lhs
+        if not custom_actions_defined["open_in_browser"] then
+          final_actions["open_in_browser"] = function(_picker, item)
             navigation.open_in_browser(item.kind, item.repository.nameWithOwner, item.number)
-          end,
-          copy_url = function(_picker, item)
-            local url = item.url
-            utils.copy_url(url)
-          end,
-        }
-        actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.issues or {})
+          end
+        end
+        if not final_keys[cfg.picker_config.mappings.open_in_browser.lhs] then
+           final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
+        end
+
+        if not custom_actions_defined["copy_url"] then
+          final_actions["copy_url"] = function(_picker, item)
+            utils.copy_url(item.url)
+          end
+        end
+        if not final_keys[cfg.picker_config.mappings.copy_url.lhs] then
+           final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
+        end
 
         Snacks.picker.pick {
-          title = opts.preview_title or "",
+          title = opts.preview_title or "Issues",
           items = issues,
           format = function(item, _)
             ---@type snacks.picker.Highlight[]
@@ -109,13 +136,10 @@ M.issues = function(opts)
           end,
           win = {
             input = {
-              keys = {
-                [cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = { "n", "i" } },
-                [cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = { "n", "i" } },
-              },
+              keys = final_keys, -- Use the constructed keys map
             },
           },
-          actions = actions,
+          actions = final_actions, -- Use the constructed actions map
         }
       end
     end,
@@ -164,24 +188,61 @@ function M.pull_requests(opts)
           pull.kind = pull.__typename:lower() == "pullrequest" and "pull_request" or "unknown"
         end
 
-        local actions = {
-          open_in_browser = function(_picker, item)
+        -- Prepare actions and keys for Snacks
+        local final_actions = {}
+        local final_keys = {}
+        local default_mode = { "n", "i" }
+
+        -- Process custom actions from config array
+        local custom_actions_defined = {}
+        if cfg.picker_config.snacks and cfg.picker_config.snacks.actions and cfg.picker_config.snacks.actions.pull_requests then
+          for _, action_item in ipairs(cfg.picker_config.snacks.actions.pull_requests) do
+            if action_item.name and action_item.fn then
+              final_actions[action_item.name] = action_item.fn
+              custom_actions_defined[action_item.name] = true
+              if action_item.lhs then
+                final_keys[action_item.lhs] = { action_item.name, mode = action_item.mode or default_mode }
+              end
+            end
+          end
+        end
+
+        -- Add default actions/keys if not overridden
+        if not custom_actions_defined["open_in_browser"] then
+          final_actions["open_in_browser"] = function(_picker, item)
             navigation.open_in_browser(item.kind, item.repository.nameWithOwner, item.number)
-          end,
-          copy_url = function(_picker, item)
+          end
+        end
+        if not final_keys[cfg.picker_config.mappings.open_in_browser.lhs] then
+           final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
+        end
+
+        if not custom_actions_defined["copy_url"] then
+          final_actions["copy_url"] = function(_picker, item)
             utils.copy_url(item.url)
-          end,
-          check_out_pr = function(_picker, item)
-            utils.checkout_pr(item.number)
-          end,
-          merge_pr = function(_picker, item)
-            utils.merge_pr(item.number)
-          end,
-        }
-        actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.pull_requests or {})
+          end
+        end
+        if not final_keys[cfg.picker_config.mappings.copy_url.lhs] then
+           final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
+        end
+
+        if not custom_actions_defined["check_out_pr"] then
+           final_actions["check_out_pr"] = function(_picker, item) utils.checkout_pr(item.number) end
+        end
+        if not final_keys[cfg.picker_config.mappings.checkout_pr.lhs] then
+           final_keys[cfg.picker_config.mappings.checkout_pr.lhs] = { "check_out_pr", mode = default_mode }
+        end
+
+        if not custom_actions_defined["merge_pr"] then
+           final_actions["merge_pr"] = function(_picker, item) utils.merge_pr(item.number) end
+        end
+        if not final_keys[cfg.picker_config.mappings.merge_pr.lhs] then
+           final_keys[cfg.picker_config.mappings.merge_pr.lhs] = { "merge_pr", mode = default_mode }
+        end
+
 
         Snacks.picker.pick {
-          title = opts.preview_title or "",
+          title = opts.preview_title or "Pull Requests",
           items = pull_requests,
           format = function(item, _)
             ---@type snacks.picker.Highlight[]
@@ -195,15 +256,10 @@ function M.pull_requests(opts)
           end,
           win = {
             input = {
-              keys = {
-                [cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = { "n", "i" } },
-                [cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = { "n", "i" } },
-                [cfg.picker_config.mappings.checkout_pr.lhs] = { "check_out_pr", mode = { "n", "i" } },
-                [cfg.picker_config.mappings.merge_pr.lhs] = { "merge_pr", mode = { "n", "i" } },
-              },
+              keys = final_keys, -- Use the constructed keys map
             },
           },
-          actions = actions,
+          actions = final_actions, -- Use the constructed actions map
         }
       end
     end,
@@ -262,14 +318,48 @@ function M.notifications(opts)
           end
         end
 
-        local actions = {
-          open_in_browser = function(_picker, item)
+        -- Prepare actions and keys for Snacks
+        local final_actions = {}
+        local final_keys = {}
+        local default_mode = { "n", "i" }
+
+        -- Process custom actions from config array
+        local custom_actions_defined = {}
+        if cfg.picker_config.snacks and cfg.picker_config.snacks.actions and cfg.picker_config.snacks.actions.notifications then
+          for _, action_item in ipairs(cfg.picker_config.snacks.actions.notifications) do
+            if action_item.name and action_item.fn then
+              final_actions[action_item.name] = action_item.fn
+              custom_actions_defined[action_item.name] = true
+              if action_item.lhs then
+                final_keys[action_item.lhs] = { action_item.name, mode = action_item.mode or default_mode }
+              end
+            end
+          end
+        end
+
+        -- Add default actions/keys if not overridden
+        if not custom_actions_defined["open_in_browser"] then
+          final_actions["open_in_browser"] = function(_picker, item)
             navigation.open_in_browser(item.kind, item.repository.full_name, item.subject.number)
-          end,
-          copy_url = function(_picker, item)
-            utils.copy_url(item.url)
-          end,
-          mark_notification_read = function(picker, item)
+          end
+        end
+        if not final_keys[cfg.picker_config.mappings.open_in_browser.lhs] then
+           final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
+        end
+
+        if not custom_actions_defined["copy_url"] then
+          final_actions["copy_url"] = function(_picker, item)
+            -- Note: notification item doesn't have a direct .url, need to construct or use subject URL?
+            -- Using subject URL for now, might need adjustment depending on desired behavior.
+            utils.copy_url(item.subject.url or "")
+          end
+        end
+        if not final_keys[cfg.picker_config.mappings.copy_url.lhs] then
+           final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
+        end
+
+        if not custom_actions_defined["mark_notification_read"] then
+          final_actions["mark_notification_read"] = function(picker, item)
             local url = string.format("/notifications/threads/%s", item.id)
             gh.run {
               args = { "api", "--method", "PATCH", url },
@@ -284,12 +374,15 @@ function M.notifications(opts)
             -- TODO: No current way to redraw the list/remove just this item
             picker:close()
             M.notifications(opts)
-          end,
-        }
-        actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.notifications or {})
+          end
+        end
+        -- Use the default mapping from the main config section for 'read'
+        if cfg.mappings.notification and cfg.mappings.notification.read and not final_keys[cfg.mappings.notification.read.lhs] then
+           final_keys[cfg.mappings.notification.read.lhs] = { "mark_notification_read", mode = default_mode }
+        end
 
         Snacks.picker.pick {
-          title = opts.preview_title or "",
+          title = opts.preview_title or "Notifications",
           items = safe_notifications,
           format = function(item, _)
             ---@type snacks.picker.Highlight[]
@@ -305,14 +398,10 @@ function M.notifications(opts)
           end,
           win = {
             input = {
-              keys = {
-                [cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = { "n", "i" } },
-                [cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = { "n", "i" } },
-                [cfg.mappings.notification.read.lhs] = { "mark_notification_read", mode = { "n", "i" } },
-              },
+              keys = final_keys, -- Use the constructed keys map
             },
           },
-          actions = actions,
+          actions = final_actions, -- Use the constructed actions map
         }
       end
     end,
@@ -353,17 +442,39 @@ function M.issue_templates(templates, cb)
   end
 
   local cfg = octo_config.values
-  local actions = {
-    confirm = function(_, item)
+
+  -- Prepare actions and keys for Snacks
+  local final_actions = {}
+  local final_keys = {}
+  local default_mode = { "n", "i" }
+
+  -- Process custom actions from config array
+  local custom_actions_defined = {}
+  if cfg.picker_config.snacks and cfg.picker_config.snacks.actions and cfg.picker_config.snacks.actions.issue_templates then
+    for _, action_item in ipairs(cfg.picker_config.snacks.actions.issue_templates) do
+      if action_item.name and action_item.fn then
+        final_actions[action_item.name] = action_item.fn
+        custom_actions_defined[action_item.name] = true
+        if action_item.lhs then
+          final_keys[action_item.lhs] = { action_item.name, mode = action_item.mode or default_mode }
+        end
+      end
+    end
+  end
+
+  -- Add default confirm action if not overridden
+  if not custom_actions_defined["confirm"] then
+    final_actions["confirm"] = function(_, item)
       if type(cb) == "function" then
         cb(item.template)
       end
-    end,
-  }
-  actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.issue_templates or {})
+    end
+  end
+  -- Default key for confirm is usually <CR> handled by Snacks itself, but allow override
+  -- No explicit default key mapping added here unless specified in config
 
   Snacks.picker.pick {
-    title = "Issue templates",
+    title = "Issue Templates",
     items = formatted_templates,
     format = function(item)
       if type(item) ~= "table" then
@@ -381,7 +492,12 @@ function M.issue_templates(templates, cb)
       return ret
     end,
     preview = preview_fn, -- Use our custom preview function
-    actions = actions,
+    win = {
+      input = {
+        keys = final_keys, -- Use the constructed keys map
+      },
+    },
+    actions = final_actions, -- Use the constructed actions map
   }
 end
 
@@ -449,15 +565,43 @@ function M.search(opts)
       end
     end
 
-    local actions = {
-      open_in_browser = function(_, item)
+    -- Prepare actions and keys for Snacks
+    local final_actions = {}
+    local final_keys = {}
+    local default_mode = { "n", "i" }
+
+    -- Process custom actions from config array
+    local custom_actions_defined = {}
+    if cfg.picker_config.snacks and cfg.picker_config.snacks.actions and cfg.picker_config.snacks.actions.search then
+      for _, action_item in ipairs(cfg.picker_config.snacks.actions.search) do
+        if action_item.name and action_item.fn then
+          final_actions[action_item.name] = action_item.fn
+          custom_actions_defined[action_item.name] = true
+          if action_item.lhs then
+            final_keys[action_item.lhs] = { action_item.name, mode = action_item.mode or default_mode }
+          end
+        end
+      end
+    end
+
+    -- Add default actions/keys if not overridden
+    if not custom_actions_defined["open_in_browser"] then
+      final_actions["open_in_browser"] = function(_picker, item)
         navigation.open_in_browser(item.kind, item.repository.nameWithOwner, item.number)
-      end,
-      copy_url = function(_, item)
+      end
+    end
+    if not final_keys[cfg.picker_config.mappings.open_in_browser.lhs] then
+       final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
+    end
+
+    if not custom_actions_defined["copy_url"] then
+      final_actions["copy_url"] = function(_picker, item)
         utils.copy_url(item.url)
-      end,
-    }
-    actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.search or {})
+      end
+    end
+    if not final_keys[cfg.picker_config.mappings.copy_url.lhs] then
+       final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
+    end
 
     Snacks.picker.pick {
       title = opts.preview_title or "GitHub Search Results",
@@ -492,13 +636,10 @@ function M.search(opts)
           minimal = true,
         },
         input = {
-          keys = {
-            [cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = { "n", "i" } },
-            [cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = { "n", "i" } },
-          },
+          keys = final_keys, -- Use the constructed keys map
         },
       },
-      actions = actions,
+      actions = final_actions, -- Use the constructed actions map
     }
   else
     utils.info "No search results found"

--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -94,10 +94,10 @@ M.issues = function(opts)
             utils.copy_url(url)
           end,
         }
-        actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions or {})
+        actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.issues or {})
 
         Snacks.picker.pick {
-          title = opts.preview_title or "",
+          title = opts.preview_title or "Issues",
           items = issues,
           format = function(item, _)
             ---@type snacks.picker.Highlight[]
@@ -180,10 +180,10 @@ function M.pull_requests(opts)
             utils.merge_pr(item.number)
           end,
         }
-        actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions or {})
+        actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.pull_requests or {})
 
         Snacks.picker.pick {
-          title = opts.preview_title or "",
+          title = opts.preview_title or "Pull Requests",
           items = pull_requests,
           format = function(item, _)
             ---@type snacks.picker.Highlight[]
@@ -288,10 +288,10 @@ function M.notifications(opts)
             M.notifications(opts)
           end,
         }
-        actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions or {})
+        actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.notifications or {})
 
         Snacks.picker.pick {
-          title = opts.preview_title or "",
+          title = opts.preview_title or "Notifications",
           items = safe_notifications,
           format = function(item, _)
             ---@type snacks.picker.Highlight[]
@@ -362,10 +362,10 @@ function M.issue_templates(templates, cb)
       end
     end,
   }
-  actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions or {})
+  actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.issue_templates or {})
 
   Snacks.picker.pick {
-    title = "Issue templates",
+    title = "Issue Templates",
     items = formatted_templates,
     format = function(item)
       if type(item) ~= "table" then
@@ -459,10 +459,10 @@ function M.search(opts)
         utils.copy_url(item.url)
       end,
     }
-    actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions or {})
+    actions = vim.tbl_deep_extend("force", actions, cfg.picker_config.snacks.actions.search or {})
 
     Snacks.picker.pick {
-      title = opts.preview_title or "GitHub Search Results",
+      title = opts.preview_title or "Search Results",
       items = search_results,
       format = function(item, _)
         local a = Snacks.picker.util.align

--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -90,7 +90,11 @@ M.issues = function(opts)
 
         -- Process custom actions from config array
         local custom_actions_defined = {} -- Keep track of names defined by user
-        if cfg.picker_config.snacks and cfg.picker_config.snacks.actions and cfg.picker_config.snacks.actions.issues then
+        if
+          cfg.picker_config.snacks
+          and cfg.picker_config.snacks.actions
+          and cfg.picker_config.snacks.actions.issues
+        then
           for _, action_item in ipairs(cfg.picker_config.snacks.actions.issues) do
             if action_item.name and action_item.fn then
               final_actions[action_item.name] = action_item.fn
@@ -109,7 +113,7 @@ M.issues = function(opts)
           end
         end
         if not final_keys[cfg.picker_config.mappings.open_in_browser.lhs] then
-           final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
+          final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
         end
 
         if not custom_actions_defined["copy_url"] then
@@ -118,7 +122,7 @@ M.issues = function(opts)
           end
         end
         if not final_keys[cfg.picker_config.mappings.copy_url.lhs] then
-           final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
+          final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
         end
 
         Snacks.picker.pick {
@@ -195,7 +199,11 @@ function M.pull_requests(opts)
 
         -- Process custom actions from config array
         local custom_actions_defined = {}
-        if cfg.picker_config.snacks and cfg.picker_config.snacks.actions and cfg.picker_config.snacks.actions.pull_requests then
+        if
+          cfg.picker_config.snacks
+          and cfg.picker_config.snacks.actions
+          and cfg.picker_config.snacks.actions.pull_requests
+        then
           for _, action_item in ipairs(cfg.picker_config.snacks.actions.pull_requests) do
             if action_item.name and action_item.fn then
               final_actions[action_item.name] = action_item.fn
@@ -214,7 +222,7 @@ function M.pull_requests(opts)
           end
         end
         if not final_keys[cfg.picker_config.mappings.open_in_browser.lhs] then
-           final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
+          final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
         end
 
         if not custom_actions_defined["copy_url"] then
@@ -223,23 +231,26 @@ function M.pull_requests(opts)
           end
         end
         if not final_keys[cfg.picker_config.mappings.copy_url.lhs] then
-           final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
+          final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
         end
 
         if not custom_actions_defined["check_out_pr"] then
-           final_actions["check_out_pr"] = function(_picker, item) utils.checkout_pr(item.number) end
+          final_actions["check_out_pr"] = function(_picker, item)
+            utils.checkout_pr(item.number)
+          end
         end
         if not final_keys[cfg.picker_config.mappings.checkout_pr.lhs] then
-           final_keys[cfg.picker_config.mappings.checkout_pr.lhs] = { "check_out_pr", mode = default_mode }
+          final_keys[cfg.picker_config.mappings.checkout_pr.lhs] = { "check_out_pr", mode = default_mode }
         end
 
         if not custom_actions_defined["merge_pr"] then
-           final_actions["merge_pr"] = function(_picker, item) utils.merge_pr(item.number) end
+          final_actions["merge_pr"] = function(_picker, item)
+            utils.merge_pr(item.number)
+          end
         end
         if not final_keys[cfg.picker_config.mappings.merge_pr.lhs] then
-           final_keys[cfg.picker_config.mappings.merge_pr.lhs] = { "merge_pr", mode = default_mode }
+          final_keys[cfg.picker_config.mappings.merge_pr.lhs] = { "merge_pr", mode = default_mode }
         end
-
 
         Snacks.picker.pick {
           title = opts.preview_title or "Pull Requests",
@@ -325,7 +336,11 @@ function M.notifications(opts)
 
         -- Process custom actions from config array
         local custom_actions_defined = {}
-        if cfg.picker_config.snacks and cfg.picker_config.snacks.actions and cfg.picker_config.snacks.actions.notifications then
+        if
+          cfg.picker_config.snacks
+          and cfg.picker_config.snacks.actions
+          and cfg.picker_config.snacks.actions.notifications
+        then
           for _, action_item in ipairs(cfg.picker_config.snacks.actions.notifications) do
             if action_item.name and action_item.fn then
               final_actions[action_item.name] = action_item.fn
@@ -344,7 +359,7 @@ function M.notifications(opts)
           end
         end
         if not final_keys[cfg.picker_config.mappings.open_in_browser.lhs] then
-           final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
+          final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
         end
 
         if not custom_actions_defined["copy_url"] then
@@ -355,7 +370,7 @@ function M.notifications(opts)
           end
         end
         if not final_keys[cfg.picker_config.mappings.copy_url.lhs] then
-           final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
+          final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
         end
 
         if not custom_actions_defined["mark_notification_read"] then
@@ -377,8 +392,12 @@ function M.notifications(opts)
           end
         end
         -- Use the default mapping from the main config section for 'read'
-        if cfg.mappings.notification and cfg.mappings.notification.read and not final_keys[cfg.mappings.notification.read.lhs] then
-           final_keys[cfg.mappings.notification.read.lhs] = { "mark_notification_read", mode = default_mode }
+        if
+          cfg.mappings.notification
+          and cfg.mappings.notification.read
+          and not final_keys[cfg.mappings.notification.read.lhs]
+        then
+          final_keys[cfg.mappings.notification.read.lhs] = { "mark_notification_read", mode = default_mode }
         end
 
         Snacks.picker.pick {
@@ -450,7 +469,11 @@ function M.issue_templates(templates, cb)
 
   -- Process custom actions from config array
   local custom_actions_defined = {}
-  if cfg.picker_config.snacks and cfg.picker_config.snacks.actions and cfg.picker_config.snacks.actions.issue_templates then
+  if
+    cfg.picker_config.snacks
+    and cfg.picker_config.snacks.actions
+    and cfg.picker_config.snacks.actions.issue_templates
+  then
     for _, action_item in ipairs(cfg.picker_config.snacks.actions.issue_templates) do
       if action_item.name and action_item.fn then
         final_actions[action_item.name] = action_item.fn
@@ -591,7 +614,7 @@ function M.search(opts)
       end
     end
     if not final_keys[cfg.picker_config.mappings.open_in_browser.lhs] then
-       final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
+      final_keys[cfg.picker_config.mappings.open_in_browser.lhs] = { "open_in_browser", mode = default_mode }
     end
 
     if not custom_actions_defined["copy_url"] then
@@ -600,7 +623,7 @@ function M.search(opts)
       end
     end
     if not final_keys[cfg.picker_config.mappings.copy_url.lhs] then
-       final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
+      final_keys[cfg.picker_config.mappings.copy_url.lhs] = { "copy_url", mode = default_mode }
     end
 
     Snacks.picker.pick {

--- a/lua/tests/octo/config_spec.lua
+++ b/lua/tests/octo/config_spec.lua
@@ -31,6 +31,36 @@ describe("Octo config", function()
         assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
       end)
 
+      it("should return invalid when picker_config.mappings action isn't a table", function()
+        config.values.picker_config.mappings = { open_in_browser = "cfg" }
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
+      end)
+
+      it("should return invalid when picker_config.mappings action lhs isn't a string", function()
+        config.values.picker_config.mappings = { open_in_browser = { lhs = 123, desc = "desc" } }
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
+      end)
+
+      it("should return invalid when picker_config.mappings action desc isn't a string", function()
+        config.values.picker_config.mappings = { open_in_browser = { lhs = "<C-b>", desc = 123 } }
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
+      end)
+
+      it("should return invalid when picker_config.snacks isn't a table", function()
+        config.values.picker_config.snacks = "cfg"
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
+      end)
+
+      it("should return invalid when picker_config.snacks.actions isn't a table", function()
+        config.values.picker_config.snacks.actions = "cfg"
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
+      end)
+
+      it("should return invalid when picker_config.snacks.actions contains non-function", function()
+        config.values.picker_config.snacks.actions = { ["<C-a>"] = "not a function" }
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
+      end)
+
       it("should return invalid when user_icon isn't a string", function()
         config.values.user_icon = false
         assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)

--- a/lua/tests/octo/config_spec.lua
+++ b/lua/tests/octo/config_spec.lua
@@ -57,8 +57,15 @@ describe("Octo config", function()
       end)
 
       it("should return invalid when picker_config.snacks.actions contains non-function", function()
-        config.values.picker_config.snacks.actions = { ["<C-a>"] = "not a function" }
+        config.values.picker_config.snacks.actions = { issues = { ["<C-a>"] = "not a function" } }
         assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
+      end)
+
+      it("should return invalid when picker_config.snacks.actions contains invalid picker type", function()
+        config.values.picker_config.snacks.actions = { invalid_picker = { ["<C-a>"] = function() end } }
+        -- This currently passes validation as we don't restrict keys, but the actions won't be used.
+        -- If strict validation is added later, this test should fail.
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) == 0)
       end)
 
       it("should return invalid when user_icon isn't a string", function()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
- Added support for snacks-specific actions in the picker.
- Updated validation to include snacks configuration.
- Refactored existing actions to integrate with snacks.
- Improved tests to cover new snacks functionality.

### Does this pull request fix one issue?
Fixes #1059 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it                                                                                                      
                                                                                                                                 
1.  **Configuration:** Modified `lua/octo/config.lua` to:                                                                        
    *   Add `"snacks"` to the list of valid pickers.                                                                             
    *   Define the new `OctoPickerConfigSnacks` and `OctoSnacksActionItem` types.                                                
    *   Add the `picker_config.snacks` table with an `actions` sub-table (using an array-of-tables structure for actions) to the default configuration.                                                                                                           
    *   Implement detailed validation logic within `validate_config()` for the new `snacks` configuration structure, including   
checking action item fields (`name`, `fn`, `lhs`, `desc`, `mode`).                                                               
    *   Updated `config.setup` to use `vim.tbl_deep_extend("force", ...)` to correctly merge user-defined action arrays.         
2.  **Provider Logic:** Refactored `lua/octo/pickers/snacks/provider.lua`:                                                       
    *   Removed hardcoded actions and keybindings.                                                                               
    *   Implemented logic in each picker function (`issues`, `pull_requests`, etc.) to:                                          
        *   Read custom actions defined by the user in `cfg.picker_config.snacks.actions`.                                       
        *   Build `final_actions` and `final_keys` tables.                                                                       
        *   Add default actions/keybindings *only if* they haven't been overridden by the user (checking both action `name` and  
`lhs` keybinding).                                                                                                               
        *   Pass these dynamically generated tables to `Snacks.picker.pick`.                                                     
3.  **Testing:** Added new test cases in `lua/tests/octo/config_spec.lua` to specifically validate the new `snacks` configuration
options and ensure the validation logic catches errors.                                                                          
4.  **Documentation:** Updated `README.md` and `doc/octo.txt` to reflect the new `snacks` picker option and document the         
`picker_config.snacks.actions` configuration structure.                                                                          

### Describe how to verify it

1.  **Install `snacks.nvim`:** Ensure you have `folke/snacks.nvim` installed alongside `octo.nvim`.                              
2.  **Configure `octo.nvim` to use `snacks`:**                                                                                   
    *   Set `picker = "snacks"` in your `octo.setup({})` call.                                                                   
    *   Add a custom action to the `snacks` configuration for testing. Use `<localleader>t` as the keybinding:                   
                                                                                                                                 
    ```lua                                                                                                                       
    require("octo").setup({                                                                                                      
      picker = "snacks",                                                                                                         
      picker_config = {                                                                                                          
        -- other mappings...                                                                                                     
        snacks = {                                                                                                               
          actions = {                                                                                                            
            issues = {                                                                                                           
              {                                                                                                                  
                name = "test_issue_action",                                                                                      
                fn = function(picker, item)                                                                                      
                  -- Simple test: print the item title                                                                           
                  print("Snacks Test Action Triggered for Issue:", item.title)                                                   
                  -- You could add more complex logic here if needed                                                             
                  -- Close the picker after action                                                                               
                  picker:close()                                                                                                 
                end,                                                                                                             
                lhs = "<localleader>t", -- Use localleader for the test mapping                                                  
                desc = "Test Snacks Issue Action"                                                                                
              },                                                                                                                 
              -- You can add more custom actions here                                                                            
            },                                                                                                                   
            -- Add custom actions for other pickers like pull_requests if desired                                                
          },                                                                                                                     
        },                                                                                                                       
      },                                                                                                                         
      -- other octo config...                                                                                                    
    })                                                                                                                           
    ```                                                                                                                          
                                                                                                                                 
3.  **Test Default Picker Actions:**                                                                                             
    *   Open an issue list: `:Octo issue list`                                                                                   
    *   Verify default mappings work within the Snacks picker:                                                                   
        *   `<C-b>`: Opens the selected issue in the browser.                                                                    
        *   `<C-y>`: Copies the URL of the selected issue.                                                                       
    *   Open a PR list: `:Octo pr list`                                                                                          
    *   Verify default mappings work within the Snacks picker:                                                                   
        *   `<C-b>`: Opens the selected PR in the browser.                                                                       
        *   `<C-y>`: Copies the URL of the selected PR.                                                                          
        *   `<C-o>`: Checks out the selected PR.                                                                                 
        *   `<C-r>`: Merges the selected PR (using the default method).                                                          
                                                                                                                                 
4.  **Test Custom Action:**                                                                                                      
    *   Open an issue list again: `:Octo issue list`                                                                             
    *   Select an issue in the Snacks picker.                                                                                    
    *   Press `<localleader>t` (or whatever you set `lhs` to).                                                                   
    *   **Expected:** The picker should close, and you should see the message "Snacks Test Action Triggered for Issue: <Issue    
Title>" printed in the Neovim command line.                                                                                      
                                                                                                                                 
5.  **Test Configuration Validation (Optional):**                                                                                
    *   Intentionally introduce an error in the `snacks` configuration (e.g., set `fn` to a string instead of a function).       
    *   Restart Neovim.                                                                                                          
    *   **Expected:** `octo.nvim` should report a configuration error on startup related to the invalid `snacks` action          
definition. Fix the error to proceed.                                                                                            

### Special notes for reviews

Running `stylua --check .` locally passes, I'm assuming there's some issue with the github action as I don't see any specific linting error in that failing action.

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
