### PR TITLE
Blakereeves/875 and 761 consolidate gp pr merge logic and use gh run

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1839,14 +1839,15 @@ function M.pr_checks()
 end
 
 function M.merge_pr(...)
+  local args = { "pr", "merge" }
+  local params = table.pack(...)
+  local conf = config.values
+  local pr_number = nil
+
   local buffer = utils.get_current_buffer()
   if not buffer or not buffer:isPullRequest() then
     return
   end
-
-  local args = { "pr", "merge", tostring(buffer.number) }
-  local params = table.pack(...)
-  local conf = config.values
 
   local merge_method = conf.default_merge_method
   for _, param in ipairs(params) do

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1064,14 +1064,14 @@ function M.add_pr_issue_or_review_thread_comment(body)
     viewerCanDelete = true,
     viewerDidAuthor = true,
     reactionGroups = {
-      { content = "THUMBS_UP",   users = { totalCount = 0 } },
+      { content = "THUMBS_UP", users = { totalCount = 0 } },
       { content = "THUMBS_DOWN", users = { totalCount = 0 } },
-      { content = "LAUGH",       users = { totalCount = 0 } },
-      { content = "HOORAY",      users = { totalCount = 0 } },
-      { content = "CONFUSED",    users = { totalCount = 0 } },
-      { content = "HEART",       users = { totalCount = 0 } },
-      { content = "ROCKET",      users = { totalCount = 0 } },
-      { content = "EYES",        users = { totalCount = 0 } },
+      { content = "LAUGH", users = { totalCount = 0 } },
+      { content = "HOORAY", users = { totalCount = 0 } },
+      { content = "CONFUSED", users = { totalCount = 0 } },
+      { content = "HEART", users = { totalCount = 0 } },
+      { content = "ROCKET", users = { totalCount = 0 } },
+      { content = "EYES", users = { totalCount = 0 } },
     },
   }
 
@@ -1109,7 +1109,7 @@ function M.add_pr_issue_or_review_thread_comment(body)
     local comment_under_cursor = buffer:get_comment_at_cursor()
     if not utils.is_blank(comment_under_cursor) and vim.fn.confirm("Reply to comment?", "&Yes\n&No", 2) == 1 then
       comment.replyTo = not utils.is_blank(comment_under_cursor.replyTo) and comment_under_cursor.replyTo.id
-          or comment_under_cursor.id
+        or comment_under_cursor.id
       vim.api.nvim_buf_set_lines(
         buffer.bufnr,
         comment_under_cursor.bufferEndLine,
@@ -1588,12 +1588,12 @@ function M.create_pr(is_draft)
 
   -- get remote branches
   if
-      info == nil
-      or info.refs == nil
-      or info.refs.nodes == nil
-      or info == vim.NIL
-      or info.refs == vim.NIL
-      or info.refs.nodes == vim.NIL
+    info == nil
+    or info.refs == nil
+    or info.refs.nodes == nil
+    or info == vim.NIL
+    or info.refs == vim.NIL
+    or info.refs.nodes == vim.NIL
   then
     utils.error "Cannot grab remote branches"
     return
@@ -1609,7 +1609,7 @@ function M.create_pr(is_draft)
   local remote_branch = local_branch
   if not remote_branch_exists then
     local choice =
-        vim.fn.confirm("Remote branch '" .. local_branch .. "' does not exist. Push local one?", "&Yes\n&No\n&Cancel", 2)
+      vim.fn.confirm("Remote branch '" .. local_branch .. "' does not exist. Push local one?", "&Yes\n&No\n&Cancel", 2)
     if choice == 1 then
       local remote = "origin"
       remote_branch = vim.fn.input {
@@ -2612,12 +2612,12 @@ function M.pin_issue(opts)
         error = "pin",
         success = "Pinned",
       }
-      or {
-        query = mutations.unpin_issue,
-        jq = ".data.unpinIssue.issue.id",
-        error = "unpin",
-        success = "Unpinned",
-      }
+    or {
+      query = mutations.unpin_issue,
+      jq = ".data.unpinIssue.issue.id",
+      error = "unpin",
+      success = "Unpinned",
+    }
   gh.api.graphql {
     query = query_info.query,
     F = { issue_id = opts.obj.id },

--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -3,6 +3,7 @@ local gh = require "octo.gh"
 local graphql = require "octo.gh.graphql"
 local queries = require "octo.gh.queries"
 local utils = require "octo.utils"
+local commands = require "octo.commands"
 local octo_config = require "octo.config"
 local navigation = require "octo.navigation"
 local Snacks = require "snacks"
@@ -257,7 +258,7 @@ function M.pull_requests(opts)
 
         if not custom_actions_defined["merge_pr"] then
           final_actions["merge_pr"] = function(_picker, item)
-            utils.merge_pr(item.number)
+            commands.merge_pr(item.number)
           end
         end
         if not final_keys[cfg.picker_config.mappings.merge_pr.lhs] then

--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -7,6 +7,7 @@ local previewers = require "octo.pickers.telescope.previewers"
 local entry_maker = require "octo.pickers.telescope.entry_maker"
 local reviews = require "octo.reviews"
 local utils = require "octo.utils"
+local commands = require "octo.command"
 local octo_config = require "octo.config"
 local notifications = require "octo.notifications"
 
@@ -305,7 +306,7 @@ local function merge_pull_request()
   return function(prompt_bufnr)
     local sel = action_state.get_selected_entry(prompt_bufnr)
     actions.close(prompt_bufnr)
-    utils.merge_pr(sel.obj.number)
+    commands.merge_pr(sel.obj.number)
   end
 end
 

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -252,7 +252,7 @@ function M.parse_git_remote()
   ---@type table<string, OctoRepo>
   local remotes = {}
   for _, line in
-  ipairs(job:result() --[[@as string[] ]])
+    ipairs(job:result() --[[@as string[] ]])
   do
     local name, url = line:match "^(%S+)%s+(%S+)"
     if name then
@@ -1435,7 +1435,7 @@ function M.process_patch(patch)
     local header = vim.split(hunk, "\n")[1]
     ---@type integer?, integer?, integer, integer, integer, integer
     local found, _, left_start, left_length, right_start, right_length =
-        string.find(header, "^%s*%-(%d+),(%d+)%s+%+(%d+),(%d+)%s*@@")
+      string.find(header, "^%s*%-(%d+),(%d+)%s+%+(%d+),(%d+)%s*@@")
     if found then
       table.insert(hunks, hunk)
       table.insert(left_ranges, { tonumber(left_start), math.max(left_start + left_length - 1, 0) })
@@ -1785,10 +1785,10 @@ function M.apply_mappings(kind, bufnr)
   local conf = config.values
   for action, value in pairs(conf.mappings[kind]) do
     if
-        not M.is_blank(value)
-        and not M.is_blank(action)
-        and not M.is_blank(value.lhs)
-        and not M.is_blank(mappings[action])
+      not M.is_blank(value)
+      and not M.is_blank(action)
+      and not M.is_blank(value.lhs)
+      and not M.is_blank(mappings[action])
     then
       if M.is_blank(value.desc) then
         value.desc = ""

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -2020,4 +2020,15 @@ function M.print_err(msg)
   vim.api.nvim_echo({ { msg } }, true, { err = true })
 end
 
+--- @param val string
+--- Check if a value is a number or numeric string (e.g. 123 or "456")
+function M.is_number_like(val)
+  if type(val) == "number" then return true end
+  if type(val) == "string" then
+    local n = tonumber(val)
+    return n ~= nil and tostring(n) == val
+  end
+  return false
+end
+
 return M

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -252,7 +252,7 @@ function M.parse_git_remote()
   ---@type table<string, OctoRepo>
   local remotes = {}
   for _, line in
-    ipairs(job:result() --[[@as string[] ]])
+  ipairs(job:result() --[[@as string[] ]])
   do
     local name, url = line:match "^(%S+)%s+(%S+)"
     if name then
@@ -623,36 +623,6 @@ function M.insert_delete_flag(args, delete)
   if delete then
     table.insert(args, "--delete-branch")
   end
-end
-
----Merges a PR by number
-function M.merge_pr(pr_number)
-  if not Job then
-    M.error "Aborting PR merge"
-    return
-  end
-
-  local conf = config.values
-  local args = { "pr", "merge", pr_number }
-
-  M.insert_merge_flag(args, conf.default_merge_method)
-  M.insert_delete_flag(args, conf.default_delete_branch)
-
-  ---@diagnostic disable-next-line: missing-fields
-  Job:new({
-    command = "gh",
-    args = args,
-    on_exit = vim.schedule_wrap(function(job, code)
-      if code == 0 then
-        M.info("Merged PR " .. pr_number .. "!")
-      else
-        local stderr = table.concat(job:stderr_result(), "\n")
-        if not M.is_blank(stderr) then
-          M.error(stderr)
-        end
-      end
-    end),
-  }):start()
 end
 
 --- Formats a integer a large integer by taking the most significant digits with a suffix.
@@ -1465,7 +1435,7 @@ function M.process_patch(patch)
     local header = vim.split(hunk, "\n")[1]
     ---@type integer?, integer?, integer, integer, integer, integer
     local found, _, left_start, left_length, right_start, right_length =
-      string.find(header, "^%s*%-(%d+),(%d+)%s+%+(%d+),(%d+)%s*@@")
+        string.find(header, "^%s*%-(%d+),(%d+)%s+%+(%d+),(%d+)%s*@@")
     if found then
       table.insert(hunks, hunk)
       table.insert(left_ranges, { tonumber(left_start), math.max(left_start + left_length - 1, 0) })
@@ -1815,10 +1785,10 @@ function M.apply_mappings(kind, bufnr)
   local conf = config.values
   for action, value in pairs(conf.mappings[kind]) do
     if
-      not M.is_blank(value)
-      and not M.is_blank(action)
-      and not M.is_blank(value.lhs)
-      and not M.is_blank(mappings[action])
+        not M.is_blank(value)
+        and not M.is_blank(action)
+        and not M.is_blank(value.lhs)
+        and not M.is_blank(mappings[action])
     then
       if M.is_blank(value.desc) then
         value.desc = ""
@@ -2023,7 +1993,9 @@ end
 --- @param val string
 --- Check if a value is a number or numeric string (e.g. 123 or "456")
 function M.is_number_like(val)
-  if type(val) == "number" then return true end
+  if type(val) == "number" then
+    return true
+  end
   if type(val) == "string" then
     local n = tonumber(val)
     return n ~= nil and tostring(n) == val


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This refactors and combines the two merge_pr implementations into one function that uses gh.run. It supports both explicit PR numbers and merging from the current buffer. Flag handling (like merge method, delete, queue) is now cleaner and more predictable.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #875
Fixes #761

### Describe how you did it
Consolidated merge logic into one function

Replaced Job:new() with gh.run

Cleaned up flag parsing and PR number detection


### Describe how to verify it
Run any existing merge commands from a PR buffer (squash, rebase queue, etc.) and confirm they behave as expected.


### Special notes for reviews
PR number must either be passed or come from the buffer.

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
