### PR TITLE
fix: review commits mapping not providing callback

### DIFF
--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -22,7 +22,13 @@ return {
     require("octo.picker").commits()
   end,
   review_commits = function()
-    require("octo.picker").review_commits()
+    local current_review = reviews.get_current_review()
+    if not current_review then
+      return
+    end
+    require("octo.picker").review_commits(function(right, left)
+      current_review:focus_commit(right, left)
+    end)
   end,
   list_changed_files = function()
     require("octo.picker").changed_files()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

A small issue was missed in https://github.com/pwntester/octo.nvim/pull/1122 where the new `<localleader>C` mapping to invoke the `review_commits` command doesn't pass in the appropriate `callback` function needed to display the selected commit from the picker. 

The existing `Octo review commit` command already handles this correctly, so I just copied over the same code to the `review_commits` mapping.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #1169

### Describe how you did it

Just looked at the traceback in #1169 and figured out that the `callback` argument wasn't getting provided.

### Describe how to verify it

Open up a review at execute the `<localleader>C` mapping to verify it works now.

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
