### PR TITLE
fix(comment): normalize lines on reversed visual selection

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1854,7 +1854,10 @@ function M.get_lines_from_context(calling_context)
     and line_number_end > 0
     and line_number_start > line_number_end
   then
-    line_number_start, line_number_end = line_number_end, line_number_start
+    -- Swap with temp var to please typing.
+    local temp = line_number_start
+    line_number_start = line_number_end
+    line_number_end = temp
   end
   return line_number_start, line_number_end
 end

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1843,6 +1843,10 @@ function M.get_lines_from_context(calling_context)
     line_number_start = vim.fn.getpos("'[")[2]
     line_number_end = vim.fn.getpos("']")[2]
   end
+  -- Ensure line_number_start is always <= line_number_end
+  if line_number_start and line_number_end and line_number_start > line_number_end then
+    line_number_start, line_number_end = line_number_end, line_number_start
+  end
   return line_number_start, line_number_end
 end
 

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1843,8 +1843,14 @@ function M.get_lines_from_context(calling_context)
     line_number_start = vim.fn.getpos("'[")[2]
     line_number_end = vim.fn.getpos("']")[2]
   end
-  -- Ensure line_number_start is always <= line_number_end
-  if line_number_start and line_number_end and line_number_start > line_number_end then
+  -- Ensure line_number_start is always <= line_number_end (only for valid line numbers)
+  if
+    line_number_start
+    and line_number_end
+    and line_number_start > 0
+    and line_number_end > 0
+    and line_number_start > line_number_end
+  then
     line_number_start, line_number_end = line_number_end, line_number_start
   end
   return line_number_start, line_number_end

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1830,8 +1830,11 @@ end
 
 ---Returns the starting and ending lines to be commented based on the calling context.
 ---@param calling_context "line" | "visual" | "motion"
+---@return integer|nil, integer|nil
 function M.get_lines_from_context(calling_context)
+  ---@type integer|nil
   local line_number_start = nil
+  ---@type integer|nil
   local line_number_end = nil
   if calling_context == "line" then
     line_number_start = vim.fn.line "."


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

## Describe what this PR does / why we need it

Fixes a bug where PR review comments on visual selections fail when selecting text from bottom to top. 

When selecting code from bottom to top (e.g., starting at line 10 and selecting up to line 8), the comment creation would:
- Show an empty snippet in the comment buffer
- Display reversed line numbers (10:8 instead of 8:10)  
- Fail with an error when attempting to save: `attempt to index field 'thread' (a userdata value)`

## Does this pull request fix one issue?

Fixes https://github.com/pwntester/octo.nvim/issues/476.

## Describe how you did it

The issue was that `utils.get_lines_from_context()` returned line numbers in the order they were selected, not normalized. When selecting bottom-to-top, this resulted in `line_start > line_end`, breaking downstream code that expects normalized ranges.

Added a simple swap in `lua/octo/utils.lua` to ensure `line_number_start <= line_number_end` regardless of selection direction.

## Describe how to verify it

1. Open a PR review with `:Octo pr edit <number>`
     - Example: https://github.com/kfpotts1/test_octo_diffs/pull/3
2. Start a review
3. In diff view select multiple lines from **bottom to top** using visual mode
4. Press `<localleader>ca` to add a comment
5. Verify the snippet shows correctly with proper line numbers
6. Add a comment and save - should work without errors

## Demo
### Before
<img width="916" height="229" alt="before_comment_lines" src="https://github.com/user-attachments/assets/0a189a12-b7b4-4d67-8fbc-4bac32b2e111" />

### After
<img width="912" height="260" alt="after_comment_lines" src="https://github.com/user-attachments/assets/148bd52c-1cb5-48d1-b650-ab96721adbfc" />

## Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt (not needed - bug fix only)
