### PR TITLE
Fix broken `:Octo review commit` command workflow

### DIFF
--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -774,11 +774,8 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
         local diffhunks = {}
         local diffhunk = ""
         local left_comment_ranges, right_comment_ranges = {}, {}
-        if not utils.is_blank(pr.diff) then
-          local diffhunks_map = utils.extract_diffhunks_from_diff(pr.diff)
-          local file_diffhunks = diffhunks_map[comment_metadata.path]
-          diffhunks, left_comment_ranges, right_comment_ranges = utils.process_patch(file_diffhunks)
-        end
+        diffhunks, left_comment_ranges, right_comment_ranges =
+          file.diffhunks, file.left_comment_ranges, file.right_comment_ranges
         local comment_ranges
         if comment_metadata.diffSide == "RIGHT" then
           comment_ranges = right_comment_ranges

--- a/lua/octo/model/pull-request.lua
+++ b/lua/octo/model/pull-request.lua
@@ -66,8 +66,19 @@ M.PullRequest = PullRequest
 local function merge_pages(data)
   local out = {}
   for _, page in ipairs(data) do
-    for _, item in ipairs(page) do
-      table.insert(out, item)
+    if type(page) == "table" then
+      -- Check if page is array-like or object-like
+      if #page > 0 then
+        -- Array-like, use ipairs
+        for _, item in ipairs(page) do
+          table.insert(out, item)
+        end
+      else
+        -- Object-like: merge its key/value pairs directly into out
+        for k, v in pairs(page) do
+          out[k] = v
+        end
+      end
     end
   end
   return out

--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -409,7 +409,11 @@ function FileEntry:place_signs()
         end
         if
           (review_level == "PR" and utils.is_thread_placed_in_buffer(thread, split.bufnr))
-          or (review_level == "COMMIT" and split.commit == comment.originalCommit.abbreviatedOid)
+          or (
+            review_level == "COMMIT"
+            and current_review.layout.right:abbrev() == comment.originalCommit.abbreviatedOid
+            and utils.is_thread_placed_in_buffer(thread, split.bufnr)
+          )
         then
           -- for lines between startLine and endLine, place the sign
           for line = startLine, endLine do

--- a/lua/octo/reviews/thread-panel.lua
+++ b/lua/octo/reviews/thread-panel.lua
@@ -44,14 +44,12 @@ function M.show_review_threads(jump_to_buffer)
     then
       table.insert(threads_at_cursor, thread)
     elseif review_level == "COMMIT" then
-      local commit
-      if split == "LEFT" then
-        commit = review.layout.left.commit
-      else
-        commit = review.layout.right.commit
-      end
       for _, comment in ipairs(thread.comments.nodes) do
-        if commit == comment.originalCommit.oid and thread.originalLine == line then
+        if
+          review.layout.right.commit == comment.originalCommit.oid
+          and utils.is_thread_placed_in_buffer(thread, bufnr)
+          and thread.originalLine == line
+        then
           table.insert(threads_at_cursor, thread)
           break
         end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
There were various different issues when you tried to use the `:Octo review commit` command. These bugs are listed as follows:

1. When you ran the `:Octo review commit` command, and then picked a specific commit, it would be stuck on processing / loading the diffed files but it would never work.
2. Even after fixing 1, when you posted a review commit comment on a certain line, the comment would show up on a different line in the actual GitHub PR.
3. Even after fixing 1 & 2, the comment that you actually posted for a commit would end up leaking through the different diffed files' buffers and even if it showed up on the correct line in the GitHub PR, the thread (and the Octo thread preview hint in the diffed buffers) would show up on the wrong line.

This PR fixes all that.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #1061
Fixes #1062 
Fixes #1063 

### Describe how you did it

####  Fixed Broken Processing for Review Commit

I debugged through the plugin and found out that it was the merge_pages function in the pull_request.lua file that was faulty. This merge_pages function was being called by the get_commit_changed_files function which gets the single commit for whose changes we want to see. Actually the result from the API call contains a list of a single JSON object.

So it sends this list of a single JSON object (corresponding to our one commit whose changes we want to see) to the merge_pages function. But merge_pages had a bug where it was not handling this case. What it was expecting instead was a list of pages and each page would contain its own set of JSON objects. But it didn't expect the case where it would just be an array of JSON objects, which is the output format for a single commit review.

Anyway, I fixed this by just simply merging the key-value into the out variable directly. It should be noted that the first case where the results contain an array of an array of JSON objects still needs to be handled (so I didn't remove that logic) because the get_changed_files function also calls the merge_pages function and it needs that case

#### Fixed Review Commit Comment Being Published on the Wrong Line in GitHub

Debugged through the plugin and found out that in order to calculate the position for where to submit the comment, we were using the diffs of the entire PR (including ALL the commits), when we should have been using the diff of only the commit for which we are adding the comment on.

#### Fixed Review Commit Comment Misplaced Across Neovim Buffers in Octo Diffs

-  ✅  Whether the comment was placed on a `COMMIT` review level, which was a good check
- ⚠️ Whether the commit ID of a comment matched the commit ID of the left pane or the right pane, this was an erroneous check 
   - Think about it. When you review a PR commit by commit, you're placing that comment for THAT specific commit, not for the commit before it, so even when you view that commit, you want to see that comment regardless of whether it's placed in the left or right pane. If you always check whether a comment's commit ID matches the left or right side, you'll find that it can never match the left side, it will always match the right side, because the left pane belongs to the previous commit, but that doesn't mean you don't want to see the comment on the left side.
   - I instead replaced this by always checking to make sure that the comment that we're about to place matches the RIGHT pane's commit ID (the commit that is being currently reviewed right now), and then we figure out whether to place it in the left or right pane in a different check.
- ❌  There was currently no check to see which pane a comment belonged to. The above check was supposed to do this but I explained why that logic is faulty so I added that check now.
- ❌  There was currently no check to see which file a comment belonged to. This is why you were seeing review commit comments leaked through different buffers for a PR.

### Describe how to verify it

1. `:Octo review`
2. `:Octo review commit`
3. Pick a commit
4. `:Octo comment add`
5. Save the comment
6. Notice that the everything is working as expected: Comment is published in the GitHub PR on the correct line in the pending state and the signs in the Octo Neovim Diffed Buffers are exactly where you would expect it to be (where you placed your comment)

### Special notes for reviews

### Checklist

- [X] Passing tests and linting standards
- [X] Documentation updates in README.md and doc/octo.txt
