### PR TITLE
feat(snacks): improve format for issue list

### DIFF
--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -87,13 +87,24 @@ M.issues = function(opts)
           title = opts.preview_title or "",
           items = issues,
           format = function(item, _)
+            local a = Snacks.picker.util.align
             ---@type snacks.picker.Highlight[]
             local ret = {}
+
             ---@diagnostic disable-next-line: assign-type-mismatch
             ret[#ret + 1] = utils.get_icon { kind = item.kind, obj = item }
-            ret[#ret + 1] = { string.format("#%d", item.number), "Comment" }
-            ret[#ret + 1] = { (" "):rep(#tostring(max_number) - #tostring(item.number) + 1) }
-            ret[#ret + 1] = { item.title, "Normal" }
+
+            ret[#ret + 1] = { " " }
+
+            local issue_id = string.format("#%d", item.number)
+            local issue_id_width = #tostring(max_number) + 1
+
+            ret[#ret + 1] = { a(issue_id, issue_id_width), "SnacksPickerGitIssue" }
+
+            ret[#ret + 1] = { " " }
+
+            ret[#ret + 1] = { item.title }
+
             return ret
           end,
           win = {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

The current issue lists looks like this for the snacks picker:

![image](https://github.com/user-attachments/assets/3fc14479-9bf8-4abc-b502-0f07a122c2ba)

There biggest issue here is that the highlight disappears across the issue title. This PR also changes the format to be in line with what the search function currently uses, which use a different highlight group for the issue id.

![image](https://github.com/user-attachments/assets/b7c0d600-c172-4229-8cbc-2aace8dc45ff)


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
