### PR TITLE
feat: open release from notification

### DIFF
--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -762,6 +762,8 @@ function M.gen_from_notification(opts)
         return "pull_request"
       elseif type == "Discussion" then
         return "discussion"
+      elseif type == "Release" then
+        return "release"
       end
       return "unknown"
     end)(notification.subject.type)

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -78,7 +78,22 @@ local function open(command)
       vim.cmd [[:tab sb %]]
     end
     if selection then
-      utils.get(selection.kind, selection.value, selection.repo)
+      if selection.kind ~= "release" then
+        utils.get(selection.kind, selection.value, selection.repo)
+      else
+        if selection.tag_name then
+          utils.get("release", selection.tag_name, selection.repo)
+        else
+          ---@type string, string
+          local owner, repo = selection.repo:match "(.*)/(.*)"
+          require("octo.release").get_tag_from_release_id(
+            { owner = owner, repo = repo, release_id = selection.value },
+            function(tag_name)
+              utils.get("release", tag_name, selection.repo)
+            end
+          )
+        end
+      end
     end
   end
 end

--- a/lua/octo/release.lua
+++ b/lua/octo/release.lua
@@ -1,0 +1,23 @@
+local gh = require "octo.gh"
+local M = {}
+
+---GraphQL only accepts tag names as a filter, and this helps with the conversion.
+---@param info {owner: string, repo: string, release_id: string}
+---@param on_success fun(tag_name: string): nil
+function M.get_tag_from_release_id(info, on_success)
+  local owner, name, number = info.owner, info.repo, info.release_id
+  gh.api.get {
+    "/repos/{owner}/{repo}/releases/{release_id}",
+    format = { owner = owner, repo = name, release_id = number },
+    jq = ".tag_name",
+    opts = {
+      cb = gh.create_callback {
+        success = function(tag_name)
+          on_success(tag_name)
+        end,
+      },
+    },
+  }
+end
+
+return M


### PR DESCRIPTION
### Describe what this PR does / why we need it

Allows viewing releases in the telescope notifications picker. I still need alternative UI to clear releases from my notifications, and this allows me to use octo for that.

### Describe how you did it

There is a decent amount of special casing to allow for this. For one, the notification URL for the release gives the release ID, which from my investigation, was not query-able with the graphql API. Thus, I created a helper that converts the release ID to the tag name. I used this to be able to open the release buffer, which is the same one I use for the preview. I also had to change the selection logic to do this conversion to open up the buffer unless it was already done and cached already by rendering the notification preview.

### Describe how to verify it

This is a bit hard to verify. It's been working in my fork for a while (which admittedly has other modifications). I would guess this would need to be tested by either waiting for a release to pop up in notifications or trigger it oneself by creating a repo, subscribing to it, and then releasing.

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
  - none needed (no config, keymap or command changes)
