### PR TITLE
chore: fix stylua precommit step

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,6 @@ ci:
 
 repos:
   - repo: https://github.com/JohnnyMorganz/StyLua
-    rev: v2.0.2
+    rev: v2.1.0
     hooks:
-      - id: stylua
+      - id: stylua-github

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,6 +1,8 @@
+syntax = "Lua52"
 column_width = 120
 line_endings = "Unix"
 indent_type = "Spaces"
 indent_width = 2
 quote_style = "AutoPreferDouble"
 no_call_parentheses = true
+


### PR DESCRIPTION
### Describe what this PR does / why we need it
This fixes the precommit hook for stylua.

### Describe how you did it
the goto syntax is a syntax in lua5.2, and its syntax conflicts with luau. thus we must specify the syntax for stylua. additionally we should install stylua from github releases because installing with cargo only embeds the lua5.1 syntax, while the github release has all syntaxes, but requires disambiguation

