### PR TITLE
fix: go to file functionality

### DIFF
--- a/lua/octo/autocmds.lua
+++ b/lua/octo/autocmds.lua
@@ -18,16 +18,18 @@ function M.setup()
     end,
   })
 
-  define({ "BufEnter" }, {
-    group = "octo_autocmds",
-    pattern = { "*" },
-    callback = function()
-      local current_buffer = vim.api.nvim_buf_get_name(0)
-      if not current_buffer:match "^octo://" then
-        require("octo").update_layout_for_current_file()
-      end
-    end,
-  })
+  if config.values.use_local_fs then
+    define({ "BufEnter" }, {
+      group = "octo_autocmds",
+      pattern = { "*" },
+      callback = function()
+        local current_buffer = vim.api.nvim_buf_get_name(0)
+        if not current_buffer:match "^octo://" then
+          require("octo").update_layout_for_current_file()
+        end
+      end,
+    })
+  end
 
   define({ "BufReadCmd" }, {
     group = "octo_autocmds",


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This PR fixes an issue that was accidentally introduced in https://github.com/pwntester/octo.nvim/pull/538 where the `BufEnter` autocmd broke the existing go to file functionality via `gf`. We should only setup this autocmd if the `use_local_fs` option is set to `true`, as this autocmd was intended to be used only if that option was enabled.

### Describe how you did it

Did a bit manual git bisecting to find the commit that introduced the problem.

### Describe how to verify it

Open up a review for a PR and do `gf` to go the the file. If `use_local_fs` is enabled then `gf` won't work, but I think that might be the point.

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
