### PR TITLE
fix(colors): don't overwrite highlight groups if they exists

### DIFF
--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -135,7 +135,9 @@ end
 
 function M.setup()
   for name, hl in pairs(get_hl_groups()) do
-    vim.api.nvim_set_hl(0, "Octo" .. name, hl)
+    if vim.fn.hlexists("Octo" .. name) == 0 then
+      vim.api.nvim_set_hl(0, "Octo" .. name, hl)
+    end
   end
 
   for from, to in pairs(get_hl_links()) do


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This PR prevent HL groups from being overwritten if they already exists (aka. provided by a theme or the user)


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
It fixes this case: https://github.com/pwntester/octo.nvim/issues/1010#issuecomment-2878240118


### Describe how you did it
By checking the hl groups existence before setting them (it was already done for linked hl groups)

### Describe how to verify it
Themes with Octo integration should have all treir highlight groups.

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
