### PR TITLE
Make notification mapping match the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ require"octo".setup({
       toggle_viewed = { lhs = "<localleader><space>", desc = "toggle viewer viewed state" },
     },
     notification = {
-      read = { lhs = "<localleader>rn", desc = "mark notification as read" },
+      read = { lhs = "<localleader>nr", desc = "mark notification as read" },
       done = { lhs = "<localleader>nd", desc = "mark notification as done" },
     },
   },


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

The README mapping was different than the actual mapping in the configuration. This makes them match.


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
