### PR TITLE
feat(review): prefetch contents from all files in a review

### DIFF
--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -175,8 +175,11 @@ function Review:set_files_and_select_first(files)
 
   self.layout.files = files
   if selected_file_idx then
-    files[selected_file_idx]:fetch()
+    files[selected_file_idx]:fetch(true)
     self.layout.selected_file_idx = selected_file_idx
+  end
+  for _, file in ipairs(files) do
+    file:fetch(false)
   end
   self.layout:update_files()
 end

--- a/lua/octo/reviews/layout.lua
+++ b/lua/octo/reviews/layout.lua
@@ -121,7 +121,7 @@ function Layout:set_current_file(file, focus)
   end
   if found then
     if not file:is_ready_to_render() then
-      local result = file:fetch()
+      local result = file:fetch(true)
       if not result then
         utils.print_err("Timeout fetching " .. file.path)
         return


### PR DESCRIPTION
### Describe what this PR does / why we need it

When going between files in a review, you have to wait for the query to finish for the file contents since it is UI blocking. With this PR, all files in a review are fetched preemptively. For simplicity, when the file is opened, if it is still loading, we block the ui as we did before.
