### PR TITLE
Adds a branch name as title for PR config

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,12 @@ require"octo".setup({
     },
   },
   pull_requests = {
-    order_by = {                           -- criteria to sort the results of `Octo pr list`
-      field = "CREATED_AT",                -- either COMMENTS, CREATED_AT or UPDATED_AT (https://docs.github.com/en/graphql/reference/enums#issueorderfield)
-      direction = "DESC"                   -- either DESC or ASC (https://docs.github.com/en/graphql/reference/enums#orderdirection)
+    order_by = {                            -- criteria to sort the results of `Octo pr list`
+      field = "CREATED_AT",                 -- either COMMENTS, CREATED_AT or UPDATED_AT (https://docs.github.com/en/graphql/reference/enums#issueorderfield)
+      direction = "DESC"                    -- either DESC or ASC (https://docs.github.com/en/graphql/reference/enums#orderdirection)
     },
-    always_select_remote_on_create = false -- always give prompt to select base remote repo when creating PRs
+    always_select_remote_on_create = false, -- always give prompt to select base remote repo when creating PRs
+    use_branch_name_as_title = false        -- sets branch name to be the name for the PR
   },
   notifications = {
     current_repo_only = false,             -- show notifications for current repo only

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -967,14 +967,14 @@ function M.add_pr_issue_or_review_thread_comment()
     viewerCanDelete = true,
     viewerDidAuthor = true,
     reactionGroups = {
-      { content = "THUMBS_UP", users = { totalCount = 0 } },
+      { content = "THUMBS_UP",   users = { totalCount = 0 } },
       { content = "THUMBS_DOWN", users = { totalCount = 0 } },
-      { content = "LAUGH", users = { totalCount = 0 } },
-      { content = "HOORAY", users = { totalCount = 0 } },
-      { content = "CONFUSED", users = { totalCount = 0 } },
-      { content = "HEART", users = { totalCount = 0 } },
-      { content = "ROCKET", users = { totalCount = 0 } },
-      { content = "EYES", users = { totalCount = 0 } },
+      { content = "LAUGH",       users = { totalCount = 0 } },
+      { content = "HOORAY",      users = { totalCount = 0 } },
+      { content = "CONFUSED",    users = { totalCount = 0 } },
+      { content = "HEART",       users = { totalCount = 0 } },
+      { content = "ROCKET",      users = { totalCount = 0 } },
+      { content = "EYES",        users = { totalCount = 0 } },
     },
   }
 
@@ -1012,7 +1012,7 @@ function M.add_pr_issue_or_review_thread_comment()
     local comment_under_cursor = buffer:get_comment_at_cursor()
     if not utils.is_blank(comment_under_cursor) and vim.fn.confirm("Reply to comment?", "&Yes\n&No", 2) == 1 then
       comment.replyTo = not utils.is_blank(comment_under_cursor.replyTo) and comment_under_cursor.replyTo.id
-        or comment_under_cursor.id
+          or comment_under_cursor.id
       vim.api.nvim_buf_set_lines(
         buffer.bufnr,
         comment_under_cursor.bufferEndLine,
@@ -1441,12 +1441,12 @@ function M.create_pr(is_draft)
 
   -- get remote branches
   if
-    info == nil
-    or info.refs == nil
-    or info.refs.nodes == nil
-    or info == vim.NIL
-    or info.refs == vim.NIL
-    or info.refs.nodes == vim.NIL
+      info == nil
+      or info.refs == nil
+      or info.refs.nodes == nil
+      or info == vim.NIL
+      or info.refs == vim.NIL
+      or info.refs.nodes == vim.NIL
   then
     utils.error "Cannot grab remote branches"
     return
@@ -1462,7 +1462,7 @@ function M.create_pr(is_draft)
   local remote_branch = local_branch
   if not remote_branch_exists then
     local choice =
-      vim.fn.confirm("Remote branch '" .. local_branch .. "' does not exist. Push local one?", "&Yes\n&No\n&Cancel", 2)
+        vim.fn.confirm("Remote branch '" .. local_branch .. "' does not exist. Push local one?", "&Yes\n&No\n&Cancel", 2)
     if choice == 1 then
       local remote = "origin"
       remote_branch = vim.fn.input {
@@ -1520,12 +1520,17 @@ function M.save_pr(opts)
     repo_idx = vim.fn.inputlist(opts.candidate_entries)
   end
 
+  local conf = config.values
+  local use_branch_name_as_title = conf.pull_requests.use_branch_name_as_title or false
   -- title and body
   local title, body
   local last_commit = string.gsub(vim.fn.system "git log -1 --pretty=%B", "%s+$", "")
   local last_commit_lines = vim.split(last_commit, "\n")
   if #last_commit_lines >= 1 then
     title = last_commit_lines[1]
+  end
+  if use_branch_name_as_title then
+    title = opts.remote_branch
   end
   if #last_commit_lines > 1 then
     if utils.is_blank(last_commit_lines[2]) and #last_commit_lines > 2 then
@@ -2336,12 +2341,12 @@ function M.pin_issue(opts)
         error = "pin",
         success = "Pinned",
       }
-    or {
-      query = mutations.unpin_issue,
-      jq = ".data.unpinIssue.issue.id",
-      error = "unpin",
-      success = "Unpinned",
-    }
+      or {
+        query = mutations.unpin_issue,
+        jq = ".data.unpinIssue.issue.id",
+        error = "unpin",
+        success = "Unpinned",
+      }
   gh.api.graphql {
     query = query_info.query,
     F = { issue_id = opts.obj.id },

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -967,14 +967,14 @@ function M.add_pr_issue_or_review_thread_comment()
     viewerCanDelete = true,
     viewerDidAuthor = true,
     reactionGroups = {
-      { content = "THUMBS_UP",   users = { totalCount = 0 } },
+      { content = "THUMBS_UP", users = { totalCount = 0 } },
       { content = "THUMBS_DOWN", users = { totalCount = 0 } },
-      { content = "LAUGH",       users = { totalCount = 0 } },
-      { content = "HOORAY",      users = { totalCount = 0 } },
-      { content = "CONFUSED",    users = { totalCount = 0 } },
-      { content = "HEART",       users = { totalCount = 0 } },
-      { content = "ROCKET",      users = { totalCount = 0 } },
-      { content = "EYES",        users = { totalCount = 0 } },
+      { content = "LAUGH", users = { totalCount = 0 } },
+      { content = "HOORAY", users = { totalCount = 0 } },
+      { content = "CONFUSED", users = { totalCount = 0 } },
+      { content = "HEART", users = { totalCount = 0 } },
+      { content = "ROCKET", users = { totalCount = 0 } },
+      { content = "EYES", users = { totalCount = 0 } },
     },
   }
 
@@ -1012,7 +1012,7 @@ function M.add_pr_issue_or_review_thread_comment()
     local comment_under_cursor = buffer:get_comment_at_cursor()
     if not utils.is_blank(comment_under_cursor) and vim.fn.confirm("Reply to comment?", "&Yes\n&No", 2) == 1 then
       comment.replyTo = not utils.is_blank(comment_under_cursor.replyTo) and comment_under_cursor.replyTo.id
-          or comment_under_cursor.id
+        or comment_under_cursor.id
       vim.api.nvim_buf_set_lines(
         buffer.bufnr,
         comment_under_cursor.bufferEndLine,
@@ -1441,12 +1441,12 @@ function M.create_pr(is_draft)
 
   -- get remote branches
   if
-      info == nil
-      or info.refs == nil
-      or info.refs.nodes == nil
-      or info == vim.NIL
-      or info.refs == vim.NIL
-      or info.refs.nodes == vim.NIL
+    info == nil
+    or info.refs == nil
+    or info.refs.nodes == nil
+    or info == vim.NIL
+    or info.refs == vim.NIL
+    or info.refs.nodes == vim.NIL
   then
     utils.error "Cannot grab remote branches"
     return
@@ -1462,7 +1462,7 @@ function M.create_pr(is_draft)
   local remote_branch = local_branch
   if not remote_branch_exists then
     local choice =
-        vim.fn.confirm("Remote branch '" .. local_branch .. "' does not exist. Push local one?", "&Yes\n&No\n&Cancel", 2)
+      vim.fn.confirm("Remote branch '" .. local_branch .. "' does not exist. Push local one?", "&Yes\n&No\n&Cancel", 2)
     if choice == 1 then
       local remote = "origin"
       remote_branch = vim.fn.input {
@@ -2341,12 +2341,12 @@ function M.pin_issue(opts)
         error = "pin",
         success = "Pinned",
       }
-      or {
-        query = mutations.unpin_issue,
-        jq = ".data.unpinIssue.issue.id",
-        error = "unpin",
-        success = "Unpinned",
-      }
+    or {
+      query = mutations.unpin_issue,
+      jq = ".data.unpinIssue.issue.id",
+      error = "unpin",
+      success = "Unpinned",
+    }
   gh.api.graphql {
     query = query_info.query,
     F = { issue_id = opts.obj.id },

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -91,6 +91,7 @@ local M = {}
 ---@class OctoConfigPR
 ---@field order_by OctoConfigOrderBy
 ---@field always_select_remote_on_create boolean
+---@field use_branch_name_as_title boolean
 
 ---@class OctoConfigOrderBy
 ---@field field string
@@ -256,6 +257,7 @@ function M.get_default_values()
         direction = "DESC",
       },
       always_select_remote_on_create = false,
+      use_branch_name_as_title = false,
     },
     file_panel = {
       size = 10,
@@ -586,6 +588,7 @@ function M.validate_config()
       validate_type(config.pull_requests.order_by.direction, "pull_requests.order_by.direction", "string")
     end
     validate_type(config.pull_requests.always_select_remote_on_create, "always_select_remote_on_create", "boolean")
+    validate_type(config.pull_requests.use_branch_name_as_title, "use_branch_name_as_title", "boolean")
   end
 
   local function validate_notifications()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
It's intended to make easy to create prs with the title equal to the local branch name.

### Does this pull request fix one issue?

#### No
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
I created the var to the config, and into the save_pr command, i used it to check if it's true, in case of been, i replaced the title variable with the remote_branch var, that cames from the create_pr call.

### Describe how to verify it
Set the var to be true on the config, and then run the `:Octo pr create`, one should see the title as the current branch name.

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
