### PR TITLE
feat(notifications): add unsubscribe keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ require"octo".setup({
     notification = {
       read = { lhs = "<localleader>nr", desc = "mark notification as read" },
       done = { lhs = "<localleader>nd", desc = "mark notification as done" },
+      unsubscribe = { lhs = "<localleader>nu", desc = "unsubscribe from notifications" },
     },
   },
 })

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -434,6 +434,7 @@ function M.get_default_values()
       notification = {
         read = { lhs = "<localleader>nr", desc = "mark notification as read" },
         done = { lhs = "<localleader>nd", desc = "mark notification as done" },
+        unsubscribe = { lhs = "<localleader>nu", desc = "unsubscribe from notifications" },
       },
       repo = {},
     },


### PR DESCRIPTION
### Describe what this PR does / why we need it

Adds the unsubscribe keymap, which unsubscribes the user from further notifications, marks the notifications as read and removes the notification from the picker list.

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
