### PR TITLE
fix(pr/issue): handle trailing accumulated timeline events

### DIFF
--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -211,33 +211,37 @@ function OctoBuffer:render_issue()
   --- labeled/unlabeled events or subissues events are rendered
   table.insert(timeline_nodes, {})
 
-  for _, item in ipairs(timeline_nodes) do
-    if item.__typename ~= "LabeledEvent" and #unrendered_labeled_events > 0 then
+  ---@param item? octo.PullRequestTimelineItem|octo.IssueTimelineItem
+  local function render_accumulated_events(item)
+    if (not item or item.__typename ~= "LabeledEvent") and #unrendered_labeled_events > 0 then
       writers.write_labeled_events(self.bufnr, unrendered_labeled_events, "added")
       unrendered_labeled_events = {}
       prev_is_event = true
     end
-    if item.__typename ~= "UnlabeledEvent" and #unrendered_unlabeled_events > 0 then
+    if (not item or item.__typename ~= "UnlabeledEvent") and #unrendered_unlabeled_events > 0 then
       writers.write_labeled_events(self.bufnr, unrendered_unlabeled_events, "removed")
       unrendered_unlabeled_events = {}
       prev_is_event = true
     end
-    if item.__typename ~= "SubIssueAddedEvent" and #unrendered_subissue_added_events > 0 then
+    if (not item or item.__typename ~= "SubIssueAddedEvent") and #unrendered_subissue_added_events > 0 then
       writers.write_subissue_events(self.bufnr, unrendered_subissue_added_events, "added")
       unrendered_subissue_added_events = {}
       prev_is_event = true
     end
-    if item.__typename ~= "SubIssueRemovedEvent" and #unrendered_subissue_removed_events > 0 then
+    if (not item or item.__typename ~= "SubIssueRemovedEvent") and #unrendered_subissue_removed_events > 0 then
       writers.write_subissue_events(self.bufnr, unrendered_subissue_removed_events, "removed")
       unrendered_subissue_removed_events = {}
       prev_is_event = true
     end
-    if item.__typename ~= "PullRequestCommit" and #commits > 0 then
+    if (not item or item.__typename ~= "PullRequestCommit") and #commits > 0 then
       writers.write_commits(self.bufnr, commits)
       commits = {}
       prev_is_event = true
     end
+  end
 
+  for _, item in ipairs(timeline_nodes) do
+    render_accumulated_events(item)
     if item.__typename == "IssueComment" then
       if prev_is_event then
         writers.write_block(self.bufnr, { "" })
@@ -351,6 +355,7 @@ function OctoBuffer:render_issue()
       prev_is_event = true
     end
   end
+  render_accumulated_events()
 
   if prev_is_event then
     writers.write_block(self.bufnr, { "" })


### PR DESCRIPTION
### Describe what this PR does / why we need it

Accumulated events would not show up if they were the last events fetched. In this PR we make sure to "finalize" the accumulated events by treating a "nil" event as the marker that the events finished. Moved the accumulated events logic to its own function to simplify this.
