### PR TITLE
fix: allow specifying repo flag

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -960,6 +960,10 @@ function M.process_varargs(repo, ...)
   local args = table.pack(...)
   if utils.is_blank(repo) then
     repo = utils.get_remote_name()
+  elseif string.find(repo, ":") or string.find(repo, "=") then
+    args.n = args.n + 1
+    table.insert(args, 1, repo)
+    repo = utils.get_remote_name()
   elseif #vim.split(repo, "/") ~= 2 then
     table.insert(args, repo)
     args.n = args.n + 1
@@ -977,7 +981,9 @@ function M.process_varargs(repo, ...)
       end
     end
   end
-  opts.repo = repo
+  if not opts.repo then
+    opts.repo = repo
+  end
   return opts
 end
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Allows for specifying `repo:` filters for `search` commands. Also allows for not specifying the repo at all and defaulting to the current repo while still using filters.

### Describe how to verify it

`:Octo pr search repo:neovim/neovim is:open`

`:Octo pr search repo:neovim/neovim`

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
