### PR TITLE
fix: add red D for removed files in review file panel

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -77,6 +77,7 @@ M.file_status_map = {
   modified = "M",
   added = "A",
   deleted = "D",
+  removed = "D",
   renamed = "R",
 }
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
Seems we used to have a red `D` in the file panel, maybe the api changed or something since then tho. Adds it back while probably keeping backwards compatibility.