### PR TITLE
add missing colors in the enum

### DIFF
--- a/lua/octo/ui/bubbles.lua
+++ b/lua/octo/ui/bubbles.lua
@@ -60,10 +60,17 @@ local function make_reaction_bubble(icon, includes_viewer, opts)
   return make_bubble(content, highlight, opts)
 end
 
+--- Enum values found here:
+--- https://docs.github.com/en/graphql/reference/enums#issuetypecolor
 local color_lookup = {
-  BLUE = "4493f8",
-  YELLOW = "d19821",
-  RED = "f75149",
+  GRAY = "3C444D",
+  BLUE = "4493F8",
+  GREEN = "3FB950",
+  YELLOW = "D19821",
+  ORANGE = "DB6D28",
+  RED = "F75149",
+  PINK = "DB61A2",
+  PURPLE = "AB7DF8",
 }
 
 local function make_label_bubble(name, color, opts)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Adds in the missing colors in the type enum

CC: @PeterCardenas 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Closes #1100

### Describe how you did it

Add all of the colors here: 

https://docs.github.com/en/graphql/reference/enums#issuetypecolor

### Describe how to verify it

octo://ghostty-org/ghostty/issue/7557
octo://ghostty-org/ghostty/issue/7591

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
