### PR TITLE
feat(fzf-lua): add notifications picker

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -133,7 +133,7 @@ end
 
 ---@class RunOpts
 ---@field args table
----@field mode string
+---@field mode string "async"|"sync"
 ---@field cb fun(stdout: string, stderr: string)
 ---@field stream_cb fun(stdout: string, stderr: string)
 ---@field headers table
@@ -142,7 +142,8 @@ end
 
 ---Run a gh command
 ---@param opts RunOpts
----@return string[]|nil
+---@return string? stdout
+---@return string? stderr
 local function run(opts)
   if not Job then
     return
@@ -324,8 +325,10 @@ end
 --- The gh.api commands
 M.api = {}
 
+---@class (partial) octo.PartialRunOpts: RunOpts
+
 ---Run a graphql query
----@param opts table the options for the graphql query
+---@param opts {opts: octo.PartialRunOpts} the options for the graphql query
 ---@return table|nil
 function M.api.graphql(opts)
   opts = opts or {}
@@ -389,6 +392,8 @@ function M.create_rest_args(method, opts)
 end
 
 ---Run a rest command
+---@param method "GET"|"POST"|"PATCH"|"DELETE"|"PUT"
+---@param opts {opts: octo.PartialRunOpts}
 local function rest(method, opts)
   local run_opts = opts.opts or {}
 
@@ -410,6 +415,7 @@ local function rest(method, opts)
   }
 end
 
+---@param opts {opts: octo.PartialRunOpts}
 function M.api.get(opts)
   return rest("GET", opts)
 end

--- a/lua/octo/notifications.lua
+++ b/lua/octo/notifications.lua
@@ -1,0 +1,132 @@
+local gh = require "octo.gh"
+local graphql = require "octo.gh.graphql"
+local utils = require "octo.utils"
+local writers = require "octo.ui.writers"
+local queries = require "octo.gh.queries"
+local release = require "octo.release"
+
+local M = {}
+
+---@param thread_id string
+function M.request_read_notification(thread_id)
+  gh.api.patch {
+    "/notifications/threads/{id}",
+    format = { id = thread_id },
+    opts = {
+      cb = gh.create_callback { success = function() end },
+      headers = { "Accept: application/vnd.github+json" },
+    },
+  }
+end
+
+---@param thread_id string
+function M.delete_notification(thread_id)
+  local opts = {
+    cb = gh.create_callback { success = function() end },
+    headers = { "Accept: application/vnd.github.v3.diff" },
+  }
+  gh.api.delete {
+    "/notifications/threads/{id}",
+    format = { id = thread_id },
+    opts = opts,
+  }
+end
+
+---@param thread_id string
+function M.unsubscribe_notification(thread_id)
+  gh.api.delete {
+    "/notifications/threads/{id}/subscription",
+    format = { id = thread_id },
+    opts = {
+      cb = gh.create_callback {
+        success = function()
+          M.request_read_notification(thread_id)
+        end,
+      },
+      headers = { "Accept: application/vnd.github+json" },
+    },
+  }
+end
+
+---@param notification octo.NotificationFromREST
+function M.copy_notification_url(notification)
+  local subject = notification.subject
+  local url = not utils.is_blank(subject.latest_comment_url) and subject.latest_comment_url or subject.url
+
+  gh.api.get {
+    url,
+    jq = ".html_url",
+    opts = {
+      cb = gh.create_callback { success = utils.copy_url },
+    },
+  }
+end
+
+---@param bufnr integer
+---@param owner string
+---@param name string
+---@param number string
+---@param kind string
+function M.populate_preview_buf(bufnr, owner, name, number, kind)
+  ---@param query string
+  ---@param fields table<string, string>
+  ---@param jq string
+  ---@param preview fun(obj: any, bufnr: integer): nil
+  local function fetch_and_preview(query, fields, jq, preview)
+    gh.api.graphql {
+      query = query,
+      fields = fields,
+      jq = jq,
+      opts = {
+        cb = gh.create_callback {
+          failure = vim.api.nvim_err_writeln,
+          success = function(output)
+            if not vim.api.nvim_buf_is_loaded(bufnr) then
+              return
+            end
+
+            local ok, obj = pcall(vim.json.decode, output)
+            if not ok then
+              utils.error("Failed to parse preview data: " .. vim.inspect(output))
+              return
+            end
+
+            preview(obj, bufnr)
+          end,
+        },
+      },
+    }
+  end
+  ---@type string, table<string, string>, string, fun(obj: any, bufnr: integer): nil
+  local query, fields, jq, preview
+
+  if kind == "issue" then
+    query = graphql("issue_query", owner, name, number, _G.octo_pv2_fragment)
+    fields = {}
+    jq = ".data.repository.issue"
+    preview = writers.issue_preview
+  elseif kind == "pull_request" then
+    query = graphql("pull_request_query", owner, name, number, _G.octo_pv2_fragment)
+    fields = {}
+    jq = ".data.repository.pullRequest"
+    preview = writers.issue_preview
+  elseif kind == "discussion" then
+    query = queries.discussion
+    fields = { owner = owner, name = name, number = number }
+    jq = ".data.repository.discussion"
+    preview = writers.discussion_preview
+  elseif kind == "release" then
+    -- GraphQL only accepts tags and release notifications give back IDs
+    release.get_tag_from_release_id({ owner = owner, repo = name, release_id = number }, function(tag_name)
+      query = queries.release
+      fields = { owner = owner, name = name, tag = tag_name }
+      jq = ".data.repository.release"
+      preview = writers.release_preview
+      fetch_and_preview(query, fields, jq, preview)
+    end)
+    return
+  end
+  fetch_and_preview(query, fields, jq, preview)
+end
+
+return M

--- a/lua/octo/pickers/fzf-lua/pickers/notifications.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/notifications.lua
@@ -1,0 +1,128 @@
+local fzf = require "fzf-lua"
+local fzf_actions = require "octo.pickers.fzf-lua.pickers.fzf_actions"
+local octo_config = require "octo.config"
+local entry_maker = require "octo.pickers.fzf-lua.entry_maker"
+local utils = require "octo.utils"
+local gh = require "octo.gh"
+local previewers = require "octo.pickers.fzf-lua.previewers"
+local picker_utils = require "octo.pickers.fzf-lua.pickers.utils"
+local notifications = require "octo.notifications"
+
+---@param formatted_notifications octo.NotificationEntry[]
+---@return fun(selected: [string]): nil
+local function mark_notification_read(formatted_notifications)
+  return function(selected)
+    local notification_entry = formatted_notifications[selected[1]]
+    notifications.request_read_notification(notification_entry.thread_id)
+  end
+end
+
+---@param formatted_notifications octo.NotificationEntry[]
+---@return fun(selected: [string]): nil
+local function mark_notification_done(formatted_notifications)
+  return function(selected)
+    local notification_entry = formatted_notifications[selected[1]]
+    notifications.delete_notification(notification_entry.thread_id)
+  end
+end
+
+---@param formatted_notifications octo.NotificationEntry[]
+---@return fun(selected: [string]): nil
+local function unsubscribe_notification(formatted_notifications)
+  return function(selected)
+    local notification_entry = formatted_notifications[selected[1]]
+    notifications.unsubscribe_notification(notification_entry.thread_id)
+  end
+end
+
+---@param opts {
+---  prompt_title: string,
+---  results_title: string,
+---  window_title: string,
+---  all: boolean,
+---}
+return function(opts)
+  opts = opts or {}
+  local formatted_notifications = {} ---@type table<string, octo.NotificationEntry> entry.ordinal -> entry
+
+  local function get_contents(fzf_cb)
+    gh.api.get {
+      "/notifications",
+      paginate = true,
+      F = {
+        all = opts.all,
+      },
+      opts = {
+        headers = { "Accept: application/vnd.github.v3.diff" },
+        stream_cb = function(data, err)
+          if err and not utils.is_blank(err) then
+            utils.error(err)
+            fzf_cb()
+          elseif data then
+            ---@type octo.NotificationFromREST[]
+            local resp = vim.json.decode(data)
+            for _, notification in ipairs(resp) do
+              local entry = entry_maker.gen_from_notification(notification)
+              if entry ~= nil then
+                local icons = utils.icons
+                local unread_icon = entry.obj.unread == true and icons.notification[entry.kind].unread
+                  or icons.notification[entry.kind].read
+                local unread_text = fzf.utils.ansi_from_hl(unread_icon[2], unread_icon[1]) ---@type string
+                local id_text = "#" .. (entry.obj.subject.url:match "/(%d+)$" or "NA") ---@type string
+                local repo_text = fzf.utils.ansi_from_hl("Number", entry.obj.repository.full_name) ---@type string
+                local content = table.concat({ unread_text, id_text, repo_text, entry.obj.subject.title }, " ")
+                local entry_id = table.concat(
+                  { unread_icon[1], id_text, entry.obj.repository.full_name, entry.obj.subject.title },
+                  " "
+                )
+                formatted_notifications[entry_id] = entry
+                fzf_cb(content)
+              end
+            end
+          end
+        end,
+        cb = function()
+          fzf_cb()
+        end,
+      },
+    }
+  end
+
+  local cfg = octo_config.values
+  ---@type table<string, function|table>
+  local notification_actions = fzf_actions.common_buffer_actions(formatted_notifications)
+  notification_actions[utils.convert_vim_mapping_to_fzf(cfg.picker_config.mappings.copy_url.lhs)] = {
+    fn = function(selected)
+      notifications.copy_notification_url(formatted_notifications[selected[1]].obj)
+    end,
+    reload = true,
+  }
+  if not cfg.mappings.notification.read.lhs:match "leader>" then
+    notification_actions[utils.convert_vim_mapping_to_fzf(cfg.mappings.notification.read.lhs)] =
+      { fn = mark_notification_read(formatted_notifications), reload = true }
+  end
+  if not cfg.mappings.notification.done.lhs:match "leader>" then
+    notification_actions[utils.convert_vim_mapping_to_fzf(cfg.mappings.notification.done.lhs)] =
+      { fn = mark_notification_done(formatted_notifications), reload = true }
+  end
+  if not cfg.mappings.notification.unsubscribe.lhs:match "leader>" then
+    notification_actions[utils.convert_vim_mapping_to_fzf(cfg.mappings.notification.unsubscribe.lhs)] =
+      { fn = unsubscribe_notification(formatted_notifications), reload = true }
+  end
+
+  fzf.fzf_exec(get_contents, {
+    prompt = picker_utils.get_prompt(opts.prompt_title),
+    previewer = previewers.notifications(formatted_notifications),
+    fzf_opts = {
+      ["--no-multi"] = "", -- TODO this can support multi, probably
+      ["--header"] = opts.results_title,
+      ["--info"] = "default",
+    },
+    winopts = {
+      title = opts.window_title or "Notifications",
+      title_pos = "center",
+    },
+    actions = notification_actions,
+    silent = true,
+  })
+end

--- a/lua/octo/pickers/fzf-lua/previewers.lua
+++ b/lua/octo/pickers/fzf-lua/previewers.lua
@@ -1,4 +1,5 @@
 local OctoBuffer = require("octo.model.octo-buffer").OctoBuffer
+local notifications = require "octo.notifications"
 local builtin = require "fzf-lua.previewer.builtin"
 local gh = require "octo.gh"
 local graphql = require "octo.gh.graphql"
@@ -365,6 +366,32 @@ function M.issue_template(formatted_templates)
       vim.api.nvim_buf_set_option(tmpbuf, "filetype", "markdown")
     end
 
+    self:set_preview_buf(tmpbuf)
+    self:update_border(entry.value)
+    self.win:update_preview_scrollbar()
+  end
+
+  return previewer
+end
+
+---@param formatted_notifications table<string, octo.NotificationEntry>
+---@return fzf-lua.previewer.BufferOrFile
+function M.notifications(formatted_notifications)
+  local previewer = M.bufferPreviewer:extend() ---@type fzf-lua.previewer.BufferOrFile
+
+  function previewer:new(o, opts, fzf_win)
+    M.bufferPreviewer.super.new(self, o, opts, fzf_win)
+    setmetatable(self, previewer)
+    return self
+  end
+
+  function previewer:populate_preview_buf(entry_str)
+    local tmpbuf = self:get_tmp_buffer() ---@type integer
+    local entry = formatted_notifications[entry_str]
+    local number = entry.value ---@type string
+    local owner, name = utils.split_repo(entry.repo)
+
+    notifications.populate_preview_buf(tmpbuf, owner, name, number, entry.kind)
     self:set_preview_buf(tmpbuf)
     self:update_border(entry.value)
     self.win:update_preview_scrollbar()

--- a/lua/octo/pickers/fzf-lua/provider.lua
+++ b/lua/octo/pickers/fzf-lua/provider.lua
@@ -27,7 +27,7 @@ M.picker = {
   review_commits = require "octo.pickers.fzf-lua.pickers.review_commits",
   search = require "octo.pickers.fzf-lua.pickers.search",
   users = require "octo.pickers.fzf-lua.pickers.users",
-  notifications = M.not_implemented,
+  notifications = require "octo.pickers.fzf-lua.pickers.notifications",
   milestones = M.not_implemented,
   workflow_runs = M.not_implemented,
 }

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -79,22 +79,7 @@ local function open(command)
       vim.cmd [[:tab sb %]]
     end
     if selection then
-      if selection.kind ~= "release" then
-        utils.get(selection.kind, selection.value, selection.repo)
-      else
-        if selection.tag_name then
-          utils.get("release", selection.tag_name, selection.repo)
-        else
-          ---@type string, string
-          local owner, repo = selection.repo:match "(.*)/(.*)"
-          require("octo.release").get_tag_from_release_id(
-            { owner = owner, repo = repo, release_id = selection.value },
-            function(tag_name)
-              utils.get("release", tag_name, selection.repo)
-            end
-          )
-        end
-      end
+      utils.get(selection.kind, selection.value, selection.repo)
     end
   end
 end

--- a/lua/octo/release.lua
+++ b/lua/octo/release.lua
@@ -3,21 +3,26 @@ local M = {}
 
 ---GraphQL only accepts tag names as a filter, and this helps with the conversion.
 ---@param info {owner: string, repo: string, release_id: string}
----@param on_success fun(tag_name: string): nil
+---@param on_success? fun(tag_name: string): nil Do not provide if synchronous
+---@return string|nil
 function M.get_tag_from_release_id(info, on_success)
   local owner, name, number = info.owner, info.repo, info.release_id
-  gh.api.get {
+  local mode = on_success and "async" or "sync"
+  local output = gh.api.get {
     "/repos/{owner}/{repo}/releases/{release_id}",
     format = { owner = owner, repo = name, release_id = number },
     jq = ".tag_name",
     opts = {
+      mode = mode,
       cb = gh.create_callback {
         success = function(tag_name)
+          assert(on_success, "on_success should be defined")
           on_success(tag_name)
         end,
       },
     },
   }
+  return output
 end
 
 return M

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -2484,4 +2484,45 @@ function M.write_virtual_text(bufnr, ns, line, chunks, mode)
   end
 end
 
+---@param obj any
+---@param bufnr integer
+function M.discussion_preview(obj, bufnr)
+  -- clear the buffer
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
+
+  local state = obj.closed and "CLOSED" or "OPEN"
+  M.write_title(bufnr, tostring(obj.title), 1)
+  M.write_state(bufnr, state, obj.number)
+  M.write_discussion_details(bufnr, obj)
+  M.write_body(bufnr, obj, 13)
+
+  if obj.answer ~= vim.NIL then
+    local line = vim.api.nvim_buf_line_count(bufnr) + 1
+    M.write_discussion_answer(bufnr, obj, line)
+  end
+
+  vim.bo[bufnr].filetype = "octo"
+end
+
+---@param obj any
+---@param bufnr integer
+function M.issue_preview(obj, bufnr)
+  local state = utils.get_displayed_state(obj.__typename == "Issue", obj.state, obj.stateReason)
+  M.write_title(bufnr, obj.title, 1)
+  M.write_details(bufnr, obj)
+  M.write_body(bufnr, obj)
+  M.write_state(bufnr, state:upper(), obj.number)
+  local reactions_line = vim.api.nvim_buf_line_count(bufnr) - 1
+  M.write_block(bufnr, { "", "" }, reactions_line)
+  M.write_reactions(bufnr, obj.reactionGroups, reactions_line)
+  vim.bo[bufnr].filetype = "octo"
+end
+
+---@param obj octo.Release
+---@param bufnr integer
+function M.release_preview(obj, bufnr)
+  M.write_release(bufnr, obj)
+  vim.bo[bufnr].filetype = "octo"
+end
+
 return M

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -4,6 +4,7 @@ local gh = require "octo.gh"
 local graphql = require "octo.gh.graphql"
 local queries = require "octo.gh.queries"
 local _, Job = pcall(require, "plenary.job")
+local release = require "octo.release"
 local vim = vim
 
 local M = {}
@@ -848,10 +849,7 @@ function M.escape_char(string)
 end
 
 --- Gets the repo and id from args.
----@param args { n: integer }|string[]
----@param is_number boolean
----@return string? repo
----@return integer|string? id
+---@type (fun(args: {n: integer}|string[], is_number: true): string?, integer?)|(fun(args: {n: integer}|string[], is_number: false): string?, string?)
 local function get_repo_id_from_args(args, is_number)
   local repo, id ---@type string|nil, string|integer|nil
   if args.n == 0 then
@@ -890,9 +888,7 @@ end
 ---@return integer? number
 function M.get_repo_number_from_varargs(...)
   local args = table.pack(...)
-  local repo, number = get_repo_id_from_args(args, true)
-  number = number --[[@as integer?]]
-  return repo, number
+  return get_repo_id_from_args(args, true)
 end
 
 --- Get the URI for a repository
@@ -920,8 +916,13 @@ end
 
 function M.get_release_uri(...)
   local args = table.pack(...)
-  local repo, tag_name = get_repo_id_from_args(args, false)
-
+  local repo, tag_name_or_id = get_repo_id_from_args(args, false)
+  local release_id = tonumber(tag_name_or_id)
+  if not release_id then
+    return string.format("octo://%s/release/%s", repo, tag_name_or_id)
+  end
+  local owner, name = M.split_repo(repo)
+  local tag_name = release.get_tag_from_release_id { owner = owner, repo = name, release_id = tostring(release_id) }
   return string.format("octo://%s/release/%s", repo, tag_name)
 end
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Refactors the telescope notifications picker to share logic with the newly created fzf-lua notifcations picker. I simplified the logic for opening a release notification by always resolving the release id to the tag name instead of caching the tag name when opening the preview.

### Does this pull request fix one issue?

didn't find any

### Describe how to verify it

use config
```lua
{
  picker = "fzf-lua"
}
```

then command `Octo notification list`

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
