### PR TITLE
fix: prevent modifications on Octo pr checks buffer

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1755,6 +1755,7 @@ function M.pr_checks()
         vim.api.nvim_buf_add_highlight(wbufnr, -1, "OctoFailingTest", i - 1, 0, -1)
       end
     end
+    vim.bo[wbufnr].modifiable = false
   end
 
   gh.pr.checks {


### PR DESCRIPTION
### Describe what this PR does / why we need it

Prevents modifications in the pr checks buffer.

### Describe how to verify it

`:Octo pr checks` in a pr buffer and try to edit the floating buffer.
### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
