### PR TITLE
chore: improve typing of OctoBuffer.node

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -150,12 +150,12 @@ function M.setup()
 
         gh.api.graphql {
           query = mutations.reopen_discussion,
-          fields = { discussion_id = buffer.node.id },
+          fields = { discussion_id = buffer:discussion().id },
           jq = ".data.reopenDiscussion.discussion.id",
           opts = {
             cb = gh.create_callback {
               success = function(response_id)
-                if response_id == buffer.node.id then
+                if response_id == buffer:discussion().id then
                   utils.info "Discussion reopened"
                 end
               end,
@@ -197,12 +197,12 @@ function M.setup()
 
           gh.api.graphql {
             query = mutations.close_discussion,
-            fields = { discussion_id = buffer.node.id, reason = string.upper(reason) },
+            fields = { discussion_id = buffer:discussion().id, reason = string.upper(reason) },
             jq = ".data.closeDiscussion.discussion.id",
             opts = {
               cb = gh.create_callback {
                 success = function(response_id)
-                  if response_id == buffer.node.id then
+                  if response_id == buffer:discussion().id then
                     utils.info("Discussion closed with reason: " .. reason)
                   end
                 end,
@@ -252,7 +252,7 @@ function M.setup()
                   gh.api.graphql {
                     query = mutations.update_issue_issue_type,
                     F = {
-                      issue_id = buffer.node.id,
+                      issue_id = buffer:issue().id,
                       issue_type_id = selected_type.id,
                     },
                     opts = {
@@ -270,7 +270,7 @@ function M.setup()
         }
       end),
       remove = M.within_issue(function(buffer)
-        local current_type = buffer.node.issueType
+        local current_type = buffer:issue().issueType
 
         if not current_type or utils.is_blank(current_type) then
           utils.error "No issue type to remove"
@@ -280,7 +280,7 @@ function M.setup()
         gh.api.graphql {
           query = mutations.update_issue_issue_type,
           F = {
-            issue_id = buffer.node.id,
+            issue_id = buffer:issue().id,
           },
           opts = {
             cb = gh.create_callback {
@@ -351,7 +351,7 @@ function M.setup()
     },
     parent = {
       edit = M.within_issue(function(buffer)
-        local parent = buffer.node.parent
+        local parent = buffer.issue().parent
 
         if utils.is_blank(parent) then
           utils.error "No parent issue found"
@@ -362,7 +362,7 @@ function M.setup()
         vim.cmd.edit(uri)
       end),
       remove = M.within_issue(function(buffer)
-        local parent = buffer.node.parent
+        local parent = buffer.issue().parent
 
         if utils.is_blank(parent) then
           utils.error "No parent issue found"
@@ -373,13 +373,13 @@ function M.setup()
           query = mutations.remove_subissue,
           fields = {
             parent_id = parent.id,
-            child_id = buffer.node.id,
+            child_id = buffer.issue().id,
           },
           jq = ".data.removeSubIssue.subIssue.id",
           opts = {
             cb = gh.create_callback {
               success = function(response_id)
-                if response_id == buffer.node.id then
+                if response_id == buffer:issue().id then
                   utils.info "Issue removed as sub-issue"
                 end
               end,
@@ -394,13 +394,13 @@ function M.setup()
             query = mutations.add_subissue,
             fields = {
               parent_id = selected.obj.id,
-              child_id = buffer.node.id,
+              child_id = buffer:issue().id,
             },
             jq = ".data.addSubIssue.subIssue.id",
             opts = {
               cb = gh.create_callback {
                 success = function(response_id)
-                  if response_id == buffer.node.id then
+                  if response_id == buffer:issue().id then
                     utils.info "Issue added as sub-issue"
                   end
                 end,
@@ -424,16 +424,16 @@ function M.setup()
         M.change_state(stateReason)
       end,
       unpin = M.within_issue(function(buffer)
-        M.pin_issue { obj = buffer.node, add = false }
+        M.pin_issue { obj = buffer:issue(), add = false }
       end),
       pin = M.within_issue(function(buffer)
-        M.pin_issue { obj = buffer.node, add = true }
+        M.pin_issue { obj = buffer:issue(), add = true }
       end),
       develop = function(repo, ...)
         local buffer = utils.get_current_buffer()
 
-        if buffer and buffer.kind and buffer.kind == "issue" then
-          utils.develop_issue(buffer.repo, buffer.node.number, repo)
+        if buffer and buffer:isIssue() then
+          utils.develop_issue(buffer.repo, buffer:issue().number, repo)
         else
           local opts = M.process_varargs(repo, ...)
           opts.cb = function(selected)
@@ -482,7 +482,7 @@ function M.setup()
           utils.error "Not a pull request buffer"
           return
         end
-        local headRefName = buffer.node.headRefName
+        local headRefName = buffer:pullRequest().headRefName
 
         require("octo.workflow_runs").list { branch = headRefName }
       end,
@@ -510,7 +510,7 @@ function M.setup()
         if not utils.in_pr_repo() then
           return
         end
-        utils.checkout_pr(buffer.node.number)
+        utils.checkout_pr(buffer:pullRequest().number)
       end,
       create = function(...)
         M.create_pr(...)
@@ -1346,6 +1346,7 @@ function M.unresolve_thread()
   }
 end
 
+---@param state "OPEN"|"CLOSED"
 function M.change_state(state)
   local buffer = utils.get_current_buffer()
 
@@ -1358,7 +1359,8 @@ function M.change_state(state)
     return
   end
 
-  local id = buffer.node.id
+  local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
+  local id = node.id
   local query, jq, desired_state, fields
   if buffer:isIssue() and state == "CLOSED" then
     query = graphql("update_issue_state_mutation", id, state)
@@ -1390,7 +1392,7 @@ function M.change_state(state)
       return
     end
 
-    buffer.node.state = new_state
+    node.state = new_state
 
     local updated_state = utils.get_displayed_state(buffer:isIssue(), new_state, obj.stateReason)
     writers.write_state(buffer.bufnr, updated_state:upper(), buffer.number)
@@ -1986,8 +1988,9 @@ function M.add_project_card()
 
   -- show column selection picker
   picker.project_columns(function(column_id)
+    local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
     -- add new card
-    local query = graphql("add_project_card_mutation", buffer.node.id, column_id)
+    local query = graphql("add_project_card_mutation", node.id, column_id)
     gh.run {
       args = { "api", "graphql", "--paginate", "-f", string.format("query=%s", query) },
       cb = function(output, stderr)
@@ -1997,7 +2000,7 @@ function M.add_project_card()
           -- refresh issue/pr details
           require("octo").load(buffer.repo, buffer.kind, buffer.number, function(obj)
             writers.write_details(buffer.bufnr, obj, true)
-            buffer.node.projectCards = obj.projectCards
+            node.projectCards = obj.projectCards
           end)
         end
       end,
@@ -2013,6 +2016,7 @@ function M.remove_project_card()
 
   -- show card selection picker
   picker.project_cards(function(card)
+    local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
     -- delete card
     local query = graphql("delete_project_card_mutation", card)
     gh.run {
@@ -2023,7 +2027,7 @@ function M.remove_project_card()
         elseif output then
           -- refresh issue/pr details
           require("octo").load(buffer.repo, buffer.kind, buffer.number, function(obj)
-            buffer.node.projectCards = obj.projectCards
+            node.projectCards = obj.projectCards
             writers.write_details(buffer.bufnr, obj, true)
           end)
         end
@@ -2041,6 +2045,7 @@ function M.move_project_card()
   picker.project_cards(function(source_card)
     -- show project column selection picker
     picker.project_columns(function(target_column)
+      local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
       -- move card to selected column
       local query = graphql("move_project_card_mutation", source_card, target_column)
       gh.run {
@@ -2051,7 +2056,7 @@ function M.move_project_card()
           elseif output then
             -- refresh issue/pr details
             require("octo").load(buffer.repo, buffer.kind, buffer.number, function(obj)
-              buffer.node.projectCards = obj.projectCards
+              node.projectCards = obj.projectCards
               writers.write_details(buffer.bufnr, obj, true)
             end)
           end
@@ -2069,8 +2074,9 @@ function M.set_project_v2_card()
 
   -- show column selection picker
   picker.project_columns_v2(function(project_id, field_id, value)
+    local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
     -- add new card
-    local add_query = graphql("add_project_v2_item_mutation", buffer.node.id, project_id)
+    local add_query = graphql("add_project_v2_item_mutation", node.id, project_id)
     gh.run {
       args = { "api", "graphql", "--paginate", "-f", string.format("query=%s", add_query) },
       cb = function(add_output, add_stderr)
@@ -2095,7 +2101,7 @@ function M.set_project_v2_card()
                 -- refresh issue/pr details
                 require("octo").load(buffer.repo, buffer.kind, buffer.number, function(obj)
                   writers.write_details(buffer.bufnr, obj, true)
-                  buffer.node.projectCards = obj.projectCards
+                  node.projectCards = obj.projectCards
                 end)
               end
             end,
@@ -2114,6 +2120,7 @@ function M.remove_project_v2_card()
 
   -- show card selection picker
   picker.project_cards_v2(function(project_id, item_id)
+    local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
     -- delete card
     local query = graphql("delete_project_v2_item_mutation", project_id, item_id)
     gh.run {
@@ -2124,7 +2131,7 @@ function M.remove_project_v2_card()
         elseif output then
           -- refresh issue/pr details
           require("octo").load(buffer.repo, buffer.kind, buffer.number, function(obj)
-            buffer.node.projectCards = obj.projectCards
+            node.projectCards = obj.projectCards
             writers.write_details(buffer.bufnr, obj, true)
           end)
         end
@@ -2283,7 +2290,7 @@ function M.add_user(subject, logins)
     return
   end
 
-  local iid = buffer.node.id ---@type string
+  local iid = buffer.node.id
   if not iid then
     utils.error "Cannot get issue/pr id"
   end
@@ -2400,7 +2407,7 @@ function M.copy_sha()
 
   local sha
   if buffer:isPullRequest() then
-    sha = buffer.node.headRefOid
+    sha = buffer.pullRequest().headRefOid
   elseif buffer:isIssue() then
     utils.error "Issues don't have commit SHAs"
     return
@@ -2453,6 +2460,7 @@ function M.search(...)
   picker.search { prompt = prompt, type = type }
 end
 
+---@param cb fun(buffer: OctoBuffer): nil
 function M.within_issue(cb)
   return function()
     local buffer = utils.get_current_buffer()

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -327,7 +327,8 @@ function M.setup()
           return
         end
 
-        local milestone = buffer.node.milestone
+        local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
+        local milestone = node.milestone
         if utils.is_blank(milestone) then
           utils.error "No milestone to remove"
           return

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -454,6 +454,7 @@ function M.get_default_values()
         unsubscribe = { lhs = "<localleader>nu", desc = "unsubscribe from notifications" },
       },
       repo = {},
+      release = {},
     },
   }
 end
@@ -694,6 +695,7 @@ function M.setup(opts)
         review_diff = {},
         file_panel = {},
         repo = {},
+        release = {},
       }
     end
     -- Use deep extend. For arrays ('actions' here), 'force' mode usually replaces the whole array,

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -104,7 +104,7 @@ query($endCursor: String) {
 ---@field updatedAt string
 ---@field url string
 ---@field headRepository { nameWithOwner: string }
----@field files { nodes: { path: string, viewerViewedState: string }[] }
+---@field files { nodes: { path: string, viewerViewedState: ViewedState }[] }
 ---@field merged boolean
 ---@field mergedBy { name: string }|{ login: string }|{ login: string, isViewer: boolean }
 ---@field participants { nodes: { login: string }[] }

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -132,7 +132,7 @@ function M.load_buffer(opts)
 end
 
 ---@param repo string
----@param kind "issue"|"pull"|"discussion"|"release"|"repo"
+---@param kind octo.NodeKind
 ---@param id integer|string pull request, issue, or discussion number or release tag
 ---@param cb fun(obj: octo.Issue|octo.PullRequest|octo.Discussion|octo.Release|octo.Repository): nil
 function M.load(repo, kind, id, cb)

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -25,7 +25,7 @@ local M = {}
 ---@field bodyMetadata BodyMetadata
 ---@field commentsMetadata CommentMetadata[]
 ---@field threadsMetadata ThreadMetadata[]
----@field node octo.PullRequest|octo.Issue|octo.Release|octo.Discussion|octo.Repository
+---@field private node octo.PullRequest|octo.Issue|octo.Release|octo.Discussion|octo.Repository
 ---@field taggable_users? string[]
 ---@field owner? string
 ---@field name? string
@@ -600,7 +600,8 @@ end
 ---@param comment_metadata CommentMetadata
 function OctoBuffer:do_add_issue_comment(comment_metadata)
   -- create new issue comment
-  local id = self:issue().id
+  local obj = self:isIssue() and self:issue() or self:pullRequest()
+  local id = obj.id
   local add_query = graphql("add_issue_comment_mutation", id, comment_metadata.body)
   gh.run {
     args = { "api", "graphql", "-f", string.format("query=%s", add_query) },

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -14,11 +14,13 @@ local vim = vim
 
 local M = {}
 
+---@alias octo.NodeKind "issue" | "pull" | "discussion" | "repo" | "release"
+
 ---@class OctoBuffer
 ---@field bufnr integer
 ---@field number integer
 ---@field repo string
----@field kind string
+---@field kind octo.NodeKind|"reviewthread"
 ---@field titleMetadata TitleMetadata
 ---@field bodyMetadata BodyMetadata
 ---@field commentsMetadata CommentMetadata[]
@@ -67,7 +69,7 @@ function OctoBuffer:new(opts)
       this.taggable_users = { this.node.author.login }
     end
   elseif this.node and not this.number then
-    this.kind = "repo"
+    this.kind = opts.kind or "repo"
   else
     this.kind = "reviewthread"
   end
@@ -81,6 +83,7 @@ M.OctoBuffer = OctoBuffer
 
 ---Apply the buffer mappings
 function OctoBuffer:apply_mappings()
+  ---@type string
   local kind = self.kind
   if self.kind == "pull" then
     kind = "pull_request"
@@ -105,7 +108,7 @@ end
 ---Writes a repo to the buffer
 function OctoBuffer:render_repo()
   self:clear()
-  writers.write_repo(self.bufnr, self.node --[[@as octo.Repository]])
+  writers.write_repo(self.bufnr, self:repository())
 
   -- reset modified option
   vim.bo[self.bufnr].modified = false
@@ -115,8 +118,7 @@ end
 
 function OctoBuffer:render_release()
   self:clear()
-  local obj = self.node
-  writers.write_release(self.bufnr, obj --[[@as octo.Release]])
+  writers.write_release(self.bufnr, self:release())
   vim.bo[self.bufnr].modified = false
   self.ready = true
 end
@@ -124,26 +126,26 @@ end
 function OctoBuffer:render_discussion()
   self:clear()
 
-  local obj = self.node
+  local obj = self:discussion()
   local state = obj.closed and "CLOSED" or "OPEN"
   writers.write_title(self.bufnr, tostring(obj.title), 1)
   writers.write_state(self.bufnr, state, self.number)
-  writers.write_discussion_details(self.bufnr, obj --[[@as octo.Discussion]])
+  writers.write_discussion_details(self.bufnr, obj)
   writers.write_body(self.bufnr, obj, 13)
 
   -- write body reactions
   local reaction_line ---@type integer?
-  if utils.count_reactions(self.node.reactionGroups) > 0 then
+  if utils.count_reactions(obj.reactionGroups) > 0 then
     local line = vim.api.nvim_buf_line_count(self.bufnr) + 1
     writers.write_block(self.bufnr, { "", "" }, line)
-    reaction_line = writers.write_reactions(self.bufnr, self.node.reactionGroups, line)
+    reaction_line = writers.write_reactions(self.bufnr, obj.reactionGroups, line)
   end
-  self.bodyMetadata.reactionGroups = self.node.reactionGroups
+  self.bodyMetadata.reactionGroups = obj.reactionGroups
   self.bodyMetadata.reactionLine = reaction_line
 
   if obj.answer ~= vim.NIL then
     local line = vim.api.nvim_buf_line_count(self.bufnr) + 1
-    writers.write_discussion_answer(self.bufnr, obj --[[@as octo.Discussion]], line)
+    writers.write_discussion_answer(self.bufnr, obj, line)
     writers.write_block(self.bufnr, { "" })
   end
 
@@ -164,28 +166,29 @@ end
 ---Writes an issue or pull request to the buffer.
 function OctoBuffer:render_issue()
   self:clear()
+  local obj = self:isPullRequest() and self:pullRequest() or self:issue()
 
   -- write title
-  writers.write_title(self.bufnr, self.node.title, 1)
+  writers.write_title(self.bufnr, obj.title, 1)
 
   -- write details in buffer
-  writers.write_details(self.bufnr, self.node --[[@as octo.PullRequest|octo.Issue]])
+  writers.write_details(self.bufnr, obj)
 
   -- write issue/pr status
-  local state = utils.get_displayed_state(self.kind == "issue", self.node.state, self.node.stateReason)
+  local state = utils.get_displayed_state(self.kind == "issue", obj.state, obj.stateReason)
   writers.write_state(self.bufnr, state:upper(), self.number)
 
   -- write body
-  writers.write_body(self.bufnr, self.node)
+  writers.write_body(self.bufnr, obj)
 
   -- write body reactions
   local reaction_line ---@type integer?
-  if utils.count_reactions(self.node.reactionGroups) > 0 then
+  if utils.count_reactions(obj.reactionGroups) > 0 then
     local line = vim.api.nvim_buf_line_count(self.bufnr) + 1
     writers.write_block(self.bufnr, { "", "" }, line)
-    reaction_line = writers.write_reactions(self.bufnr, self.node.reactionGroups, line)
+    reaction_line = writers.write_reactions(self.bufnr, obj.reactionGroups, line)
   end
-  self.bodyMetadata.reactionGroups = self.node.reactionGroups
+  self.bodyMetadata.reactionGroups = obj.reactionGroups
   self.bodyMetadata.reactionLine = reaction_line
 
   -- write timeline items
@@ -198,7 +201,7 @@ function OctoBuffer:render_issue()
 
   ---@type (octo.PullRequestTimelineItem|octo.IssueTimelineItem)[]
   local timeline_nodes = {}
-  for _, item in ipairs(self.node.timelineItems.nodes) do
+  for _, item in ipairs(obj.timelineItems.nodes) do
     if item ~= vim.NIL then
       table.insert(timeline_nodes, item)
     end
@@ -252,7 +255,7 @@ function OctoBuffer:render_issue()
       -- A review can have 0+ threads
       local threads = {}
       for _, comment in ipairs(item.comments.nodes) do
-        for _, reviewThread in ipairs(self.node.reviewThreads.nodes) do
+        for _, reviewThread in ipairs(self:pullRequest().reviewThreads.nodes) do
           if comment.id == reviewThread.comments.nodes[1].id then
             -- found a thread for the current review
             table.insert(threads, reviewThread)
@@ -492,11 +495,12 @@ function OctoBuffer:save()
   vim.bo[bufnr].modified = false
 end
 
----Sync issue/PR title and body with GitHub
+---Sync issue/PR/discussion title and body with GitHub
 function OctoBuffer:do_save_title_and_body()
   local title_metadata = self.titleMetadata
   local desc_metadata = self.bodyMetadata
-  local id = self.node.id
+  local node = self:isIssue() and self:issue() or self:isPullRequest() and self:pullRequest() or self:discussion()
+  local id = node.id
   if title_metadata.dirty or desc_metadata.dirty then
     -- trust but verify
     if string.find(title_metadata.body, "\n") then
@@ -556,7 +560,7 @@ end
 ---@param comment_metadata CommentMetadata
 function OctoBuffer:do_add_discussion_comment(comment_metadata)
   local f = {
-    discussion_id = self.node.id,
+    discussion_id = self:discussion().id,
     body = comment_metadata.body,
   }
   if comment_metadata.replyTo then
@@ -596,7 +600,7 @@ end
 ---@param comment_metadata CommentMetadata
 function OctoBuffer:do_add_issue_comment(comment_metadata)
   -- create new issue comment
-  local id = self.node.id
+  local id = self:issue().id
   local add_query = graphql("add_issue_comment_mutation", id, comment_metadata.body)
   gh.run {
     args = { "api", "graphql", "-f", string.format("query=%s", add_query) },
@@ -1117,9 +1121,19 @@ function OctoBuffer:isDiscussion()
   return self.kind == "discussion"
 end
 
+function OctoBuffer:discussion()
+  assert(self:isDiscussion(), "Not a discussion buffer")
+  return self.node --[[@as octo.Discussion]]
+end
+
 --- Checks if the buffer represents a Pull Request
 function OctoBuffer:isPullRequest()
   return self.kind == "pull"
+end
+
+function OctoBuffer:pullRequest()
+  assert(self:isPullRequest(), "Not a pull request buffer")
+  return self.node --[[@as octo.PullRequest]]
 end
 
 --- Checks if the buffer represents an Issue
@@ -1127,9 +1141,28 @@ function OctoBuffer:isIssue()
   return self.kind == "issue"
 end
 
+function OctoBuffer:issue()
+  assert(self:isIssue(), "Not an issue buffer")
+  return self.node --[[@as octo.Issue]]
+end
+
 ---Checks if the buffer represents a GitHub repo
 function OctoBuffer:isRepo()
   return self.kind == "repo"
+end
+
+function OctoBuffer:repository()
+  assert(self:isRepo(), "Not a repo buffer")
+  return self.node --[[@as octo.Repository]]
+end
+
+function OctoBuffer:isRelease()
+  return self.kind == "release"
+end
+
+function OctoBuffer:release()
+  assert(self:isRelease(), "Not a release buffer")
+  return self.node --[[@as octo.Release]]
 end
 
 ---Gets the PR object for the current octo buffer
@@ -1145,13 +1178,13 @@ function OctoBuffer:get_pr()
   return PullRequest:new {
     bufnr = bufnr,
     repo = self.repo,
-    head_repo = self.node.headRepository.nameWithOwner,
-    head_ref_name = self.node.headRefName,
+    head_repo = self:pullRequest().headRepository.nameWithOwner,
+    head_ref_name = self:pullRequest().headRefName,
     number = self.number,
-    id = self.node.id,
-    left = Rev:new(self.node.baseRefOid),
-    right = Rev:new(self.node.headRefOid),
-    files = self.node.files.nodes,
+    id = self:pullRequest().id,
+    left = Rev:new(self:pullRequest().baseRefOid),
+    right = Rev:new(self:pullRequest().headRefOid),
+    files = self:pullRequest().files.nodes,
   }
 end
 

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -55,8 +55,7 @@ function M.open_in_browser(kind, repo, number)
     elseif buffer:isRepo() then
       cmd = string.format("gh repo view --web %s/%s", remote, buffer.repo)
     elseif buffer:isDiscussion() then
-      ---@type string
-      local url = buffer.node.url
+      local url = buffer:discussion().url
       M.open_in_browser_raw(url)
       return
     end

--- a/lua/octo/pickers/fzf-lua/pickers/project_cards.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/project_cards.lua
@@ -6,7 +6,8 @@ local utils = require "octo.utils"
 
 return function(callback)
   local buffer = utils.get_current_buffer()
-  local cards = buffer.node.projectCards
+  local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
+  local cards = node.projectCards
   if not cards or #cards.nodes == 0 then
     utils.error "Can't find any project cards"
     return

--- a/lua/octo/pickers/fzf-lua/pickers/project_cards_v2.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/project_cards_v2.lua
@@ -4,7 +4,8 @@ local utils = require "octo.utils"
 
 return function(callback)
   local buffer = utils.get_current_buffer()
-  local cards = buffer.node.projectItems
+  local obj = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
+  local cards = obj.projectItems
   if not cards or #cards.nodes == 0 then
     utils.error "Can't find any project v2 cards"
     return

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -1757,7 +1757,8 @@ function M.project_cards_v2(cb)
     return
   end
 
-  local cards = buffer.node.projectItems
+  local obj = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
+  local cards = obj.projectItems
   if not cards or #cards.nodes == 0 then
     utils.error "Can't find any project v2 cards"
     return

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -400,8 +400,7 @@ end
 function M.write_state(bufnr, state, number)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
-  local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
-  state = state or node.state
+  state = state or (buffer:isIssue() and buffer:issue() or buffer:pullRequest()).state
   number = number or buffer.number
 
   -- clear virtual texts

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -400,7 +400,8 @@ end
 function M.write_state(bufnr, state, number)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   local buffer = octo_buffers[bufnr]
-  state = state or buffer.node.state
+  local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
+  state = state or node.state
   number = number or buffer.number
 
   -- clear virtual texts

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -414,7 +414,7 @@ function M.write_state(bufnr, state, number)
 
   -- PR virtual text
   if buffer and buffer:isPullRequest() then
-    if buffer.node.isDraft then
+    if buffer:pullRequest().isDraft then
       table.insert(title_vt, { "[DRAFT]", "OctoStateDraftFloat" })
     end
   end
@@ -448,6 +448,9 @@ function M.write_body_agnostic(bufnr, body, line, viewer_can_update)
   end
 end
 
+---@param bufnr integer
+---@param issue octo.Issue|octo.PullRequest|octo.Discussion
+---@param line? integer
 function M.write_body(bufnr, issue, line)
   M.write_body_agnostic(bufnr, issue.body, line, issue.viewerCanUpdate)
 end

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -455,8 +455,14 @@ function M.in_pr_repo()
   end
 
   local local_repo = M.get_remote_name()
-  if buffer.node.baseRepository.nameWithOwner ~= local_repo then
-    M.error(string.format("Not in PR repo. Expected %s, got %s", buffer.node.baseRepository.nameWithOwner, local_repo))
+  if buffer:pullRequest().baseRepository.nameWithOwner ~= local_repo then
+    M.error(
+      string.format(
+        "Not in PR repo. Expected %s, got %s",
+        buffer:pullRequest().baseRepository.nameWithOwner,
+        local_repo
+      )
+    )
     return false
   else
     return true


### PR DESCRIPTION
### Describe what this PR does / why we need it
Discourage use of `OctoBuffer.node` in favor of `OctoBuffer:issue()`, `OctoBuffer:pull_request()`, `OctoBuffer:repository()`, `OctoBuffer:release()`, and `OctoBuffer:discussion()`.
This removes the need for casting on the `node` property since it is abstracted in a safe manner.
