### PR TITLE
feat: add multiple reviewers/assignees at once

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -114,6 +114,7 @@ function M.setup()
 end
 
 --- Create a callback function for the job
+---@param opts? { success?: fun(stdout: string), failure?: fun(stderr: string) }
 function M.create_callback(opts)
   opts = opts or {}
 

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -325,8 +325,10 @@ end
 --- The gh.api commands
 M.api = {}
 
+---@class (partial) octo.PartialRunOpts: RunOpts
+
 ---Run a graphql query
----@param opts table the options for the graphql query
+---@param opts {opts?: octo.PartialRunOpts}|GraphQLOpts the options for the graphql query
 ---@return table|nil
 function M.api.graphql(opts)
   opts = opts or {}

--- a/lua/octo/gh/mutations.lua
+++ b/lua/octo/gh/mutations.lua
@@ -877,8 +877,8 @@ mutation {
 
 -- https://docs.github.com/en/graphql/reference/mutations#addassigneestoassignable
 M.add_assignees = [[
-mutation {
-  addAssigneesToAssignable(input: {assignableId: "%s", assigneeIds: %s}) {
+mutation($object_id: ID!, $user_ids: [ID!]!) {
+  addAssigneesToAssignable(input: {assignableId: $object_id, assigneeIds: $user_ids}) {
     assignable {
       ... on Issue {
         id
@@ -910,8 +910,8 @@ mutation {
 -- https://docs.github.com/en/graphql/reference/mutations#requestreviews
 -- for teams use `teamIds`
 M.request_reviews = [[
-mutation {
-  requestReviews(input: {pullRequestId: "%s", union: true, userIds: %s}) {
+mutation($object_id: ID!, $user_ids: [ID!]!) {
+  requestReviews(input: {pullRequestId: $object_id, union: true, userIds: $user_ids}) {
     pullRequest {
       id
       reviewRequests(first: 100) {

--- a/lua/octo/gh/mutations.lua
+++ b/lua/octo/gh/mutations.lua
@@ -878,7 +878,7 @@ mutation {
 -- https://docs.github.com/en/graphql/reference/mutations#addassigneestoassignable
 M.add_assignees = [[
 mutation {
-  addAssigneesToAssignable(input: {assignableId: "%s", assigneeIds: ["%s"]}) {
+  addAssigneesToAssignable(input: {assignableId: "%s", assigneeIds: %s}) {
     assignable {
       ... on Issue {
         id
@@ -911,7 +911,7 @@ mutation {
 -- for teams use `teamIds`
 M.request_reviews = [[
 mutation {
-  requestReviews(input: {pullRequestId: "%s", union: true, userIds: ["%s"]}) {
+  requestReviews(input: {pullRequestId: "%s", union: true, userIds: %s}) {
     pullRequest {
       id
       reviewRequests(first: 100) {

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1579,7 +1579,7 @@ function M.get_user_id(login)
     return
   end
 
-  return id
+  return id --[[@as string]]
 end
 
 function M.get_label_id(label)


### PR DESCRIPTION
### Describe what this PR does / why we need it

Allows for adding multiple reviewers/assignees at once. Implementation is a bit hacky in that there is a request for the user id for each user, when it probably could be done in a single request. Though, I don't usually think there's so many reviewers that it matters.

### Describe how to verify it

`Octo reviewer add user1 user2`

`Octo assignee add user1 user2`

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
