### PR TITLE
fix: do not error when code block has no parser

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -1020,6 +1020,9 @@ local function highlight_content(content_lines, lang)
     return get_unhighlighted_ranges()
   end
   local content = table.concat(content_lines, "\n")
+  if not vim.treesitter.language.add(lang) then
+    return get_unhighlighted_ranges()
+  end
   local parser = vim.treesitter.get_string_parser(content, lang)
   local parsers = parser:parse()
   if not parsers then


### PR DESCRIPTION
### Describe what this PR does / why we need it
Some files do not have treesitter parsers, or the user just might not have them installed. So we check against it before trying to parse and highlight.
