### PR TITLE
docs: add aside concerning ssh aliases when getting unauthenticated errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ GITHUB_TOKEN= gh auth login
 
 `gh` must store the credentials so it can work in a subshell.
 
-ALSO:
+**Why am I getting authentication error from gh? Part 2**
 
 It is possible that Octo is trying to authenticate against the origin listed in your repository's config (.git/config) which _could be_ an _ssh alias_ to _github.com_. To properly let octo.nvim know about the ssh alias, you need to list it in the config per above. Example:
 ```lua

--- a/README.md
+++ b/README.md
@@ -694,7 +694,7 @@ GITHUB_TOKEN= gh auth login
 ALSO:
 
 It is possible that Octo is trying to authenticate against the origin listed in your repository's config (.git/config) which _could be_ an _ssh alias_ to _github.com_. To properly let octo.nvim know about the ssh alias, you need to list it in the config per above. Example:
-```
+```lua
 require('octo').setup({
   ssh_aliases = {["<THE ALIAS YOU HAVE LISTED IN ~/.ssh/config>"] = "github.com"}
 })

--- a/README.md
+++ b/README.md
@@ -691,6 +691,15 @@ GITHUB_TOKEN= gh auth login
 
 `gh` must store the credentials so it can work in a subshell.
 
+ALSO:
+
+It is possible that Octo is trying to authenticate against the origin listed in your repository's config (.git/config) which _could be_ an _ssh alias_ to _github.com_. To properly let octo.nvim know about the ssh alias, you need to list it in the config per above. Example:
+```
+require('octo').setup({
+  ssh_aliases = {["<THE ALIAS YOU HAVE LISTED IN ~/.ssh/config>"] = "github.com"}
+})
+```
+
 **Can I use treesitter markdown parser with octo buffers?**
 
 Just add the following lines to your TreeSitter config:


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This PR adds a note to the README concerning possibly running into authentication errors that I experienced not fully understanding the need to add ssh aliases to the setup config.

### Does this pull request fix one issue?
I didn't create an issue 🤷‍♂️. It felt easier just to update the README since I wasn't making any code changes. If you need me to, just let me know.

"NONE"

### Describe how you did it
I forked the repo, cloned locally, checked out my branch, and typed in the addition.

### Describe how to verify it
The creator should verify whether this is correct.

### Special notes for reviews
Thanks for creating this project. Haven't gotten to fully use it yet, but it looks awesome.

Didn't change any code so I did not run any tests or linters.

### Checklist

- [ ] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
