### PR TITLE
fix: copy_sha error

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2408,7 +2408,7 @@ function M.copy_sha()
 
   local sha
   if buffer:isPullRequest() then
-    sha = buffer.pullRequest().headRefOid
+    sha = buffer:pullRequest().headRefOid
   elseif buffer:isIssue() then
     utils.error "Issues don't have commit SHAs"
     return


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fixes an error in a `copy_sha` method, where we're not executing the `:pull_request` method properly. thought this would incur a type error 🤔

