### PR TITLE
feat: render release

### DIFF
--- a/lua/octo/constants.lua
+++ b/lua/octo/constants.lua
@@ -25,6 +25,7 @@ M.LONG_ISSUE_PATTERN = "([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(%d+)"
 M.SHORT_ISSUE_PATTERN = "[^%w%d]+#(%d+)"
 M.SHORT_ISSUE_LINE_BEGINNING_PATTERN = "^#(%d+)"
 M.URL_ISSUE_PATTERN = "[htps]+://[^/]+/([^/]+/[^/]+)/([pulisedcton]+)/(%d+)"
+M.URL_RELEASE_PATTERN = "[htps]+://[^/]+/([^/]+/[^/]+)/(releases)/tag/([^/]+)"
 
 M.USER_PATTERN = "@([%w-_]+)"
 

--- a/lua/octo/gh/fragments.lua
+++ b/lua/octo/gh/fragments.lua
@@ -106,6 +106,12 @@ fragment DemilestonedEventFragment on DemilestonedEvent {
   milestoneTitle
 }
 ]]
+---@class octo.ReactionGroupsFragment
+--- @field reactionGroups {
+---   content: string,
+---   viewerHasReacted: boolean,
+---   users: { totalCount: number } }[]
+
 M.reaction_groups = [[
 fragment ReactionGroupsFragment on Reactable {
   reactionGroups {

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -476,6 +476,59 @@ query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
 }
 ]] .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.discussion_info .. fragments.discussion_details .. fragments.discussion_comment
 
+---@class octo.Release : octo.ReactionGroupsFragment
+--- @field id string
+--- @field name string
+--- @field tagName string
+--- @field tagCommit { abbreviatedOid: string }
+--- @field url string
+--- @field isPrerelease boolean
+--- @field isLatest boolean
+--- @field publishedAt string
+--- @field description string
+--- @field author { login: string }
+--- @field releaseAssets {
+---   nodes: {
+---     name: string,
+---     downloadUrl: string,
+---     downloadCount: number,
+---     size: number,
+---     updatedAt: string,
+---   }[] }
+
+M.release = [[
+query($owner: String!, $name: String!, $tag: String!) {
+  repository(owner: $owner, name: $name) {
+    release(tagName: $tag) {
+      id
+      name
+      tagName
+      tagCommit {
+        abbreviatedOid
+      }
+      url
+      isPrerelease
+      isLatest
+      publishedAt
+      description
+      releaseAssets(first: 100) {
+        nodes {
+          name
+          downloadUrl
+          downloadCount
+          size
+          updatedAt
+        }
+      }
+      author {
+        login
+      }
+      ...ReactionGroupsFragment
+    }
+  }
+}
+]] .. fragments.reaction_groups
+
 -- https://docs.github.com/en/graphql/reference/objects#project
 M.projects = [[
 query {

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -100,6 +100,14 @@ function OctoBuffer:render_repo()
   self.ready = true
 end
 
+function OctoBuffer:render_release()
+  self:clear()
+  local obj = self.node
+  writers.write_release(self.bufnr, obj)
+  vim.bo[self.bufnr].modified = false
+  self.ready = true
+end
+
 function OctoBuffer:render_discussion()
   self:clear()
 

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -623,7 +623,26 @@ function M.merge_pr(pr_number)
   }):start()
 end
 
+--- Formats a integer a large integer by taking the most significant digits with a suffix.
+--- e.g. 123456789 -> 12.3m
+---@param n integer
+---@param is_capitalized boolean
+function M.format_large_int(n, is_capitalized)
+  if n < 1000 then
+    return tostring(n)
+  end
+  local suffixes = is_capitalized and { "K", "M", "B", "T" } or { "k", "m", "b", "t" }
+  local i = 0
+  while n >= 1000 do
+    i = i + 1
+    n = n / 1000
+  end
+  return string.format("%.1f%s", n, suffixes[i])
+end
+
 ---Formats a string as a date
+---@param date_string string
+---@return string
 function M.format_date(date_string)
   if date_string == nil then
     return ""
@@ -920,6 +939,11 @@ function M.parse_url(url)
     return repo, number, kind
   elseif repo and number and kind == "discussions" then
     return repo, number, "discussion"
+  elseif not repo then
+    repo, kind, number = string.match(url, constants.URL_RELEASE_PATTERN)
+    if repo and number and kind == "releases" then
+      return repo, number, "release"
+    end
   end
 end
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Renders releases with the format `octo://<owner>/<repo>/release/<tag>`. This will be used for notifications to have something to preview and look at.

There is decent room for improvement here, but wanted to get a start here an incrementally improve it.

### Does this pull request fix one issue?

NONE

### Describe how you did it

Writing to the buffer was fairly standard, though writing the `Pre-release` and `Latest` title virtual text is not using the `write_status` util, but rather more one-off.
Some slight changes to how we parse the `octo://` uri so that releases can be re-used here. In that previously only numbers we allowed for that last part of the uri, but now it's alphanumeric + numbers. This might not be comprehensive, but it was enough for my uses.

### Describe how to verify it

`:e octo://neovim/neovim/release/nightly`

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
  - Need to add more features here before adding to documentation
