### PR TITLE
fix: set buftype=nofile for left buffer

### DIFF
--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -317,6 +317,9 @@ function FileEntry:load_buffers(left_winid, right_winid)
     vim.api.nvim_win_set_buf(split.winid, split.bufid)
   end
 
+  -- Set this to disable LSPs from attempting to attach to this buffer
+  vim.api.nvim_set_option_value("buftype", "nofile", { buf = self.left_bufid })
+
   -- show thread signs and virtual text
   self:place_signs()
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Some LSPs will attempt to attach to the left buffer when doing a review.

For example, `ruff` will fail to attach since the left buffer isn't a real file and it will continually print out this warning message:

```
Client ruff quit with exit code 2 and signal 0. Check log for errors
```

To prevent LSPs from attaching to the left buffer, we can set the `buftype` option to `nofile` so LSPs won't attempt to attach to this buffer, since no LSP should be able to attach to it anyway.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

Set `buftype=nofile` for the left buffer

### Describe how to verify it

Open up a review and verify that your LSPs don't attach to the left buffer via `:LspInfo`. Also no warning messages should appear.

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
