### PR TITLE
fix: fzflua empty initial results

### DIFF
--- a/lua/octo/pickers/fzf-lua/pickers/search.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/search.lua
@@ -87,6 +87,7 @@ return function(opts)
   -- TODO this is still not as fast as I would like.
   fzf.fzf_live(contents, {
     prompt = picker_utils.get_prompt(opts.prompt_title),
+    exec_empty_query = true,
     func_async_callback = false,
     previewer = previewers.search(),
     query_delay = 500,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

- Adds `exec_empty_query = true` to the `fzf_live` call to make the initial request when the query is empty.
- This was preventing the search provider to show results before typing in a character.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes https://github.com/pwntester/octo.nvim/issues/1097

### Describe how you did it

- Added missing important parameter to `fzf_live` function call.

### Describe how to verify it

1. Set up fzf-lua as your picker.
2. Run `:Octo pr search is:open`
3. Should show results right away if there are open PRs.

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
