### PR TITLE
feat: add `review_commits` to `file_panel` and `review_diff`

### DIFF
--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -431,6 +431,7 @@ function M.get_default_values()
         toggle_viewed = { lhs = "<localleader><space>", desc = "toggle viewer viewed state" },
         goto_file = { lhs = "gf", desc = "go to file" },
         copy_sha = { lhs = "<C-e>", desc = "copy commit SHA to system clipboard" },
+        review_commits = { lhs = "<localleader>C", desc = "review PR commits" },
       },
       file_panel = {
         submit_review = { lhs = "<localleader>vs", desc = "submit review" },
@@ -447,6 +448,7 @@ function M.get_default_values()
         select_last_entry = { lhs = "]Q", desc = "move to last changed file" },
         close_review_tab = { lhs = "<C-c>", desc = "close review tab" },
         toggle_viewed = { lhs = "<localleader><space>", desc = "toggle viewer viewed state" },
+        review_commits = { lhs = "<localleader>C", desc = "review PR commits" },
       },
       notification = {
         read = { lhs = "<localleader>nr", desc = "mark notification as read" },

--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -21,6 +21,9 @@ return {
   list_commits = function()
     require("octo.picker").commits()
   end,
+  review_commits = function()
+    require("octo.picker").review_commits()
+  end,
   list_changed_files = function()
     require("octo.picker").changed_files()
   end,


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR adds the `review_commits`, aka `:Octo review commit`, to both the `file_panel` and the `review_diff` context, which are the (as far as I know) the only two that the command can be invoked (inside a review).

This is useful when you are reviewing big PRs that have a lengthy list of commits and you want to go one by one and you don't want to every time type `:Octo review commit`.

### Does this pull request fix one issue?

NONE

### Describe how you did it

1. Added `review_commits` command to the `mappings.lua`
2. Added the `review_commits` to the default mappings in `config.lua` both in the `file_panel` and the `review_diff`.

### Describe how to verify it

In neovim using `octo.nvim`:

1. Go to a PR
2. Start a review
3. Then do `<localleader>C` either in the `file_panel` or the `review_diff`

### Special notes for reviews

using the `<localleader>C` because it is the only keymap that will be consistent between these two contexts

I am fine with bikeshedding the `desc` (`"review PR commits"`) or the keymap `<localleader>C` to any other alternative.

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
