### PR TITLE
Fix review commit comments misplaced across buffers

### DIFF
--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -774,11 +774,8 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
         local diffhunks = {}
         local diffhunk = ""
         local left_comment_ranges, right_comment_ranges = {}, {}
-        if not utils.is_blank(pr.diff) then
-          local diffhunks_map = utils.extract_diffhunks_from_diff(pr.diff)
-          local file_diffhunks = diffhunks_map[comment_metadata.path]
-          diffhunks, left_comment_ranges, right_comment_ranges = utils.process_patch(file_diffhunks)
-        end
+        diffhunks, left_comment_ranges, right_comment_ranges =
+          file.diffhunks, file.left_comment_ranges, file.right_comment_ranges
         local comment_ranges
         if comment_metadata.diffSide == "RIGHT" then
           comment_ranges = right_comment_ranges

--- a/lua/octo/model/pull-request.lua
+++ b/lua/octo/model/pull-request.lua
@@ -66,8 +66,19 @@ M.PullRequest = PullRequest
 local function merge_pages(data)
   local out = {}
   for _, page in ipairs(data) do
-    for _, item in ipairs(page) do
-      table.insert(out, item)
+    if type(page) == "table" then
+      -- Check if page is array-like or object-like
+      if #page > 0 then
+        -- Array-like, use ipairs
+        for _, item in ipairs(page) do
+          table.insert(out, item)
+        end
+      else
+        -- Object-like: merge its key/value pairs directly into out
+        for k, v in pairs(page) do
+          out[k] = v
+        end
+      end
     end
   end
   return out

--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -409,7 +409,11 @@ function FileEntry:place_signs()
         end
         if
           (review_level == "PR" and utils.is_thread_placed_in_buffer(thread, split.bufnr))
-          or (review_level == "COMMIT" and split.commit == comment.originalCommit.abbreviatedOid)
+          or (
+            review_level == "COMMIT"
+            and current_review.layout.right:abbrev() == comment.originalCommit.abbreviatedOid
+            and utils.is_thread_placed_in_buffer(thread, split.bufnr)
+          )
         then
           -- for lines between startLine and endLine, place the sign
           for line = startLine, endLine do

--- a/lua/octo/reviews/thread-panel.lua
+++ b/lua/octo/reviews/thread-panel.lua
@@ -44,14 +44,12 @@ function M.show_review_threads(jump_to_buffer)
     then
       table.insert(threads_at_cursor, thread)
     elseif review_level == "COMMIT" then
-      local commit
-      if split == "LEFT" then
-        commit = review.layout.left.commit
-      else
-        commit = review.layout.right.commit
-      end
       for _, comment in ipairs(thread.comments.nodes) do
-        if commit == comment.originalCommit.oid and thread.originalLine == line then
+        if
+          review.layout.right.commit == comment.originalCommit.oid
+          and utils.is_thread_placed_in_buffer(thread, bufnr)
+          and thread.originalLine == line
+        then
           table.insert(threads_at_cursor, thread)
           break
         end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

There was an issue in the `octo.nvim` plugin where if you added a comment on a commit-level for a PR, it would show the comment in the octo buffers in the wrong place. 

For example, you would place the comment on a commit-level on the left side of a certain file, but it would show the comment on the right side of the file, and the visibility of those comment would also leak across files / buffers in octo.

This PR fixes that.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #1063 

### Describe how you did it

I debugged through the application and found the place where the plugin was checking the signs for the comments and when it should be placing them and found the place where it was determining where to show the review threads.

For example, before, in order to determine when to show a comment, it would check:

-  ✅  Whether the comment was placed on a `COMMIT` review level, which was a good check
- ⚠️ Whether the commit ID of a comment matched the commit ID of the left pane or the right pane, this was an erroneous check 
   - Think about it. When you review a PR commit by commit, you're placing that comment for THAT specific commit, not for the commit before it, so even when you view that commit, you want to see that comment regardless of whether it's placed in the left or right pane. If you always check whether a comment's commit ID matches the left or right side, you'll find that it can never match the left side, it will always match the right side, because the left pane belongs to the previous commit, but that doesn't mean you don't want to see the comment on the left side.
   - I instead replaced this by always checking to make sure that the comment that we're about to place matches the RIGHT pane's commit ID (the commit that is being currently reviewed right now), and then we figure out whether to place it in the left or right pane in a different check.
- ❌  There was currently no check to see which pane a comment belonged to. The above check was supposed to do this but I explained why that logic is faulty so I added that check now.
- ❌  There was currently no check to see which file a comment belonged to. This is why you were seeing review commit comments leaked through different buffers for a PR.

### Describe how to verify it

1. `:Octo review`
2. `:Octo review commit`
3. Pick a commit
4. `:Octo comment add`
5. Save the comment
6. Notice that the signs in the Octo.nvim buffers are exactly where you would expect it to be (where you placed your comment)

### Special notes for reviews

This PR is dependent on two previous PRs:

1. [The first commit in this PR](https://github.com/pwntester/octo.nvim/commit/d05f64c45122712174636d201cb48727e5f37f19) which has its [own PR](https://github.com/pwntester/octo.nvim/pull/1072)
2. [The second commit in this PR](https://github.com/pwntester/octo.nvim/commit/d05f64c45122712174636d201cb48727e5f37f19) which has its [own PR](https://github.com/pwntester/octo.nvim/pull/1073)

The work in this PR is based off of those PR's commits to actually get the `:Octo review commit` command working.

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
