### PR TITLE
fix: write review decision when empty

### DIFF
--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -257,8 +257,10 @@ function OctoBuffer:render_issue()
           folds.create(self.bufnr, review_start + 1, review_end, true)
         end
         writers.write_block(self.bufnr, { "" })
-        prev_is_event = false
+      else
+        writers.write_review_decision(self.bufnr, item)
       end
+      prev_is_event = false
     elseif item.__typename == "AssignedEvent" then
       writers.write_assigned_event(self.bufnr, item)
       prev_is_event = true

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -929,6 +929,29 @@ function M.write_comment(bufnr, comment, kind, line)
   return start_line, line - 1
 end
 
+---@param bufnr integer
+---@param review any
+function M.write_review_decision(bufnr, review)
+  local line = vim.api.nvim_buf_line_count(bufnr) + 1
+  local conf = config.values
+  M.write_block(bufnr, { "", "" }, line)
+  local header_vt = {}
+  local state_bubble =
+    bubbles.make_bubble(utils.state_msg_map[review.state], utils.state_hl_map[review.state] .. "Bubble")
+  table.insert(header_vt, { conf.timeline_marker .. " ", "OctoTimelineMarker" })
+  table.insert(header_vt, { "REVIEW: ", "OctoTimelineItemHeading" })
+  table.insert(header_vt, {
+    review.author.login,
+    review.viewerDidAuthor and "OctoUserViewer" or "OctoUser",
+  })
+  table.insert(header_vt, { " ", "OctoTimelineItemHeading" })
+  vim.list_extend(header_vt, state_bubble)
+  table.insert(header_vt, { " " .. utils.format_date(review.createdAt), "OctoDate" })
+
+  local comment_vt_ns = vim.api.nvim_create_namespace ""
+  M.write_virtual_text(bufnr, comment_vt_ns, line - 1, header_vt)
+end
+
 local function find_snippet_range(diffhunk_lines)
   local conf = config.values
   local context_lines = conf.snippet_context_lines or 4

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -642,7 +642,7 @@ end
 
 ---Formats a string as a date
 ---@param date_string string
----@param round_under_one_minute boolean
+---@param round_under_one_minute? boolean defaults to true
 ---@return string
 function M.format_date(date_string, round_under_one_minute)
   if date_string == nil then


### PR DESCRIPTION
### Describe what this PR does / why we need it

Review decisions don't get written to the timeline if they don't have a comment/body. This is mostly fine, but I would still like to see if someone stamped my PR, which this allows for.

### Does this pull request fix one issue?

closes #1018

### Describe how you did it

I copied over some of the logic from `writers.write_comment`, leaving out the readonly marker since there's no comment to write.

### Describe how to verify it

Try making a review decision on this PR without a comment and with a comment.

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
