### PR TITLE
refactor: use `gh.api.get` over `gh.run` for telescope pickers

### DIFF
--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -405,7 +405,7 @@ function M.commits()
 
   -- TODO: graphql
   gh.api.get {
-    "repos/{repo}/pulls/{number}/commits",
+    "/repos/{repo}/pulls/{number}/commits",
     format = { repo = buffer.repo, number = buffer.number },
     paginate = true,
     opts = {
@@ -513,7 +513,7 @@ function M.changed_files()
   end
 
   gh.api.get {
-    "repos/{repo}/pulls/{number}/files",
+    "/repos/{repo}/pulls/{number}/files",
     format = { repo = buffer.repo, number = buffer.number },
     paginate = true,
     opts = {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Migrate the last telescope commands

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
