### PR TITLE
fix(pull request): do not show comment code block when empty

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -898,7 +898,7 @@ function M.write_thread_snippet(bufnr, diffhunk, start_line, comment_start, comm
   -- since the diff hunk always use the original positions.
 
   start_line = start_line or vim.api.nvim_buf_line_count(bufnr) + 1
-  if not diffhunk then
+  if not diffhunk or diffhunk == "" then
     return start_line, start_line
   end
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Adding a file comment still shows the thread snippet because the diffHunk ends up being an empty string. We don't handle this case since we end up showing an empty box with a bunch of new lines.

### Describe how to verify it

Add a file comment to a PR and view it in octo.

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
