### PR TITLE
start in normal mode at the beginning of the file

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1604,8 +1604,6 @@ function M.save_pr(opts)
           local pr = resp.data.createPullRequest.pullRequest
           utils.info(string.format("#%d - `%s` created successfully", pr.number, pr.title))
           require("octo").create_buffer("pull", pr, opts.repo, true)
-          vim.fn.execute "normal! Gk"
-          vim.fn.execute "startinsert"
         end
       end,
     }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

1. Start in normal mode after PR creation.
2. Start at the beginning of the file after PR creation.

I noticed that after PR creation the plugin takes you to the end of the file and starts in insert mode.
In my experience and talking with other devs, most of the times PRs have a template and even if it doesn't, there is some PR data at the top of the file. First thing you do in the current state after landing at the end of the file in insert mode is press `<Esc>` to go to normal mode and navigate to where you want to start editing the PR description, most often near the beginning of the file.

This can be taken as a personal preference perhaps, but I find that it's better to land at the beginning of the file where the PR summary is (author, title, labels, status, etc) than at the end of the file where, if the template is long, you can't even see the summary. Also to start in normal mode so we're able to navigate right away rather than pressing `<Esc>` first to navigate to where I want to start editing the PR.

If this is not a change the owners would want to accept I would suggest that I can also add a prop to change this behavior via config rather than having all the same behavior. I'm open to suggestions and feedback.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

Removing the 2 lines that takes you to the end of the file and starts insert mode after PR creation:

```lua
          vim.fn.execute "normal! Gk"
          vim.fn.execute "startinsert"
```

### Describe how to verify it

1. Create a PR using `:Octo pr create`.
3. You should start in normal mode at the beginning of the file.

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
