### PR TITLE
fix: properly handle white space user cmd completion

### DIFF
--- a/lua/octo/completion/init.lua
+++ b/lua/octo/completion/init.lua
@@ -2,16 +2,21 @@ local M = {}
 local vim = vim
 local utils = require "octo.utils"
 
+---@param argLead string
+---@param cmdLine string
+---@return string[]
 function M.octo_command_complete(argLead, cmdLine)
   -- ArgLead		the leading portion of the argument currently being completed on
   -- CmdLine		the entire command line
   -- CursorPos	the cursor position in it (byte index)
   local octo_commands = require "octo.commands"
   local command_keys = vim.tbl_keys(octo_commands.commands)
-  local parts = vim.split(vim.trim(cmdLine), " ")
+  local parts = vim.split(cmdLine:match "[^%s].*$", "%s+")
 
+  ---@param options string[]
+  ---@return string[]
   local function get_options(options)
-    local valid_options = {}
+    local valid_options = {} ---@type string[]
     for _, option in pairs(options) do
       if string.sub(option, 1, #argLead) == argLead then
         table.insert(valid_options, option)


### PR DESCRIPTION
### Describe what this PR does / why we need it

The last argument of user commands gets duplicated. For example if you type `Oct notifications list `, I get `list` as a completion item. This PR fixes that and also handles the case where there's multiple spaces between arguments.

### Does this pull request fix one issue?

doesn't really address it, but we can probably close #347

### Describe how to verify it

`Octo notifications list ` completes nothing
`Octo  notifications ` completes `list`

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
