### PR TITLE
Fix review commit comment published on wrong line

### DIFF
--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -774,11 +774,8 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
         local diffhunks = {}
         local diffhunk = ""
         local left_comment_ranges, right_comment_ranges = {}, {}
-        if not utils.is_blank(pr.diff) then
-          local diffhunks_map = utils.extract_diffhunks_from_diff(pr.diff)
-          local file_diffhunks = diffhunks_map[comment_metadata.path]
-          diffhunks, left_comment_ranges, right_comment_ranges = utils.process_patch(file_diffhunks)
-        end
+        diffhunks, left_comment_ranges, right_comment_ranges =
+          file.diffhunks, file.left_comment_ranges, file.right_comment_ranges
         local comment_ranges
         if comment_metadata.diffSide == "RIGHT" then
           comment_ranges = right_comment_ranges

--- a/lua/octo/model/pull-request.lua
+++ b/lua/octo/model/pull-request.lua
@@ -66,8 +66,19 @@ M.PullRequest = PullRequest
 local function merge_pages(data)
   local out = {}
   for _, page in ipairs(data) do
-    for _, item in ipairs(page) do
-      table.insert(out, item)
+    if type(page) == "table" then
+      -- Check if page is array-like or object-like
+      if #page > 0 then
+        -- Array-like, use ipairs
+        for _, item in ipairs(page) do
+          table.insert(out, item)
+        end
+      else
+        -- Object-like: merge its key/value pairs directly into out
+        for k, v in pairs(page) do
+          out[k] = v
+        end
+      end
     end
   end
   return out


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

There was an issue where when someone posts a comment on a PR on a "commit level" (using `:Octo review commit` and then selecting a commit and then running `:Octo comment add`), then it would end up submitting that comment to the wrong line in the PR on GitHub. This PR fixes that issue.


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #1062 

### Describe how you did it

Debugged through the plugin and found out that in order to calculate the `position` for where to submit the comment, we were using the diffs of the entire PR (including ALL the commits), when we should have been using the diff of **only** the commit for which we are adding the comment on.

### Describe how to verify it

Just follow the expected flow for adding a comment on a commit level to a GitHub PR:
1. `:Octo review`
2. `:Octo review commit`
3. Pick a commit
4. `:Octo comment add`
5. Save the comment
6. Navigate to the GitHub PR and notice that the comment is placed in the right position.

Note: Ideally, you should run this test for a PR that has multiple commits. Also note that octo.nvim is still broken in the sense that it won't show the correct placement of the comment in octo.nvim, so you'll have to directly validate from GitHub. That specific bug I'm talking about is tracked by #1063 

### Special notes for reviews

This PR is dependent on a different PR #1072 which is what the [first commit](https://github.com/pwntester/octo.nvim/commit/d05f64c45122712174636d201cb48727e5f37f19) is for. The work in this PR is based off of that PR's branch to actually get the `:Octo review commit` command working.

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
