### PR TITLE
Adjust user pattern to also find users from enterprise orgs

### DIFF
--- a/lua/octo/constants.lua
+++ b/lua/octo/constants.lua
@@ -26,6 +26,6 @@ M.SHORT_ISSUE_PATTERN = "[^%w%d]+#(%d+)"
 M.SHORT_ISSUE_LINE_BEGINNING_PATTERN = "^#(%d+)"
 M.URL_ISSUE_PATTERN = "[htps]+://[^/]+/([^/]+/[^/]+)/([pulisedcton]+)/(%d+)"
 
-M.USER_PATTERN = "@([%w-]+)"
+M.USER_PATTERN = "@([%w-_]+)"
 
 return M


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

adjust the user pattern to also find users from enterprise organizations in github 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #1070

### Describe how you did it

added `_` to pattern so users from enterprise organization can be queried via gh cli

### Describe how to verify it

move to a mention of user from enterprice org in an issue or similar, hover should appear with the short info of the user

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt # not needed
