### PR TITLE
fix(env): add DBUS env var to enable accessing token in keyring

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -27,6 +27,7 @@ local env_vars = {
   https_proxy = vim.env["https_proxy"],
   no_proxy = vim.env["no_proxy"],
   SSH_AUTH_SOCK = vim.env["SSH_AUTH_SOCK"],
+  DBUS_SESSION_BUS_ADDRESS = vim.env["DBUS_SESSION_BUS_ADDRESS"],
 }
 
 local function get_env()


### PR DESCRIPTION
### Describe what this PR does / why we need it

Use environment variable `DBUS_SESSION_BUS_ADDRESS`  to access token in keyring otherwise every `gh` will fail in Octo.

### Does this pull request fix one issue?

Fixes: #1066 

### Describe how you did it

Inject environment variable `DBUS_SESSION_BUS_ADDRESS` when running `gh`  commands

### Describe how to verify it

See #1066 for details

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
