### PR TITLE
fix: `remove_user`/`remove_assignee` not implemented

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -865,6 +865,9 @@ function M.setup()
       add = function(...)
         M.add_user("reviewer", { ... })
       end,
+      remove = function(login)
+        M.remove_reviewer(login)
+      end,
     },
     reaction = {
       thumbs_up = function()
@@ -2338,6 +2341,16 @@ function M.add_user(subject, logins)
   end
 end
 
+function M.remove_user(subject, login)
+  if subject == "assignee" then
+    M.remove_assignee(login)
+  elseif subject == "reviewer" then
+    M.remove_reviewer(login)
+  else
+    utils.error("Remove user not implemented for: " .. subject)
+  end
+end
+
 function M.remove_assignee(login)
   local buffer = utils.get_current_buffer()
   if not buffer then
@@ -2374,6 +2387,42 @@ function M.remove_assignee(login)
     end
   else
     picker.assignees(cb)
+  end
+end
+
+function M.remove_reviewer(login)
+  local buffer = utils.get_current_buffer()
+  if not buffer then
+    utils.error "No buffer found"
+    return
+  end
+
+  if not buffer:isPullRequest() then
+    utils.error "Not a pull request buffer"
+    return
+  end
+
+  local function cb(reviewer_login)
+    gh.pr.edit {
+      buffer.number,
+      remove_reviewer = reviewer_login,
+      opts = {
+        cb = gh.create_callback {
+          success = function()
+            require("octo").load(buffer.repo, buffer.kind, buffer.number, function(obj)
+              writers.write_details(buffer.bufnr, obj, true)
+            end)
+          end,
+        },
+      },
+    }
+  end
+
+  if login then
+    cb(login)
+  else
+    -- TODO: Implement reviewer picker when available
+    utils.error "Reviewer picker not yet implemented. Please provide a login."
   end
 end
 

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -861,6 +861,35 @@ query {
 }
 ]] .. fragments.label_connection .. fragments.label
 
+M.pull_request_reviewers = [[
+query {
+  repository(owner: "%s", name: "%s") {
+    pullRequest(number: %d) {
+      reviewRequests(first: 100) {
+        totalCount
+        nodes {
+          requestedReviewer {
+            ... on User {
+              id
+              login
+              name
+            }
+            ... on Mannequin { 
+              id
+              login 
+            }
+            ... on Team { 
+              id
+              name 
+            }
+          }
+        }
+      }
+    }
+  }
+}
+]]
+
 M.issue_assignees = [[
 query {
   repository(owner: "%s", name: "%s") {


### PR DESCRIPTION
### Describe what this PR does / why we need it

While working on #1133 I realized that we don't have a `remove_assignee` function that will be called if we do `remove_user`/`remove_user "assignee"`.
Hence this PR fixes that by implementing it.

### Does this pull request fix one issue?

~~Honestly, I don't know. I was too deep into the weeds and snatched this commit out of a #1133.~~

Fixes #1103.

### Describe how you did it

In the same light of `add_user "assignee"` and `add_assignee` this PR implements `remove_assignee`. I also added a `pull_request_reviewers` to `gh` queries in `queries.lua` antecipating the work to be done in `remove_user "reviewer"`/`{add,remove}_reviewer`.

### Describe how to verify it

Open any PR, add an assigne, and then remove witha `<localleader>ad` or `:Octo assignee remove`.

Snacks support will come in #1133.

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
