### PR TITLE
fix: skip ProjectV2Events by config key default_to_projects_v2 (#1234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ require"octo".setup({
   gh_env = {},                             -- extra environment variables to pass on to GitHub CLI, can be a table or function returning a table
   timeout = 5000,                          -- timeout for requests between the remote server
   default_to_projects_v2 = false,          -- use projects v2 for the `Octo card ...` command by default. Both legacy and v2 commands are available under `Octo cardlegacy ...` and `Octo cardv2 ...` respectively.
+                                           -- Also disable sending v2 events into Github API.
   ui = {
     use_signcolumn = false,                -- show "modified" marks on the sign column
     use_signstatus = true,                 -- show "modified" marks on the status column

--- a/lua/octo/gh/fragments.lua
+++ b/lua/octo/gh/fragments.lua
@@ -1,24 +1,26 @@
+local config = require "octo.config"
 local M = {}
 
----@class octo.fragments.ProjectsV2Connection
----@field nodes {
----  id: string,
----  project: {
----    id: string,
----    title: string,
----  },
----  fieldValues: {
----    nodes: {
----      name: string,
----      optionId: string,
----      field: {
----        name: string,
----      },
----    }[],
----  },
----}[]
+M.setup = function()
+  ---@class octo.fragments.ProjectsV2Connection
+  ---@field nodes {
+  ---  id: string,
+  ---  project: {
+  ---    id: string,
+  ---    title: string,
+  ---  },
+  ---  fieldValues: {
+  ---    nodes: {
+  ---      name: string,
+  ---      optionId: string,
+  ---      field: {
+  ---        name: string,
+  ---      },
+  ---    }[],
+  ---  },
+  ---}[]
 
-M.projects_v2 = [[
+  M.projects_v2 = [[
   projectItems(first: 100) {
     nodes {
       id
@@ -43,15 +45,15 @@ M.projects_v2 = [[
   }
 ]]
 
----@class octo.fragments.Issue
---- @field __typename "Issue"
----@field id string
----@field number integer
----@field title string
----@field state string
----@field stateReason string
+  ---@class octo.fragments.Issue
+  ---@field __typename "Issue"
+  ---@field id string
+  ---@field number integer
+  ---@field title string
+  ---@field state string
+  ---@field stateReason string
 
-M.issue = [[
+  M.issue = [[
 fragment IssueFields on Issue {
   id
   number
@@ -61,14 +63,14 @@ fragment IssueFields on Issue {
 }
 ]]
 
----@class octo.fragments.PullRequest
---- @field __typename "PullRequest"
---- @field number integer
---- @field title string
---- @field state string
---- @field isDraft boolean
+  ---@class octo.fragments.PullRequest
+  --- @field __typename "PullRequest"
+  --- @field number integer
+  --- @field title string
+  --- @field state string
+  --- @field isDraft boolean
 
-M.pull_request = [[
+  M.pull_request = [[
 fragment PullRequestFields on PullRequest {
   number
   title
@@ -77,16 +79,16 @@ fragment PullRequestFields on PullRequest {
 }
 ]]
 
----https://docs.github.com/en/graphql/reference/objects#projectv2itemstatuschangedevent
----@class octo.fragments.ProjectV2ItemStatusChangedEvent
----@field __typename "ProjectV2ItemStatusChangedEvent"
----@field actor { login: string }
----@field createdAt string
----@field previousStatus string
----@field status string
----@field project { title: string }
+  ---https://docs.github.com/en/graphql/reference/objects#projectv2itemstatuschangedevent
+  ---@class octo.fragments.ProjectV2ItemStatusChangedEvent
+  ---@field __typename "ProjectV2ItemStatusChangedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field previousStatus string
+  ---@field status string
+  ---@field project { title: string }
 
-M.project_v2_item_status_changed_event = [[
+  M.project_v2_item_status_changed_event = [[
 fragment ProjectV2ItemStatusChangedEventFragment on ProjectV2ItemStatusChangedEvent {
   actor { login }
   createdAt
@@ -96,14 +98,14 @@ fragment ProjectV2ItemStatusChangedEventFragment on ProjectV2ItemStatusChangedEv
 }
 ]]
 
----https://docs.github.com/en/graphql/reference/objects#addedtoprojectv2event
----@class octo.fragments.AddedToProjectV2Event
----@field __typename "AddedToProjectV2Event"
----@field actor { login: string }
----@field createdAt string
----@field project { title: string }
+  ---https://docs.github.com/en/graphql/reference/objects#addedtoprojectv2event
+  ---@class octo.fragments.AddedToProjectV2Event
+  ---@field __typename "AddedToProjectV2Event"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field project { title: string }
 
-M.added_to_project_v2_event = [[
+  M.added_to_project_v2_event = [[
 fragment AddedToProjectV2EventFragment on AddedToProjectV2Event {
   actor { login }
   createdAt
@@ -111,14 +113,14 @@ fragment AddedToProjectV2EventFragment on AddedToProjectV2Event {
 }
 ]]
 
----https://docs.github.com/en/graphql/reference/objects#removedfromprojectv2event
----@class octo.fragments.RemovedFromProjectV2Event
----@field __typename "RemovedFromProjectV2Event"
----@field actor { login: string }
----@field createdAt string
----@field project { title: string }
+  ---https://docs.github.com/en/graphql/reference/objects#removedfromprojectv2event
+  ---@class octo.fragments.RemovedFromProjectV2Event
+  ---@field __typename "RemovedFromProjectV2Event"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field project { title: string }
 
-M.removed_from_project_v2_event = [[
+  M.removed_from_project_v2_event = [[
 fragment RemovedFromProjectV2EventFragment on RemovedFromProjectV2Event {
   actor { login }
   createdAt
@@ -126,27 +128,27 @@ fragment RemovedFromProjectV2EventFragment on RemovedFromProjectV2Event {
 }
 ]]
 
----https://docs.github.com/en/graphql/reference/objects#autosquashenabledevent
----@class octo.fragments.AutoSquashEnabledEvent
----@field __typename "AutoSquashEnabledEvent"
----@field actor { login: string }
----@field createdAt string
+  ---https://docs.github.com/en/graphql/reference/objects#autosquashenabledevent
+  ---@class octo.fragments.AutoSquashEnabledEvent
+  ---@field __typename "AutoSquashEnabledEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
 
-M.auto_squash_enabled_event = [[
+  M.auto_squash_enabled_event = [[
 fragment AutoSquashEnabledEventFragment on AutoSquashEnabledEvent {
   actor { login }
   createdAt
 }
 ]]
 
----https://docs.github.com/en/graphql/reference/objects#headrefdeletedevent
----@class octo.fragments.HeadRefDeletedEvent
----@field __typename "HeadRefDeletedEvent"
----@field actor { login: string }
----@field createdAt string
----@field headRefName string
+  ---https://docs.github.com/en/graphql/reference/objects#headrefdeletedevent
+  ---@class octo.fragments.HeadRefDeletedEvent
+  ---@field __typename "HeadRefDeletedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field headRefName string
 
-M.head_ref_deleted_event = [[
+  M.head_ref_deleted_event = [[
 fragment HeadRefDeletedEventFragment on HeadRefDeletedEvent {
   actor {
     login
@@ -156,14 +158,14 @@ fragment HeadRefDeletedEventFragment on HeadRefDeletedEvent {
 }
 ]]
 
----https://docs.github.com/en/graphql/reference/objects#headrefrestoredevent
----@class octo.fragments.HeadRefRestoredEvent
----@field __typename "HeadRefRestoredEvent"
----@field actor { login: string }
----@field createdAt string
----@field pullRequest { headRefName: string }
+  ---https://docs.github.com/en/graphql/reference/objects#headrefrestoredevent
+  ---@class octo.fragments.HeadRefRestoredEvent
+  ---@field __typename "HeadRefRestoredEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field pullRequest { headRefName: string }
 
-M.head_ref_restored_event = [[
+  M.head_ref_restored_event = [[
 fragment HeadRefRestoredEventFragment on HeadRefRestoredEvent {
   actor { login }
   createdAt
@@ -171,16 +173,16 @@ fragment HeadRefRestoredEventFragment on HeadRefRestoredEvent {
 }
 ]]
 
----https://docs.github.com/en/graphql/reference/objects#headrefforcepushedevent
----@class octo.fragments.HeadRefForcePushedEvent
----@field __typename "HeadRefForcePushedEvent"
----@field actor { login: string }
----@field pullRequest { headRefName: string }
----@field createdAt string
----@field beforeCommit { abbreviatedOid: string }
----@field afterCommit { abbreviatedOid: string }
+  ---https://docs.github.com/en/graphql/reference/objects#headrefforcepushedevent
+  ---@class octo.fragments.HeadRefForcePushedEvent
+  ---@field __typename "HeadRefForcePushedEvent"
+  ---@field actor { login: string }
+  ---@field pullRequest { headRefName: string }
+  ---@field createdAt string
+  ---@field beforeCommit { abbreviatedOid: string }
+  ---@field afterCommit { abbreviatedOid: string }
 
-M.head_ref_force_pushed_event = [[
+  M.head_ref_force_pushed_event = [[
 fragment HeadRefForcePushedEventFragment on HeadRefForcePushedEvent {
   actor { login }
   createdAt
@@ -190,15 +192,15 @@ fragment HeadRefForcePushedEventFragment on HeadRefForcePushedEvent {
 }
 ]]
 
----@class octo.fragments.ConnectedEvent
---- @field __typename "ConnectedEvent"
---- @field actor { login: string }
---- @field createdAt string
---- @field isCrossRepository boolean
---- @field source octo.fragments.Issue|octo.fragments.PullRequest
---- @field subject octo.fragments.Issue|octo.fragments.PullRequest
+  ---@class octo.fragments.ConnectedEvent
+  --- @field __typename "ConnectedEvent"
+  --- @field actor { login: string }
+  --- @field createdAt string
+  --- @field isCrossRepository boolean
+  --- @field source octo.fragments.Issue|octo.fragments.PullRequest
+  --- @field subject octo.fragments.Issue|octo.fragments.PullRequest
 
-M.connected_event = [[
+  M.connected_event = [[
 fragment ConnectedEventFragment on ConnectedEvent {
   actor { login }
   createdAt
@@ -216,12 +218,12 @@ fragment ConnectedEventFragment on ConnectedEvent {
 }
 ]]
 
----@class octo.fragments.ConvertToDraftEvent
----@field __typename "ConvertToDraftEvent"
----@field actor { login: string }
----@field createdAt string
+  ---@class octo.fragments.ConvertToDraftEvent
+  ---@field __typename "ConvertToDraftEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
 
-M.convert_to_draft_event = [[
+  M.convert_to_draft_event = [[
 fragment ConvertToDraftEventFragment on ConvertToDraftEvent {
   actor {
     login
@@ -230,20 +232,20 @@ fragment ConvertToDraftEventFragment on ConvertToDraftEvent {
 }
 ]]
 
----@class octo.fragments.ReferencedEvent
----@field __typename "ReferencedEvent"
----@field createdAt string
----@field actor { login: string }
----@field commit {
----  __typename: string,
----  abbreviatedOid: string,
----  message: string,
----  repository: {
----    nameWithOwner: string,
----  },
----}
+  ---@class octo.fragments.ReferencedEvent
+  ---@field __typename "ReferencedEvent"
+  ---@field createdAt string
+  ---@field actor { login: string }
+  ---@field commit {
+  ---  __typename: string,
+  ---  abbreviatedOid: string,
+  ---  message: string,
+  ---  repository: {
+  ---    nameWithOwner: string,
+  ---  },
+  ---}
 
-M.referenced_event = [[
+  M.referenced_event = [[
 fragment ReferencedEventFragment on ReferencedEvent {
   createdAt
   actor {
@@ -259,15 +261,15 @@ fragment ReferencedEventFragment on ReferencedEvent {
   }
 }
 ]]
----@class octo.fragments.CrossReferencedEvent
----@field __typename "CrossReferencedEvent"
----@field actor { login: string }
----@field createdAt string
----@field willCloseTarget boolean
----@field source octo.fragments.Issue|octo.fragments.PullRequest
----@field target octo.fragments.Issue|octo.fragments.PullRequest
+  ---@class octo.fragments.CrossReferencedEvent
+  ---@field __typename "CrossReferencedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field willCloseTarget boolean
+  ---@field source octo.fragments.Issue|octo.fragments.PullRequest
+  ---@field target octo.fragments.Issue|octo.fragments.PullRequest
 
-M.cross_referenced_event = [[
+  M.cross_referenced_event = [[
 fragment CrossReferencedEventFragment on CrossReferencedEvent {
   createdAt
   actor { login }
@@ -285,26 +287,26 @@ fragment CrossReferencedEventFragment on CrossReferencedEvent {
 }
 ]]
 
----@class octo.fragments.MilestonedEvent
----@field __typename "MilestonedEvent"
----@field actor { login: string }
----@field createdAt string
----@field milestoneTitle string
+  ---@class octo.fragments.MilestonedEvent
+  ---@field __typename "MilestonedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field milestoneTitle string
 
-M.milestoned_event = [[
+  M.milestoned_event = [[
 fragment MilestonedEventFragment on MilestonedEvent {
   actor { login }
   createdAt
   milestoneTitle
 }
 ]]
----@class octo.fragments.DemilestonedEvent
----@field __typename "DemilestonedEvent"
----@field actor { login: string }
----@field createdAt string
----@field milestoneTitle string
+  ---@class octo.fragments.DemilestonedEvent
+  ---@field __typename "DemilestonedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field milestoneTitle string
 
-M.demilestoned_event = [[
+  M.demilestoned_event = [[
 fragment DemilestonedEventFragment on DemilestonedEvent {
   actor { login }
   createdAt
@@ -312,15 +314,15 @@ fragment DemilestonedEventFragment on DemilestonedEvent {
 }
 ]]
 
----@class octo.ReactionGroupsFragment.reactionGroups
---- @field content string
---- @field viewerHasReacted boolean
---- @field users { totalCount: number }
+  ---@class octo.ReactionGroupsFragment.reactionGroups
+  --- @field content string
+  --- @field viewerHasReacted boolean
+  --- @field users { totalCount: number }
 
----@class octo.ReactionGroupsFragment
---- @field reactionGroups octo.ReactionGroupsFragment.reactionGroups[]
+  ---@class octo.ReactionGroupsFragment
+  --- @field reactionGroups octo.ReactionGroupsFragment.reactionGroups[]
 
-M.reaction_groups = [[
+  M.reaction_groups = [[
 fragment ReactionGroupsFragment on Reactable {
   reactionGroups {
     content
@@ -331,15 +333,15 @@ fragment ReactionGroupsFragment on Reactable {
   }
 }
 ]]
----@class octo.fragments.ReactionGroupsUsers
----@field reactionGroups {
----  content: string,
----  users: {
----    nodes: { login: string }[],
----  },
----}[]
+  ---@class octo.fragments.ReactionGroupsUsers
+  ---@field reactionGroups {
+  ---  content: string,
+  ---  users: {
+  ---    nodes: { login: string }[],
+  ---  },
+  ---}[]
 
-M.reaction_groups_users = [[
+  M.reaction_groups_users = [[
 fragment ReactionGroupsUsersFragment on Reactable {
   reactionGroups {
     content
@@ -351,32 +353,32 @@ fragment ReactionGroupsUsersFragment on Reactable {
   }
 }
 ]]
----@class octo.fragments.Label
----@field id string
----@field name string
----@field color string
+  ---@class octo.fragments.Label
+  ---@field id string
+  ---@field name string
+  ---@field color string
 
-M.label = [[
+  M.label = [[
 fragment LabelFragment on Label {
   id
   name
   color
 }
 ]]
----@class octo.fragments.LabelConnection
----@field nodes octo.fragments.Label[]
+  ---@class octo.fragments.LabelConnection
+  ---@field nodes octo.fragments.Label[]
 
-M.label_connection = [[
+  M.label_connection = [[
 fragment LabelConnectionFragment on LabelConnection {
   nodes {
     ...LabelFragment
   }
 }
 ]]
----@class octo.fragments.AssigneeConnection
----@field nodes { id: string, login: string, isViewer: boolean }[]
+  ---@class octo.fragments.AssigneeConnection
+  ---@field nodes { id: string, login: string, isViewer: boolean }[]
 
-M.assignee_connection = [[
+  M.assignee_connection = [[
 fragment AssigneeConnectionFragment on UserConnection {
   nodes {
     id
@@ -386,17 +388,17 @@ fragment AssigneeConnectionFragment on UserConnection {
 }
 ]]
 
----@class octo.fragments.IssueComment : octo.ReactionGroupsFragment
----@field __typename "IssueComment"
----@field id string
----@field body string
----@field createdAt string
----@field author { login: string }
----@field viewerDidAuthor boolean
----@field viewerCanUpdate boolean
----@field viewerCanDelete boolean
+  ---@class octo.fragments.IssueComment : octo.ReactionGroupsFragment
+  ---@field __typename "IssueComment"
+  ---@field id string
+  ---@field body string
+  ---@field createdAt string
+  ---@field author { login: string }
+  ---@field viewerDidAuthor boolean
+  ---@field viewerCanUpdate boolean
+  ---@field viewerCanDelete boolean
 
-M.issue_comment = [[
+  M.issue_comment = [[
 fragment IssueCommentFragment on IssueComment {
   id
   body
@@ -410,13 +412,13 @@ fragment IssueCommentFragment on IssueComment {
   viewerCanDelete
 }
 ]]
----@class octo.fragments.AssignedEvent
----@field __typename "AssignedEvent"
----@field actor { login: string }
----@field assignee { name?: string, login?: string, isViewer?: boolean }
----@field createdAt string
+  ---@class octo.fragments.AssignedEvent
+  ---@field __typename "AssignedEvent"
+  ---@field actor { login: string }
+  ---@field assignee { name?: string, login?: string, isViewer?: boolean }
+  ---@field createdAt string
 
-M.assigned_event = [[
+  M.assigned_event = [[
 fragment AssignedEventFragment on AssignedEvent {
   actor {
     login
@@ -434,13 +436,13 @@ fragment AssignedEventFragment on AssignedEvent {
 }
 ]]
 
----@class octo.fragments.LabeledEvent
----@field __typename "LabeledEvent"
----@field actor { login: string }
----@field createdAt string
----@field label octo.fragments.Label
+  ---@class octo.fragments.LabeledEvent
+  ---@field __typename "LabeledEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field label octo.fragments.Label
 
-M.labeled_event = [[
+  M.labeled_event = [[
 fragment LabeledEventFragment on LabeledEvent {
   actor {
     login
@@ -452,13 +454,13 @@ fragment LabeledEventFragment on LabeledEvent {
 }
 ]]
 
----@class octo.fragments.UnlabeledEvent
----@field __typename "UnlabeledEvent"
----@field actor { login: string }
----@field createdAt string
----@field label octo.fragments.Label
+  ---@class octo.fragments.UnlabeledEvent
+  ---@field __typename "UnlabeledEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field label octo.fragments.Label
 
-M.unlabeled_event = [[
+  M.unlabeled_event = [[
 fragment UnlabeledEventFragment on UnlabeledEvent {
   actor {
     login
@@ -469,14 +471,14 @@ fragment UnlabeledEventFragment on UnlabeledEvent {
   }
 }
 ]]
----@class octo.fragments.ClosedEvent
----@field __typename "ClosedEvent"
----@field actor { login: string }
----@field createdAt string
----@field stateReason string
----@field closable { __typename: string, state: string, stateReason?: string }
+  ---@class octo.fragments.ClosedEvent
+  ---@field __typename "ClosedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field stateReason string
+  ---@field closable { __typename: string, state: string, stateReason?: string }
 
-M.closed_event = [[
+  M.closed_event = [[
 fragment ClosedEventFragment on ClosedEvent {
   actor {
     login
@@ -496,12 +498,12 @@ fragment ClosedEventFragment on ClosedEvent {
 }
 ]]
 
----@class octo.fragments.ReopenedEvent
----@field __typename "ReopenedEvent"
----@field actor { login: string }
----@field createdAt string
+  ---@class octo.fragments.ReopenedEvent
+  ---@field __typename "ReopenedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
 
-M.reopened_event = [[
+  M.reopened_event = [[
 fragment ReopenedEventFragment on ReopenedEvent {
   actor {
     login
@@ -509,39 +511,39 @@ fragment ReopenedEventFragment on ReopenedEvent {
   createdAt
 }
 ]]
----@class octo.fragments.PullRequestReview.comment : octo.ReactionGroupsFragment
----@field id string
----@field url string
----@field replyTo { id: string, url: string }
----@field body string
----@field commit { oid: string, abbreviatedOid: string }
----@field author { login: string }
----@field authorAssociation string
----@field viewerDidAuthor boolean
----@field viewerCanUpdate boolean
----@field viewerCanDelete boolean
----@field originalPosition integer
----@field position integer
----@field state string
----@field outdated boolean
----@field diffHunk string
+  ---@class octo.fragments.PullRequestReview.comment : octo.ReactionGroupsFragment
+  ---@field id string
+  ---@field url string
+  ---@field replyTo { id: string, url: string }
+  ---@field body string
+  ---@field commit { oid: string, abbreviatedOid: string }
+  ---@field author { login: string }
+  ---@field authorAssociation string
+  ---@field viewerDidAuthor boolean
+  ---@field viewerCanUpdate boolean
+  ---@field viewerCanDelete boolean
+  ---@field originalPosition integer
+  ---@field position integer
+  ---@field state string
+  ---@field outdated boolean
+  ---@field diffHunk string
 
----@class octo.fragments.PullRequestReview : octo.ReactionGroupsFragment
----@field __typename "PullRequestReview"
----@field id string
----@field body string
----@field createdAt string
----@field viewerCanUpdate boolean
----@field viewerCanDelete boolean
----@field author { login: string }
----@field viewerDidAuthor boolean
----@field state string
----@field comments {
----  totalCount: integer,
----  nodes: octo.fragments.PullRequestReview.comment[],
----}
+  ---@class octo.fragments.PullRequestReview : octo.ReactionGroupsFragment
+  ---@field __typename "PullRequestReview"
+  ---@field id string
+  ---@field body string
+  ---@field createdAt string
+  ---@field viewerCanUpdate boolean
+  ---@field viewerCanDelete boolean
+  ---@field author { login: string }
+  ---@field viewerDidAuthor boolean
+  ---@field state string
+  ---@field comments {
+  ---  totalCount: integer,
+  ---  nodes: octo.fragments.PullRequestReview.comment[],
+  ---}
 
-M.pull_request_review = [[
+  M.pull_request_review = [[
 fragment PullRequestReviewFragment on PullRequestReview {
   id
   body
@@ -580,13 +582,13 @@ fragment PullRequestReviewFragment on PullRequestReview {
   }
 }
 ]]
----@class octo.fragments.ProjectCard
----@field id string
----@field note string
----@field state string
----@field column { id: string, name: string }
+  ---@class octo.fragments.ProjectCard
+  ---@field id string
+  ---@field note string
+  ---@field state string
+  ---@field column { id: string, name: string }
 
-M.project_cards = [[
+  M.project_cards = [[
 fragment ProjectCardFragment on ProjectCard {
   id
   note
@@ -597,22 +599,22 @@ fragment ProjectCardFragment on ProjectCard {
   }
 }
 ]]
----@class octo.fragments.PullRequestCommit
----@field __typename "PullRequestCommit"
----@field commit {
----  messageHeadline: string,
----  committedDate: string,
----  oid: string,
----  abbreviatedOid: string,
----  changedFiles: integer,
----  additions: integer,
----  deletions: integer,
----  author: { user: { login: string } },
----  statusCheckRollup: { state: string },
----  committer: { user: { login: string } },
----}
+  ---@class octo.fragments.PullRequestCommit
+  ---@field __typename "PullRequestCommit"
+  ---@field commit {
+  ---  messageHeadline: string,
+  ---  committedDate: string,
+  ---  oid: string,
+  ---  abbreviatedOid: string,
+  ---  changedFiles: integer,
+  ---  additions: integer,
+  ---  deletions: integer,
+  ---  author: { user: { login: string } },
+  ---  statusCheckRollup: { state: string },
+  ---  committer: { user: { login: string } },
+  ---}
 
-M.pull_request_commit = [[
+  M.pull_request_commit = [[
 fragment PullRequestCommitFragment on PullRequestCommit {
   commit {
     messageHeadline
@@ -639,17 +641,17 @@ fragment PullRequestCommitFragment on PullRequestCommit {
 }
 ]]
 
----@class octo.fragments.ReviewRequestRemovedEvent
----@field __typename "ReviewRequestRemovedEvent"
----@field createdAt string
----@field actor { login: string }
----@field requestedReviewer {
----  login?: string,
----  isViewer?: boolean,
----  name?: string,
----}
+  ---@class octo.fragments.ReviewRequestRemovedEvent
+  ---@field __typename "ReviewRequestRemovedEvent"
+  ---@field createdAt string
+  ---@field actor { login: string }
+  ---@field requestedReviewer {
+  ---  login?: string,
+  ---  isViewer?: boolean,
+  ---  name?: string,
+  ---}
 
-M.review_request_removed_event = [[
+  M.review_request_removed_event = [[
 fragment ReviewRequestRemovedEventFragment on ReviewRequestRemovedEvent {
   createdAt
   actor {
@@ -670,16 +672,16 @@ fragment ReviewRequestRemovedEventFragment on ReviewRequestRemovedEvent {
 }
 ]]
 
----https://docs.github.com/en/graphql/reference/enums#deploymentstatusstate
----@alias DeploymentState "ABANDONED" | "ACTIVE" | "DESTROYED" | "ERROR" | "FAILURE" | "INACTIVE" | "IN_PROGRESS" | "PENDING" | "QUEUED" | "SUCCESS" | "WAITING"
+  ---https://docs.github.com/en/graphql/reference/enums#deploymentstatusstate
+  ---@alias DeploymentState "ABANDONED" | "ACTIVE" | "DESTROYED" | "ERROR" | "FAILURE" | "INACTIVE" | "IN_PROGRESS" | "PENDING" | "QUEUED" | "SUCCESS" | "WAITING"
 
----@class octo.fragments.DeployedEvent
----@field __typename "DeployedEvent"
----@field createdAt string
----@field actor { login: string }
----@field deployment { environment: string, state: DeploymentState }
+  ---@class octo.fragments.DeployedEvent
+  ---@field __typename "DeployedEvent"
+  ---@field createdAt string
+  ---@field actor { login: string }
+  ---@field deployment { environment: string, state: DeploymentState }
 
-M.deployed_event = [[
+  M.deployed_event = [[
 fragment DeployedEventFragment on DeployedEvent {
   actor { login }
   createdAt
@@ -690,17 +692,17 @@ fragment DeployedEventFragment on DeployedEvent {
 }
 ]]
 
----@class octo.fragments.ReviewRequestedEvent
----@field __typename "ReviewRequestedEvent"
----@field createdAt string
----@field actor { login: string }
----@field requestedReviewer {
----  login?: string,
----  isViewer?: boolean,
----  name?: string,
----}
+  ---@class octo.fragments.ReviewRequestedEvent
+  ---@field __typename "ReviewRequestedEvent"
+  ---@field createdAt string
+  ---@field actor { login: string }
+  ---@field requestedReviewer {
+  ---  login?: string,
+  ---  isViewer?: boolean,
+  ---  name?: string,
+  ---}
 
-M.review_requested_event = [[
+  M.review_requested_event = [[
 fragment ReviewRequestedEventFragment on ReviewRequestedEvent {
   createdAt
   actor {
@@ -718,14 +720,14 @@ fragment ReviewRequestedEventFragment on ReviewRequestedEvent {
 }
 ]]
 
----@class octo.fragments.MergedEvent
----@field __typename "MergedEvent"
----@field createdAt string
----@field actor { login: string }
----@field commit { oid: string, abbreviatedOid: string }
----@field mergeRefName string
+  ---@class octo.fragments.MergedEvent
+  ---@field __typename "MergedEvent"
+  ---@field createdAt string
+  ---@field actor { login: string }
+  ---@field commit { oid: string, abbreviatedOid: string }
+  ---@field mergeRefName string
 
-M.merged_event = [[
+  M.merged_event = [[
 fragment MergedEventFragment on MergedEvent {
   createdAt
   actor {
@@ -739,12 +741,12 @@ fragment MergedEventFragment on MergedEvent {
 }
 ]]
 
----@class octo.fragments.ReadyForReviewEvent
----@field __typename "ReadyForReviewEvent"
----@field actor { login: string }
----@field createdAt string
+  ---@class octo.fragments.ReadyForReviewEvent
+  ---@field __typename "ReadyForReviewEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
 
-M.ready_for_review_event = [[
+  M.ready_for_review_event = [[
 fragment ReadyForReviewEventFragment on ReadyForReviewEvent {
   actor {
     login
@@ -753,14 +755,14 @@ fragment ReadyForReviewEventFragment on ReadyForReviewEvent {
 }
 ]]
 
----@class octo.fragments.RenamedTitleEvent
----@field __typename "RenamedTitleEvent"
----@field actor { login: string }
----@field createdAt string
----@field previousTitle string
----@field currentTitle string
+  ---@class octo.fragments.RenamedTitleEvent
+  ---@field __typename "RenamedTitleEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field previousTitle string
+  ---@field currentTitle string
 
-M.renamed_title_event = [[
+  M.renamed_title_event = [[
 fragment RenamedTitleEventFragment on RenamedTitleEvent {
   actor { login }
   createdAt
@@ -769,13 +771,13 @@ fragment RenamedTitleEventFragment on RenamedTitleEvent {
 }
 ]]
 
----@class octo.fragments.ReviewDismissedEvent
----@field __typename "ReviewDismissedEvent"
----@field createdAt string
----@field actor { login: string }
----@field dismissalMessage string
+  ---@class octo.fragments.ReviewDismissedEvent
+  ---@field __typename "ReviewDismissedEvent"
+  ---@field createdAt string
+  ---@field actor { login: string }
+  ---@field dismissalMessage string
 
-M.review_dismissed_event = [[
+  M.review_dismissed_event = [[
 fragment ReviewDismissedEventFragment on ReviewDismissedEvent {
   createdAt
   actor {
@@ -785,12 +787,12 @@ fragment ReviewDismissedEventFragment on ReviewDismissedEvent {
 }
 ]]
 
----@class octo.fragments.PinnedEvent
----@field __typename "PinnedEvent"
----@field actor { login: string }
----@field createdAt string
+  ---@class octo.fragments.PinnedEvent
+  ---@field __typename "PinnedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
 
-M.pinned_event = [[
+  M.pinned_event = [[
 fragment PinnedEventFragment on PinnedEvent {
   actor {
     login
@@ -799,12 +801,12 @@ fragment PinnedEventFragment on PinnedEvent {
 }
 ]]
 
----@class octo.fragments.UnpinnedEvent
----@field __typename "UnpinnedEvent"
----@field actor { login: string }
----@field createdAt string
+  ---@class octo.fragments.UnpinnedEvent
+  ---@field __typename "UnpinnedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
 
-M.unpinned_event = [[
+  M.unpinned_event = [[
 fragment UnpinnedEventFragment on UnpinnedEvent {
   actor {
     login
@@ -813,13 +815,13 @@ fragment UnpinnedEventFragment on UnpinnedEvent {
 }
 ]]
 
----@class octo.fragments.SubIssueAddedEvent
----@field __typename "SubIssueAddedEvent"
----@field actor { login: string }
----@field createdAt string
----@field subIssue {}
+  ---@class octo.fragments.SubIssueAddedEvent
+  ---@field __typename "SubIssueAddedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field subIssue {}
 
-M.subissue_added_event = [[
+  M.subissue_added_event = [[
 fragment SubIssueAddedEventFragment on SubIssueAddedEvent {
   actor {
     login
@@ -831,13 +833,13 @@ fragment SubIssueAddedEventFragment on SubIssueAddedEvent {
 }
 ]]
 
----@class octo.fragments.SubIssueRemovedEvent
----@field __typename "SubIssueRemovedEvent"
----@field actor { login: string }
----@field createdAt string
----@field subIssue {}
+  ---@class octo.fragments.SubIssueRemovedEvent
+  ---@field __typename "SubIssueRemovedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field subIssue {}
 
-M.subissue_removed_event = [[
+  M.subissue_removed_event = [[
 fragment SubIssueRemovedEventFragment on SubIssueRemovedEvent {
   actor {
     login
@@ -849,13 +851,13 @@ fragment SubIssueRemovedEventFragment on SubIssueRemovedEvent {
 }
 ]]
 
----@class octo.fragments.ParentIssueAddedEvent
----@field __typename "ParentIssueAddedEvent"
----@field actor { login: string }
----@field createdAt string
----@field parent {}
+  ---@class octo.fragments.ParentIssueAddedEvent
+  ---@field __typename "ParentIssueAddedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field parent {}
 
-M.parent_issue_added_event = [[
+  M.parent_issue_added_event = [[
 fragment ParentIssueAddedEventFragment on ParentIssueAddedEvent {
   actor {
     login
@@ -867,13 +869,13 @@ fragment ParentIssueAddedEventFragment on ParentIssueAddedEvent {
 }
 ]]
 
----@class octo.fragments.ParentIssueRemovedEvent
----@field __typename "ParentIssueRemovedEvent"
----@field actor { login: string }
----@field createdAt string
----@field parent {}
+  ---@class octo.fragments.ParentIssueRemovedEvent
+  ---@field __typename "ParentIssueRemovedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field parent {}
 
-M.parent_issue_removed_event = [[
+  M.parent_issue_removed_event = [[
 fragment ParentIssueRemovedEventFragment on ParentIssueRemovedEvent {
   actor {
     login
@@ -884,13 +886,13 @@ fragment ParentIssueRemovedEventFragment on ParentIssueRemovedEvent {
   }
 }
 ]]
----@class octo.fragments.IssueTypeAddedEvent
----@field __typename "IssueTypeAddedEvent"
----@field actor { login: string }
----@field createdAt string
----@field issueType { id: string, name: string, color: string }
+  ---@class octo.fragments.IssueTypeAddedEvent
+  ---@field __typename "IssueTypeAddedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field issueType { id: string, name: string, color: string }
 
-M.issue_type_added_event = [[
+  M.issue_type_added_event = [[
 fragment IssueTypeAddedEventFragment on IssueTypeAddedEvent {
   actor {
     login
@@ -903,13 +905,13 @@ fragment IssueTypeAddedEventFragment on IssueTypeAddedEvent {
   }
 }
 ]]
----@class octo.fragments.IssueTypeRemovedEvent
----@field __typename "IssueTypeRemovedEvent"
----@field actor { login: string }
----@field createdAt string
----@field issueType { id: string, name: string, color: string }
+  ---@class octo.fragments.IssueTypeRemovedEvent
+  ---@field __typename "IssueTypeRemovedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field issueType { id: string, name: string, color: string }
 
-M.issue_type_removed_event = [[
+  M.issue_type_removed_event = [[
 fragment IssueTypeRemovedEventFragment on IssueTypeRemovedEvent {
   actor {
     login
@@ -922,14 +924,14 @@ fragment IssueTypeRemovedEventFragment on IssueTypeRemovedEvent {
   }
 }
 ]]
----@class octo.fragments.IssueTypeChangedEvent
----@field __typename "IssueTypeChangedEvent"
----@field actor { login: string }
----@field createdAt string
----@field prevIssueType { id: string, name: string, color: string }
----@field issueType { id: string, name: string, color: string }
+  ---@class octo.fragments.IssueTypeChangedEvent
+  ---@field __typename "IssueTypeChangedEvent"
+  ---@field actor { login: string }
+  ---@field createdAt string
+  ---@field prevIssueType { id: string, name: string, color: string }
+  ---@field issueType { id: string, name: string, color: string }
 
-M.issue_type_changed_event = [[
+  M.issue_type_changed_event = [[
 fragment IssueTypeChangedEventFragment on IssueTypeChangedEvent {
   actor {
     login
@@ -947,14 +949,8 @@ fragment IssueTypeChangedEventFragment on IssueTypeChangedEvent {
   }
 }
 ]]
----@alias octo.IssueTimelineItem octo.fragments.AssignedEvent|octo.fragments.ClosedEvent|octo.fragments.ConnectedEvent|octo.fragments.ReferencedEvent|octo.fragments.CrossReferencedEvent|octo.fragments.DemilestonedEvent|octo.fragments.IssueComment|octo.fragments.LabeledEvent|octo.fragments.MilestonedEvent|octo.fragments.RenamedTitleEvent|octo.fragments.ReopenedEvent|octo.fragments.UnlabeledEvent|octo.fragments.PinnedEvent|octo.fragments.UnpinnedEvent|octo.fragments.SubIssueAddedEvent|octo.fragments.SubIssueRemovedEvent|octo.fragments.ParentIssueAddedEvent|octo.fragments.ParentIssueRemovedEvent|octo.fragments.IssueTypeAddedEvent|octo.fragments.IssueTypeRemovedEvent|octo.fragments.IssueTypeChangedEvent|octo.fragments.AddedToProjectV2Event|octo.fragments.ProjectV2ItemStatusChangedEvent|octo.fragments.RemovedFromProjectV2Event
 
----@class octo.fragments.IssueTimelineItemsConnection
----@field nodes octo.IssueTimelineItem[]
-
-M.issue_timeline_items_connection = [[
-fragment IssueTimelineItemsConnectionFragment on IssueTimelineItemsConnection {
-  nodes {
+  local issue_timeline_items_connection_fragments = [[
     __typename
     ...AssignedEventFragment
     ...ClosedEventFragment
@@ -977,20 +973,33 @@ fragment IssueTimelineItemsConnectionFragment on IssueTimelineItemsConnection {
     ...IssueTypeAddedEventFragment
     ...IssueTypeRemovedEventFragment
     ...IssueTypeChangedEventFragment
+]]
+  if config.values.default_to_projects_v2 then
+    issue_timeline_items_connection_fragments = issue_timeline_items_connection_fragments
+      .. [[
     ...AddedToProjectV2EventFragment
     ...RemovedFromProjectV2EventFragment
     ...ProjectV2ItemStatusChangedEventFragment
+    ]]
+  end
+
+  ---@alias octo.IssueTimelineItem octo.fragments.AssignedEvent|octo.fragments.ClosedEvent|octo.fragments.ConnectedEvent|octo.fragments.ReferencedEvent|octo.fragments.CrossReferencedEvent|octo.fragments.DemilestonedEvent|octo.fragments.IssueComment|octo.fragments.LabeledEvent|octo.fragments.MilestonedEvent|octo.fragments.RenamedTitleEvent|octo.fragments.ReopenedEvent|octo.fragments.UnlabeledEvent|octo.fragments.PinnedEvent|octo.fragments.UnpinnedEvent|octo.fragments.SubIssueAddedEvent|octo.fragments.SubIssueRemovedEvent|octo.fragments.ParentIssueAddedEvent|octo.fragments.ParentIssueRemovedEvent|octo.fragments.IssueTypeAddedEvent|octo.fragments.IssueTypeRemovedEvent|octo.fragments.IssueTypeChangedEvent|octo.fragments.AddedToProjectV2Event|octo.fragments.ProjectV2ItemStatusChangedEvent|octo.fragments.RemovedFromProjectV2Event
+
+  ---@class octo.fragments.IssueTimelineItemsConnection
+  ---@field nodes octo.IssueTimelineItem[]
+
+  M.issue_timeline_items_connection = string.format(
+    [[
+fragment IssueTimelineItemsConnectionFragment on IssueTimelineItemsConnection {
+  nodes {
+  %s
   }
 }
-]]
----@alias octo.PullRequestTimelineItem octo.fragments.AssignedEvent|octo.fragments.ClosedEvent|octo.fragments.ConnectedEvent|octo.fragments.ConvertToDraftEvent|octo.fragments.CrossReferencedEvent|octo.fragments.DemilestonedEvent|octo.fragments.IssueComment|octo.fragments.LabeledEvent|octo.fragments.MergedEvent|octo.fragments.MilestonedEvent|octo.fragments.PullRequestCommit|octo.fragments.PullRequestReview|octo.fragments.ReadyForReviewEvent|octo.fragments.RenamedTitleEvent|octo.fragments.ReopenedEvent|octo.fragments.ReviewDismissedEvent|octo.fragments.ReviewRequestRemovedEvent|octo.fragments.ReviewRequestedEvent|octo.fragments.UnlabeledEvent|octo.fragments.DeployedEvent|octo.fragments.HeadRefDeletedEvent|octo.fragments.HeadRefRestoredEvent|octo.fragments.HeadRefForcePushedEvent|octo.fragments.AutoSquashEnabledEvent|octo.fragments.AddedToProjectV2Event|octo.fragments.RemovedFromProjectV2Event|octo.fragments.ProjectV2ItemStatusChangedEvent
+]],
+    issue_timeline_items_connection_fragments
+  )
 
----@class octo.fragments.PullRequestTimelineItemsConnection
----@field nodes octo.PullRequestTimelineItem[]
-
-M.pull_request_timeline_items_connection = [[
-fragment PullRequestTimelineItemsConnectionFragment on PullRequestTimelineItemsConnection {
-  nodes {
+  local pull_request_timeline_items_connection_fragments = [[
     __typename
     ...AssignedEventFragment
     ...ClosedEventFragment
@@ -1016,31 +1025,51 @@ fragment PullRequestTimelineItemsConnectionFragment on PullRequestTimelineItemsC
     ...HeadRefRestoredEventFragment
     ...HeadRefForcePushedEventFragment
     ...AutoSquashEnabledEventFragment
+]]
+
+  if config.values.default_to_projects_v2 then
+    pull_request_timeline_items_connection_fragments = pull_request_timeline_items_connection_fragments
+      .. [[
     ...AddedToProjectV2EventFragment
     ...RemovedFromProjectV2EventFragment
     ...ProjectV2ItemStatusChangedEventFragment
+    ]]
+  end
+
+  ---@alias octo.PullRequestTimelineItem octo.fragments.AssignedEvent|octo.fragments.ClosedEvent|octo.fragments.ConnectedEvent|octo.fragments.ConvertToDraftEvent|octo.fragments.CrossReferencedEvent|octo.fragments.DemilestonedEvent|octo.fragments.IssueComment|octo.fragments.LabeledEvent|octo.fragments.MergedEvent|octo.fragments.MilestonedEvent|octo.fragments.PullRequestCommit|octo.fragments.PullRequestReview|octo.fragments.ReadyForReviewEvent|octo.fragments.RenamedTitleEvent|octo.fragments.ReopenedEvent|octo.fragments.ReviewDismissedEvent|octo.fragments.ReviewRequestRemovedEvent|octo.fragments.ReviewRequestedEvent|octo.fragments.UnlabeledEvent|octo.fragments.DeployedEvent|octo.fragments.HeadRefDeletedEvent|octo.fragments.HeadRefRestoredEvent|octo.fragments.HeadRefForcePushedEvent|octo.fragments.AutoSquashEnabledEvent|octo.fragments.AddedToProjectV2Event|octo.fragments.RemovedFromProjectV2Event|octo.fragments.ProjectV2ItemStatusChangedEvent
+
+  ---@class octo.fragments.PullRequestTimelineItemsConnection
+  ---@field nodes octo.PullRequestTimelineItem[]
+
+  M.pull_request_timeline_items_connection = string.format(
+    [[
+fragment PullRequestTimelineItemsConnectionFragment on PullRequestTimelineItemsConnection {
+  nodes {
+  %s
   }
 }
-]]
+]],
+    pull_request_timeline_items_connection_fragments
+  )
 
----@class octo.fragments.IssueInformation
----@field id string
----@field number integer
----@field state string
----@field stateReason string
----@field issueType { id: string, name: string, color: string }
----@field title string
----@field body string
----@field createdAt string
----@field closedAt string
----@field updatedAt string
----@field url string
----@field viewerDidAuthor boolean
----@field viewerCanUpdate boolean
----@field milestone { title: string, state: string }
----@field author { login: string }
+  ---@class octo.fragments.IssueInformation
+  ---@field id string
+  ---@field number integer
+  ---@field state string
+  ---@field stateReason string
+  ---@field issueType { id: string, name: string, color: string }
+  ---@field title string
+  ---@field body string
+  ---@field createdAt string
+  ---@field closedAt string
+  ---@field updatedAt string
+  ---@field url string
+  ---@field viewerDidAuthor boolean
+  ---@field viewerCanUpdate boolean
+  ---@field milestone { title: string, state: string }
+  ---@field author { login: string }
 
-M.issue_information = [[
+  M.issue_information = [[
 fragment IssueInformationFragment on Issue {
   id
   number
@@ -1069,26 +1098,26 @@ fragment IssueInformationFragment on Issue {
 }
 ]]
 
----@class octo.ReviewThreadCommentFragment : octo.ReactionGroupsFragment
---- @field id string
---- @field body string
---- @field diffHunk string
---- @field createdAt string
---- @field lastEditedAt string
---- @field outdated boolean
---- @field originalCommit { oid: string, abbreviatedOid: string }
---- @field author { login: string }
---- @field authorAssociation string
---- @field viewerDidAuthor boolean
---- @field viewerCanUpdate boolean
---- @field viewerCanDelete boolean
---- @field state string
---- @field url string
---- @field replyTo { id: string, url: string }
---- @field pullRequestReview { id: string, state: string }
---- @field path string
+  ---@class octo.ReviewThreadCommentFragment : octo.ReactionGroupsFragment
+  --- @field id string
+  --- @field body string
+  --- @field diffHunk string
+  --- @field createdAt string
+  --- @field lastEditedAt string
+  --- @field outdated boolean
+  --- @field originalCommit { oid: string, abbreviatedOid: string }
+  --- @field author { login: string }
+  --- @field authorAssociation string
+  --- @field viewerDidAuthor boolean
+  --- @field viewerCanUpdate boolean
+  --- @field viewerCanDelete boolean
+  --- @field state string
+  --- @field url string
+  --- @field replyTo { id: string, url: string }
+  --- @field pullRequestReview { id: string, state: string }
+  --- @field path string
 
-M.review_thread_comment = [[
+  M.review_thread_comment = [[
 fragment ReviewThreadCommentFragment on PullRequestReviewComment {
   id
   body
@@ -1122,21 +1151,21 @@ fragment ReviewThreadCommentFragment on PullRequestReviewComment {
 }
 ]]
 
----@class octo.ReviewThreadInformationFragment
---- @field id string
---- @field path string
---- @field diffSide string
---- @field startDiffSide string
---- @field line number
---- @field originalLine number
---- @field startLine number
---- @field originalStartLine number
---- @field resolvedBy { login: string }
---- @field isResolved boolean
---- @field isCollapsed boolean
---- @field isOutdated boolean
+  ---@class octo.ReviewThreadInformationFragment
+  --- @field id string
+  --- @field path string
+  --- @field diffSide string
+  --- @field startDiffSide string
+  --- @field line number
+  --- @field originalLine number
+  --- @field startLine number
+  --- @field originalStartLine number
+  --- @field resolvedBy { login: string }
+  --- @field isResolved boolean
+  --- @field isCollapsed boolean
+  --- @field isOutdated boolean
 
-M.review_thread_information = [[
+  M.review_thread_information = [[
 fragment ReviewThreadInformationFragment on PullRequestReviewThread {
   id
   path
@@ -1155,18 +1184,18 @@ fragment ReviewThreadInformationFragment on PullRequestReviewThread {
 }
 ]]
 
----@class octo.fragments.DiscussionInfo
----@field id string
----@field number integer
----@field title string
----@field url string
----@field closed boolean
----@field isAnswered boolean
----@field viewerDidAuthor boolean
----@field repository { nameWithOwner: string }
----@field author { login: string }
+  ---@class octo.fragments.DiscussionInfo
+  ---@field id string
+  ---@field number integer
+  ---@field title string
+  ---@field url string
+  ---@field closed boolean
+  ---@field isAnswered boolean
+  ---@field viewerDidAuthor boolean
+  ---@field repository { nameWithOwner: string }
+  ---@field author { login: string }
 
-M.discussion_info = [[
+  M.discussion_info = [[
 fragment DiscussionInfoFragment on Discussion {
   id
   number
@@ -1183,18 +1212,18 @@ fragment DiscussionInfoFragment on Discussion {
   }
 }
 ]]
----@class octo.fragments.DiscussionDetails : octo.fragments.DiscussionInfo, octo.ReactionGroupsFragment
----@field body string
----@field category { name: string, emoji: string }
----@field answer { author: { login: string }, body: string, createdAt: string, viewerDidAuthor: boolean }
----@field createdAt string
----@field closedAt string
----@field updatedAt string
----@field upvoteCount integer
----@field viewerHasUpvoted boolean
----@field viewerDidAuthor boolean
+  ---@class octo.fragments.DiscussionDetails : octo.fragments.DiscussionInfo, octo.ReactionGroupsFragment
+  ---@field body string
+  ---@field category { name: string, emoji: string }
+  ---@field answer { author: { login: string }, body: string, createdAt: string, viewerDidAuthor: boolean }
+  ---@field createdAt string
+  ---@field closedAt string
+  ---@field updatedAt string
+  ---@field upvoteCount integer
+  ---@field viewerHasUpvoted boolean
+  ---@field viewerDidAuthor boolean
 
-M.discussion_details = [[
+  M.discussion_details = [[
 fragment DiscussionDetailsFragment on Discussion {
   ...DiscussionInfoFragment
   body
@@ -1219,20 +1248,20 @@ fragment DiscussionDetailsFragment on Discussion {
   ...ReactionGroupsFragment
 }
 ]]
----@class octo.fragments.DiscussionComment : octo.ReactionGroupsFragment
----@field __typename string
----@field id string
----@field body string
----@field url string
----@field createdAt string
----@field lastEditedAt string
----@field author { login: string }
----@field replyTo { id: string }
----@field viewerDidAuthor boolean
----@field viewerCanUpdate boolean
----@field viewerCanDelete boolean
+  ---@class octo.fragments.DiscussionComment : octo.ReactionGroupsFragment
+  ---@field __typename string
+  ---@field id string
+  ---@field body string
+  ---@field url string
+  ---@field createdAt string
+  ---@field lastEditedAt string
+  ---@field author { login: string }
+  ---@field replyTo { id: string }
+  ---@field viewerDidAuthor boolean
+  ---@field viewerCanUpdate boolean
+  ---@field viewerCanDelete boolean
 
-M.discussion_comment = [[
+  M.discussion_comment = [[
 fragment DiscussionCommentFragment on DiscussionComment {
   __typename
   id
@@ -1252,27 +1281,27 @@ fragment DiscussionCommentFragment on DiscussionComment {
   viewerCanDelete
 }
 ]]
----@class octo.fragments.Repository
----@field id string
----@field createdAt string
----@field description string
----@field diskUsage integer
----@field forkCount integer
----@field isArchived boolean
----@field isDisabled boolean
----@field isEmpty boolean
----@field isFork boolean
----@field isInOrganization boolean
----@field isPrivate boolean
----@field isSecurityPolicyEnabled boolean
----@field name string
----@field nameWithOwner string
----@field parent { nameWithOwner: string }
----@field stargazerCount integer
----@field updatedAt string
----@field url string
+  ---@class octo.fragments.Repository
+  ---@field id string
+  ---@field createdAt string
+  ---@field description string
+  ---@field diskUsage integer
+  ---@field forkCount integer
+  ---@field isArchived boolean
+  ---@field isDisabled boolean
+  ---@field isEmpty boolean
+  ---@field isFork boolean
+  ---@field isInOrganization boolean
+  ---@field isPrivate boolean
+  ---@field isSecurityPolicyEnabled boolean
+  ---@field name string
+  ---@field nameWithOwner string
+  ---@field parent { nameWithOwner: string }
+  ---@field stargazerCount integer
+  ---@field updatedAt string
+  ---@field url string
 
-M.repository = [[
+  M.repository = [[
 fragment RepositoryFragment on Repository {
   id
   createdAt
@@ -1296,5 +1325,6 @@ fragment RepositoryFragment on Repository {
   url
 }
 ]]
+end
 
 return M

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -1,5 +1,7 @@
 local config = require "octo.config"
 local fragments = require "octo.gh.fragments"
+local queries = require "octo.gh.queries"
+local mutations = require "octo.gh.mutations"
 local _, Job = pcall(require, "plenary.job")
 local vim = vim
 
@@ -98,6 +100,9 @@ function M.has_scope(test_scopes)
 end
 
 function M.setup()
+  fragments.setup()
+  queries.setup()
+  mutations.setup()
   _G.octo_pv2_fragment = ""
   ---@diagnostic disable-next-line: missing-fields
   Job:new({

--- a/lua/octo/gh/mutations.lua
+++ b/lua/octo/gh/mutations.lua
@@ -1,9 +1,11 @@
 local fragments = require "octo.gh.fragments"
+local config = require "octo.config"
 
 local M = {}
 
--- https://docs.github.com/en/graphql/reference/mutations#addreaction
-M.add_reaction = [[
+M.setup = function()
+  -- https://docs.github.com/en/graphql/reference/mutations#addreaction
+  M.add_reaction = [[
 mutation {
   addReaction(input: {subjectId: "%s", content: %s}) {
     subject {
@@ -13,8 +15,8 @@ mutation {
 }
 ]] .. fragments.reaction_groups
 
--- https://docs.github.com/en/graphql/reference/mutations#removereaction
-M.remove_reaction = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#removereaction
+  M.remove_reaction = [[
 mutation {
   removeReaction(input: {subjectId: "%s", content: %s}) {
     subject {
@@ -24,8 +26,8 @@ mutation {
 }
 ]] .. fragments.reaction_groups
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#resolvereviewthread
-M.resolve_review_thread = [[
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#resolvereviewthread
+  M.resolve_review_thread = [[
 mutation {
   resolveReviewThread(input: {threadId: "%s"}) {
     thread {
@@ -51,8 +53,8 @@ mutation {
 }
 ]] .. fragments.reaction_groups .. fragments.review_thread_information .. fragments.review_thread_comment
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#unresolvereviewthread
-M.unresolve_review_thread = [[
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#unresolvereviewthread
+  M.unresolve_review_thread = [[
 mutation {
   unresolveReviewThread(input: {threadId: "%s"}) {
     thread {
@@ -77,23 +79,23 @@ mutation {
   }
 }
 ]] .. fragments.reaction_groups .. fragments.review_thread_information .. fragments.review_thread_comment
----@class octo.mutations.StartReview
----@field data {
----  addPullRequestReview: {
----    pullRequestReview: {
----      id: string,
----      state: string,
----      pullRequest: {
----        reviewThreads: {
----          nodes: octo.ReviewThread[],
----        },
----      },
----    },
----  },
----}
+  ---@class octo.mutations.StartReview
+  ---@field data {
+  ---  addPullRequestReview: {
+  ---    pullRequestReview: {
+  ---      id: string,
+  ---      state: string,
+  ---      pullRequest: {
+  ---        reviewThreads: {
+  ---          nodes: octo.ReviewThread[],
+  ---        },
+  ---      },
+  ---    },
+  ---  },
+  ---}
 
--- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreview
-M.start_review = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreview
+  M.start_review = [[
 mutation {
   addPullRequestReview(input: {pullRequestId: "%s"}) {
     pullRequestReview {
@@ -116,8 +118,8 @@ mutation {
 }
 ]] .. fragments.reaction_groups .. fragments.review_thread_information .. fragments.review_thread_comment
 
--- https://docs.github.com/en/graphql/reference/mutations#markfileasviewed
-M.mark_file_as_viewed = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#markfileasviewed
+  M.mark_file_as_viewed = [[
 mutation($path: String!, $pullRequestId: ID!) {
   markFileAsViewed(input: {path: $path, pullRequestId: $pullRequestId}) {
     pullRequest {
@@ -132,8 +134,8 @@ mutation($path: String!, $pullRequestId: ID!) {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/mutations#unmarkfileasviewed
-M.unmark_file_as_viewed = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#unmarkfileasviewed
+  M.unmark_file_as_viewed = [[
 mutation($path: String!, $pullRequestId: ID!) {
   unmarkFileAsViewed(input: {path: $path, pullRequestId: $pullRequestId}) {
     pullRequest {
@@ -148,8 +150,8 @@ mutation($path: String!, $pullRequestId: ID!) {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreview
-M.submit_pull_request_review = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreview
+  M.submit_pull_request_review = [[
 mutation {
   submitPullRequestReview(input: {pullRequestReviewId: "%s", event: %s, body: """%s"""}) {
     pullRequestReview {
@@ -160,7 +162,7 @@ mutation {
 }
 ]]
 
-M.delete_pull_request_review = [[
+  M.delete_pull_request_review = [[
 mutation {
   deletePullRequestReview(input: {pullRequestReviewId: "%s"}) {
     pullRequestReview {
@@ -171,20 +173,20 @@ mutation {
 }
 ]]
 
----@alias DiffSide "LEFT" | "RIGHT"
+  ---@alias DiffSide "LEFT" | "RIGHT"
 
----https://docs.github.com/en/graphql/reference/input-objects#addpullrequestreviewthreadinput
----@class octo.mutations.AddPullRequestReviewThreadInput
----@field pullRequestReviewId string
----@field body string
----@field path string?
----@field startSide DiffSide?
----@field side DiffSide?
----@field startLine integer?
----@field line integer?
+  ---https://docs.github.com/en/graphql/reference/input-objects#addpullrequestreviewthreadinput
+  ---@class octo.mutations.AddPullRequestReviewThreadInput
+  ---@field pullRequestReviewId string
+  ---@field body string
+  ---@field path string?
+  ---@field startSide DiffSide?
+  ---@field side DiffSide?
+  ---@field startLine integer?
+  ---@field line integer?
 
--- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreviewthread
-M.add_pull_request_review_thread = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreviewthread
+  M.add_pull_request_review_thread = [[
 mutation($input: AddPullRequestReviewThreadInput!) {
   addPullRequestReviewThread(input: $input) {
     thread {
@@ -233,62 +235,62 @@ mutation($input: AddPullRequestReviewThreadInput!) {
 }
 ]] .. fragments.reaction_groups .. fragments.review_thread_information .. fragments.review_thread_comment
 
----@class octo.mutations.AddPullRequestReviewThread
----@field thread {
----   id: string,
----   comments: {
----     nodes: {
----       id: string,
----       body: string,
----       diffHunk: string,
----       createdAt: string,
----       lastEditedAt: string,
----       commit: {
----         oid: string,
----         abbreviatedOid: string,
----       },
----       author: {
----         login: string,
----       },
----       authorAssociation: string,
----       viewerDidAuthor: boolean,
----       viewerCanUpdate: boolean,
----       viewerCanDelete: boolean,
----       state: string,
----       url: string,
----       replyTo: {
----         id: string,
----         url: string,
----       },
----       pullRequest: {
----         reviewThreads: {
----           nodes: octo.ReviewThread[],
----         },
----       },
----       path: string,
----     }[],
----   },
----   pullRequest: {
----     reviewThreads: {
----       nodes: octo.ReviewThread[],
----     },
----   },
---- }
+  ---@class octo.mutations.AddPullRequestReviewThread
+  ---@field thread {
+  ---   id: string,
+  ---   comments: {
+  ---     nodes: {
+  ---       id: string,
+  ---       body: string,
+  ---       diffHunk: string,
+  ---       createdAt: string,
+  ---       lastEditedAt: string,
+  ---       commit: {
+  ---         oid: string,
+  ---         abbreviatedOid: string,
+  ---       },
+  ---       author: {
+  ---         login: string,
+  ---       },
+  ---       authorAssociation: string,
+  ---       viewerDidAuthor: boolean,
+  ---       viewerCanUpdate: boolean,
+  ---       viewerCanDelete: boolean,
+  ---       state: string,
+  ---       url: string,
+  ---       replyTo: {
+  ---         id: string,
+  ---         url: string,
+  ---       },
+  ---       pullRequest: {
+  ---         reviewThreads: {
+  ---           nodes: octo.ReviewThread[],
+  ---         },
+  ---       },
+  ---       path: string,
+  ---     }[],
+  ---   },
+  ---   pullRequest: {
+  ---     reviewThreads: {
+  ---       nodes: octo.ReviewThread[],
+  ---     },
+  ---   },
+  --- }
 
----@class octo.mutations.AddIssueComment
----@field data {
----  addComment: {
----    commentEdge: {
----      node: {
----        id: string,
----        body: string,
----      },
----    },
----  },
----}
+  ---@class octo.mutations.AddIssueComment
+  ---@field data {
+  ---  addComment: {
+  ---    commentEdge: {
+  ---      node: {
+  ---        id: string,
+  ---        body: string,
+  ---      },
+  ---    },
+  ---  },
+  ---}
 
--- https://docs.github.com/en/graphql/reference/mutations#addcomment
-M.add_issue_comment = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#addcomment
+  M.add_issue_comment = [[
 mutation {
   addComment(input: {subjectId: "%s", body: """%s"""}) {
     commentEdge {
@@ -300,18 +302,18 @@ mutation {
   }
 }
 ]]
----@class octo.mutations.UpdateIssueComment
----@field data {
----  updateIssueComment: {
----    issueComment: {
----      id: string,
----      body: string,
----    },
----  },
----}j
+  ---@class octo.mutations.UpdateIssueComment
+  ---@field data {
+  ---  updateIssueComment: {
+  ---    issueComment: {
+  ---      id: string,
+  ---      body: string,
+  ---    },
+  ---  },
+  ---}j
 
--- https://docs.github.com/en/graphql/reference/mutations#updateissuecomment
-M.update_issue_comment = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#updateissuecomment
+  M.update_issue_comment = [[
 mutation {
   updateIssueComment(input: {id: "%s", body: """%s"""}) {
     issueComment {
@@ -321,18 +323,18 @@ mutation {
   }
 }
 ]]
----@class octo.mutations.UpdateDiscussionComment
----@field data {
----  updateDiscussionComment: {
----    comment: {
----      id: string,
----      body: string,
----    },
----  },
----}
+  ---@class octo.mutations.UpdateDiscussionComment
+  ---@field data {
+  ---  updateDiscussionComment: {
+  ---    comment: {
+  ---      id: string,
+  ---      body: string,
+  ---    },
+  ---  },
+  ---}
 
---- https://docs.github.com/en/graphql/guides/using-the-graphql-api-for-discussions#updatediscussioncomment
-M.update_discussion_comment = [[
+  --- https://docs.github.com/en/graphql/guides/using-the-graphql-api-for-discussions#updatediscussioncomment
+  M.update_discussion_comment = [[
 mutation {
   updateDiscussionComment(input: {commentId: "%s", body: """%s"""}) {
     comment {
@@ -342,23 +344,23 @@ mutation {
   }
 }
 ]]
----@class octo.mutations.UpdatePullRequestReviewComment
----@field data {
----  updatePullRequestReviewComment: {
----    pullRequestReviewComment: {
----      id: string,
----      body: string,
----      pullRequest: {
----        reviewThreads: {
----          nodes: octo.ReviewThread[],
----        },
----      },
----    },
----  },
----}
+  ---@class octo.mutations.UpdatePullRequestReviewComment
+  ---@field data {
+  ---  updatePullRequestReviewComment: {
+  ---    pullRequestReviewComment: {
+  ---      id: string,
+  ---      body: string,
+  ---      pullRequest: {
+  ---        reviewThreads: {
+  ---          nodes: octo.ReviewThread[],
+  ---        },
+  ---      },
+  ---    },
+  ---  },
+  ---}
 
--- https://docs.github.com/en/graphql/reference/mutations#updatepullrequestreviewcomment
-M.update_pull_request_review_comment = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#updatepullrequestreviewcomment
+  M.update_pull_request_review_comment = [[
 mutation {
   updatePullRequestReviewComment(input: {pullRequestReviewCommentId: "%s", body: """%s"""}) {
     pullRequestReviewComment {
@@ -380,25 +382,25 @@ mutation {
   }
 }
 ]] .. fragments.reaction_groups .. fragments.review_thread_information .. fragments.review_thread_comment
----@class octo.mutations.UpdateDiscussion
----@field data {
----  updateDiscussion: {
----    discussion: {
----      id: string,
----      title: string,
----      body: string,
----    },
----  },
----}
+  ---@class octo.mutations.UpdateDiscussion
+  ---@field data {
+  ---  updateDiscussion: {
+  ---    discussion: {
+  ---      id: string,
+  ---      title: string,
+  ---      body: string,
+  ---    },
+  ---  },
+  ---}
 
----https://docs.github.com/en/graphql/reference/input-objects#updatediscussioninput
----@class octo.mutations.UpdateDiscussionInput
----@field discussionId string
----@field title string?
----@field body string?
----@field categoryId string?
+  ---https://docs.github.com/en/graphql/reference/input-objects#updatediscussioninput
+  ---@class octo.mutations.UpdateDiscussionInput
+  ---@field discussionId string
+  ---@field title string?
+  ---@field body string?
+  ---@field categoryId string?
 
-M.update_discussion = [[
+  M.update_discussion = [[
 mutation($input: UpdateDiscussionInput!) {
   updateDiscussion(input: $input) {
     discussion {
@@ -410,7 +412,7 @@ mutation($input: UpdateDiscussionInput!) {
 }
 ]]
 
-M.add_discussion_comment = [[
+  M.add_discussion_comment = [[
 mutation($discussion_id: ID!, $body: String!, $reply_to_id: ID) {
   addDiscussionComment(input: {
     discussionId: $discussion_id,
@@ -424,19 +426,19 @@ mutation($discussion_id: ID!, $body: String!, $reply_to_id: ID) {
   }
 }
 ]]
----@class octo.mutations.UpdatePullRequestReview
----@field data {
----  updatePullRequestReview: {
----    pullRequestReview: {
----      id: string,
----      state: string,
----      body: string,
----    },
----  },
----}
+  ---@class octo.mutations.UpdatePullRequestReview
+  ---@field data {
+  ---  updatePullRequestReview: {
+  ---    pullRequestReview: {
+  ---      id: string,
+  ---      state: string,
+  ---      body: string,
+  ---    },
+  ---  },
+  ---}
 
--- https://docs.github.com/en/graphql/reference/mutations#updatepullrequestreview
-M.update_pull_request_review = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#updatepullrequestreview
+  M.update_pull_request_review = [[
 mutation {
   updatePullRequestReview(input: {pullRequestReviewId: "%s", body: """%s"""}) {
     pullRequestReview {
@@ -447,23 +449,23 @@ mutation {
   }
 }
 ]]
----@class octo.mutations.AddPullRequestReviewComment
----@field data {
----  addPullRequestReviewComment: {
----    comment: {
----      id: string,
----      body: string,
----      pullRequest: {
----        reviewThreads: {
----          nodes: octo.ReviewThread[],
----        },
----      },
----    },
----  },
----}
+  ---@class octo.mutations.AddPullRequestReviewComment
+  ---@field data {
+  ---  addPullRequestReviewComment: {
+  ---    comment: {
+  ---      id: string,
+  ---      body: string,
+  ---      pullRequest: {
+  ---        reviewThreads: {
+  ---          nodes: octo.ReviewThread[],
+  ---        },
+  ---      },
+  ---    },
+  ---  },
+  ---}
 
--- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreviewcomment
-M.add_pull_request_review_comment = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreviewcomment
+  M.add_pull_request_review_comment = [[
 mutation {
   addPullRequestReviewComment(input: {inReplyTo: "%s", body: """%s""", pullRequestReviewId: "%s"}) {
     comment {
@@ -485,23 +487,23 @@ mutation {
   }
 }
 ]] .. fragments.reaction_groups .. fragments.review_thread_information .. fragments.review_thread_comment
----@class octo.mutations.AddPullRequestReviewCommitThread
----@field data {
----  addPullRequestReviewComment: {
----    comment: {
----      id: string,
----      body: string,
----      pullRequest: {
----        reviewThreads: {
----          nodes: octo.ReviewThread[],
----        },
----      },
----    },
----  },
----}
+  ---@class octo.mutations.AddPullRequestReviewCommitThread
+  ---@field data {
+  ---  addPullRequestReviewComment: {
+  ---    comment: {
+  ---      id: string,
+  ---      body: string,
+  ---      pullRequest: {
+  ---        reviewThreads: {
+  ---          nodes: octo.ReviewThread[],
+  ---        },
+  ---      },
+  ---    },
+  ---  },
+  ---}
 
--- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreviewcomment
-M.add_pull_request_review_commit_thread = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#addpullrequestreviewcomment
+  M.add_pull_request_review_commit_thread = [[
 mutation {
   addPullRequestReviewComment(input: {commitOID: "%s", body: """%s""", pullRequestReviewId: "%s", path: "%s", position: %d }) {
     comment {
@@ -524,19 +526,19 @@ mutation {
 }
 ]] .. fragments.reaction_groups .. fragments.review_thread_information .. fragments.review_thread_comment
 
--- M.add_pull_request_review_comment = [[
--- mutation {
---   addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: "%s", body: """%s"""}) {
---     comment{
---       id
---       body
---     }
---   }
--- }
--- ]]
+  -- M.add_pull_request_review_comment = [[
+  -- mutation {
+  --   addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: "%s", body: """%s"""}) {
+  --     comment{
+  --       id
+  --       body
+  --     }
+  --   }
+  -- }
+  -- ]]
 
--- https://docs.github.com/en/graphql/reference/mutations#deleteissuecomment
-M.delete_issue_comment = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#deleteissuecomment
+  M.delete_issue_comment = [[
 mutation {
   deleteIssueComment(input: {id: "%s"}) {
     clientMutationId
@@ -544,7 +546,7 @@ mutation {
 }
 ]]
 
-M.delete_discussion_comment = [[
+  M.delete_discussion_comment = [[
 mutation {
   deleteDiscussionComment(input: {id: "%s"}) {
     clientMutationId
@@ -552,8 +554,8 @@ mutation {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/mutations#deletepullrequestreviewcomment
-M.delete_pull_request_review_comment = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#deletepullrequestreviewcomment
+  M.delete_pull_request_review_comment = [[
 mutation {
   deletePullRequestReviewComment(input: {id: "%s"}) {
     pullRequestReview {
@@ -575,30 +577,30 @@ mutation {
   }
 }
 ]] .. fragments.reaction_groups .. fragments.review_thread_information .. fragments.review_thread_comment
----@class octo.mutations.UpdateIssue
----@field data {
----  updateIssue: {
----    issue: {
----      id: string,
----      number: integer,
----      state: string,
----      title: string,
----      body: string,
----      repository: {
----        nameWithOwner: string,
----      },
----    },
----  },
----}
+  ---@class octo.mutations.UpdateIssue
+  ---@field data {
+  ---  updateIssue: {
+  ---    issue: {
+  ---      id: string,
+  ---      number: integer,
+  ---      state: string,
+  ---      title: string,
+  ---      body: string,
+  ---      repository: {
+  ---        nameWithOwner: string,
+  ---      },
+  ---    },
+  ---  },
+  ---}
 
----https://docs.github.com/en/graphql/reference/input-objects#updateissueinput
----@class octo.mutations.UpdateIssueInput
----@field id string
----@field title string?
----@field body string?
+  ---https://docs.github.com/en/graphql/reference/input-objects#updateissueinput
+  ---@class octo.mutations.UpdateIssueInput
+  ---@field id string
+  ---@field title string?
+  ---@field body string?
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#updateissue
-M.update_issue = [[
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#updateissue
+  M.update_issue = [[
 mutation($input: UpdateIssueInput!) {
   updateIssue(input: $input) {
     issue {
@@ -615,14 +617,14 @@ mutation($input: UpdateIssueInput!) {
 }
 ]]
 
----https://docs.github.com/en/graphql/reference/input-objects#createissueinput
----@class octo.mutations.CreateIssueInput
----@field repositoryId string
----@field title string
----@field body string?
+  ---https://docs.github.com/en/graphql/reference/input-objects#createissueinput
+  ---@class octo.mutations.CreateIssueInput
+  ---@field repositoryId string
+  ---@field title string
+  ---@field body string?
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#createissue
-M.create_issue = [[
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#createissue
+  M.create_issue = [[
 mutation($input: CreateIssueInput!) {
   createIssue(input: $input) {
     issue {
@@ -648,9 +650,16 @@ mutation($input: CreateIssueInput!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.renamed_title_event .. fragments.issue_information .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event .. fragments.added_to_project_v2_event .. fragments.project_v2_item_status_changed_event .. fragments.removed_from_project_v2_event
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.renamed_title_event .. fragments.issue_information .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event
 
-M.close_issue = [[
+  if config.values.default_to_projects_v2 then
+    M.create_issue = M.create_issue
+      .. fragments.added_to_project_v2_event
+      .. fragments.project_v2_item_status_changed_event
+      .. fragments.removed_from_project_v2_event
+  end
+
+  M.close_issue = [[
 mutation($issueId: ID!, $stateReason: IssueCloseReason) {
   closeIssue(input: {issueId: $issueId, stateReason: $stateReason}) {
     issue {
@@ -685,10 +694,17 @@ mutation($issueId: ID!, $stateReason: IssueCloseReason) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.label_connection .. fragments.label .. fragments.reaction_groups .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.renamed_title_event .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event .. fragments.added_to_project_v2_event .. fragments.project_v2_item_status_changed_event .. fragments.removed_from_project_v2_event
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.label_connection .. fragments.label .. fragments.reaction_groups .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.renamed_title_event .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#updateissue
-M.update_issue_state = [[
+  if config.values.default_to_projects_v2 then
+    M.close_issue = M.close_issue
+      .. fragments.added_to_project_v2_event
+      .. fragments.project_v2_item_status_changed_event
+      .. fragments.removed_from_project_v2_event
+  end
+
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#updateissue
+  M.update_issue_state = [[
 mutation($id: ID!, $state: IssueState!) {
   updateIssue(input: {id: $id, state: $state}) {
     issue {
@@ -723,10 +739,17 @@ mutation($id: ID!, $state: IssueState!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.renamed_title_event .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event .. fragments.added_to_project_v2_event .. fragments.project_v2_item_status_changed_event .. fragments.removed_from_project_v2_event
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.renamed_title_event .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event
 
--- https://docs.github.com/en/graphql/reference/mutations#reopenissue
-M.reopen_issue = [[
+  if config.values.default_to_projects_v2 then
+    M.update_issue_state = M.update_issue_state
+      .. fragments.added_to_project_v2_event
+      .. fragments.project_v2_item_status_changed_event
+      .. fragments.removed_from_project_v2_event
+  end
+
+  -- https://docs.github.com/en/graphql/reference/mutations#reopenissue
+  M.reopen_issue = [[
 mutation($issueId: ID!) {
   reopenIssue(input: {
     issueId: $issueId
@@ -763,29 +786,36 @@ mutation($issueId: ID!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.renamed_title_event .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event .. fragments.added_to_project_v2_event .. fragments.project_v2_item_status_changed_event .. fragments.removed_from_project_v2_event
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.renamed_title_event .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event
 
----@class octo.mutations.UpdatePullRequest
----@field data {
----  updatePullRequest: {
----    pullRequest: {
----      id: string,
----      number: integer,
----      state: string,
----      title: string,
----      body: string,
----    },
----  },
----}
+  if config.values.default_to_projects_v2 then
+    M.reopen_issue = M.reopen_issue
+      .. fragments.added_to_project_v2_event
+      .. fragments.project_v2_item_status_changed_event
+      .. fragments.removed_from_project_v2_event
+  end
 
----https://docs.github.com/en/graphql/reference/input-objects#updatepullrequestinput
----@class octo.mutations.UpdatePullRequestInput
----@field pullRequestId string
----@field title string?
----@field body string?
+  ---@class octo.mutations.UpdatePullRequest
+  ---@field data {
+  ---  updatePullRequest: {
+  ---    pullRequest: {
+  ---      id: string,
+  ---      number: integer,
+  ---      state: string,
+  ---      title: string,
+  ---      body: string,
+  ---    },
+  ---  },
+  ---}
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#updatepullrequest
-M.update_pull_request = [[
+  ---https://docs.github.com/en/graphql/reference/input-objects#updatepullrequestinput
+  ---@class octo.mutations.UpdatePullRequestInput
+  ---@field pullRequestId string
+  ---@field title string?
+  ---@field body string?
+
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#updatepullrequest
+  M.update_pull_request = [[
 mutation($input: UpdatePullRequestInput!) {
   updatePullRequest(input: $input) {
     pullRequest {
@@ -799,8 +829,8 @@ mutation($input: UpdatePullRequestInput!) {
 }
 ]]
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#updatepullrequest
-M.update_pull_request_state = [[
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#updatepullrequest
+  M.update_pull_request_state = [[
 mutation($pullRequestId: ID!, $state: PullRequestState!) {
   updatePullRequest(input: {pullRequestId: $pullRequestId, state: $state}) {
     pullRequest {
@@ -888,9 +918,16 @@ mutation($pullRequestId: ID!, $state: PullRequestState!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.ready_for_review_event .. fragments.reopened_event .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.merged_event .. fragments.review_requested_event .. fragments.renamed_title_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.deployed_event .. fragments.head_ref_deleted_event .. fragments.head_ref_restored_event .. fragments.head_ref_force_pushed_event .. fragments.auto_squash_enabled_event .. fragments.added_to_project_v2_event .. fragments.removed_from_project_v2_event .. fragments.project_v2_item_status_changed_event
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.ready_for_review_event .. fragments.reopened_event .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.merged_event .. fragments.review_requested_event .. fragments.renamed_title_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.deployed_event .. fragments.head_ref_deleted_event .. fragments.head_ref_restored_event .. fragments.head_ref_force_pushed_event .. fragments.auto_squash_enabled_event
 
-M.create_discussion = [[
+  if config.values.default_to_projects_v2 then
+    M.update_pull_request_state = M.update_pull_request_state
+      .. fragments.added_to_project_v2_event
+      .. fragments.removed_from_project_v2_event
+      .. fragments.project_v2_item_status_changed_event
+  end
+
+  M.create_discussion = [[
 mutation($repo_id: ID!, $category_id: ID!, $title: String!, $body: String!) {
   createDiscussion(input: {
     repositoryId: $repo_id,
@@ -920,8 +957,8 @@ mutation($repo_id: ID!, $category_id: ID!, $title: String!, $body: String!) {
   }
 ]] .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.discussion_info .. fragments.discussion_details .. fragments.discussion_comment
 
--- https://docs.github.com/en/graphql/reference/mutations#addprojectv2itembyid
-M.add_project_v2_item = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#addprojectv2itembyid
+  M.add_project_v2_item = [[
 mutation {
   addProjectV2ItemById(input: {contentId: "%s", projectId: "%s"}) {
     item {
@@ -931,8 +968,8 @@ mutation {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/mutations#updateprojectv2itemfieldvalue
-M.update_project_v2_item = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#updateprojectv2itemfieldvalue
+  M.update_project_v2_item = [[
 mutation {
   updateProjectV2ItemFieldValue(
     input: {
@@ -949,8 +986,8 @@ mutation {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/mutations#deleteprojectv2item
-M.delete_project_v2_item = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#deleteprojectv2item
+  M.delete_project_v2_item = [[
 mutation {
   deleteProjectV2Item(input: {projectId: "%s", itemId: "%s"}) {
     deletedItemId
@@ -958,9 +995,9 @@ mutation {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/mutations#createlabel
--- requires application/vnd.github.bane-preview+json
-M.create_label = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#createlabel
+  -- requires application/vnd.github.bane-preview+json
+  M.create_label = [[
 mutation {
   createLabel(input: {repositoryId: "%s", name: "%s", description: """%s""", color: "%s"}) {
     label {
@@ -970,8 +1007,8 @@ mutation {
 }
 ]] .. fragments.label
 
--- https://docs.github.com/en/graphql/reference/mutations#removelabelsfromlabelable
-M.add_labels = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#removelabelsfromlabelable
+  M.add_labels = [[
 mutation {
   addLabelsToLabelable(input: {labelableId: "%s", labelIds: %s}) {
     labelable {
@@ -989,8 +1026,8 @@ mutation {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/mutations#removelabelsfromlabelable
-M.remove_labels = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#removelabelsfromlabelable
+  M.remove_labels = [[
 mutation {
   removeLabelsFromLabelable(input: {labelableId: "%s", labelIds: %s}) {
     labelable {
@@ -1008,8 +1045,8 @@ mutation {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/mutations#addassigneestoassignable
-M.add_assignees = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#addassigneestoassignable
+  M.add_assignees = [[
 mutation($object_id: ID!, $user_ids: [ID!]!) {
   addAssigneesToAssignable(input: {assignableId: $object_id, assigneeIds: $user_ids}) {
     assignable {
@@ -1024,8 +1061,8 @@ mutation($object_id: ID!, $user_ids: [ID!]!) {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/mutations#removeassigneestoassignable
-M.remove_assignees = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#removeassigneestoassignable
+  M.remove_assignees = [[
 mutation {
   removeAssigneesFromAssignable(input: {assignableId: "%s", assigneeIds: ["%s"]}) {
     assignable {
@@ -1040,9 +1077,9 @@ mutation {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/mutations#requestreviews
--- for teams use `teamIds`
-M.request_reviews = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#requestreviews
+  -- for teams use `teamIds`
+  M.request_reviews = [[
 mutation($object_id: ID!, $user_ids: [ID!]!) {
   requestReviews(input: {pullRequestId: $object_id, union: true, userIds: $user_ids}) {
     pullRequest {
@@ -1064,17 +1101,17 @@ mutation($object_id: ID!, $user_ids: [ID!]!) {
 }
 ]]
 
----https://docs.github.com/en/graphql/reference/input-objects#createpullrequestinput
----@class octo.mutations.CreatePullRequestInput
----@field baseRefName string
----@field headRefName string
----@field repositoryId string
----@field title string
----@field body string
----@field draft boolean
+  ---https://docs.github.com/en/graphql/reference/input-objects#createpullrequestinput
+  ---@class octo.mutations.CreatePullRequestInput
+  ---@field baseRefName string
+  ---@field headRefName string
+  ---@field repositoryId string
+  ---@field title string
+  ---@field body string
+  ---@field draft boolean
 
--- https://docs.github.com/en/graphql/reference/mutations#createpullrequest
-M.create_pr = [[
+  -- https://docs.github.com/en/graphql/reference/mutations#createpullrequest
+  M.create_pr = [[
 mutation($input: CreatePullRequestInput!) {
   createPullRequest(input: $input) {
     pullRequest {
@@ -1168,9 +1205,16 @@ mutation($input: CreatePullRequestInput!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.ready_for_review_event .. fragments.reopened_event .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.review_requested_event .. fragments.merged_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.renamed_title_event .. fragments.deployed_event .. fragments.head_ref_deleted_event .. fragments.head_ref_restored_event .. fragments.head_ref_force_pushed_event .. fragments.auto_squash_enabled_event .. fragments.added_to_project_v2_event .. fragments.removed_from_project_v2_event .. fragments.project_v2_item_status_changed_event
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.ready_for_review_event .. fragments.reopened_event .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.review_requested_event .. fragments.merged_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.renamed_title_event .. fragments.deployed_event .. fragments.head_ref_deleted_event .. fragments.head_ref_restored_event .. fragments.head_ref_force_pushed_event .. fragments.auto_squash_enabled_event
 
-M.mark_answer = [[
+  if config.values.default_to_projects_v2 then
+    M.create_pr = M.create_pr
+      .. fragments.added_to_project_v2_event
+      .. fragments.removed_from_project_v2_event
+      .. fragments.project_v2_item_status_changed_event
+  end
+
+  M.mark_answer = [[
 mutation($id: ID!) {
   markDiscussionCommentAsAnswer(input: {id: $id}) {
     clientMutationId
@@ -1178,7 +1222,7 @@ mutation($id: ID!) {
 }
 ]]
 
-M.unmark_answer = [[
+  M.unmark_answer = [[
 mutation($id: ID!) {
   unmarkDiscussionCommentAsAnswer(input: {id: $id}) {
     clientMutationId
@@ -1186,7 +1230,7 @@ mutation($id: ID!) {
 }
 ]]
 
-M.pin_issue = [[
+  M.pin_issue = [[
 mutation($issue_id: ID!) {
   pinIssue(input: {issueId: $issue_id}) {
     issue {
@@ -1196,7 +1240,7 @@ mutation($issue_id: ID!) {
 }
 ]]
 
-M.unpin_issue = [[
+  M.unpin_issue = [[
 mutation($issue_id: ID!) {
   unpinIssue(input: {issueId: $issue_id}) {
     issue {
@@ -1206,7 +1250,7 @@ mutation($issue_id: ID!) {
 }
 ]]
 
-M.close_discussion = [[
+  M.close_discussion = [[
 mutation($discussion_id: ID!, $reason: DiscussionCloseReason) {
   closeDiscussion(input: {discussionId: $discussion_id, reason: $reason}) {
     discussion {
@@ -1216,7 +1260,7 @@ mutation($discussion_id: ID!, $reason: DiscussionCloseReason) {
 }
 ]]
 
-M.reopen_discussion = [[
+  M.reopen_discussion = [[
 mutation($discussion_id: ID!) {
   reopenDiscussion(input: {discussionId: $discussion_id}) {
     discussion {
@@ -1226,7 +1270,7 @@ mutation($discussion_id: ID!) {
 }
 ]]
 
-M.add_subissue = [[
+  M.add_subissue = [[
 mutation($parent_id: ID!, $child_id: ID!) {
   addSubIssue(input: {issueId: $parent_id, subIssueId: $child_id}) {
     issue {
@@ -1239,7 +1283,7 @@ mutation($parent_id: ID!, $child_id: ID!) {
 }
 ]]
 
-M.remove_subissue = [[
+  M.remove_subissue = [[
 mutation($parent_id: ID!, $child_id: ID!) {
   removeSubIssue(input: {issueId: $parent_id, subIssueId: $child_id}) {
     issue {
@@ -1252,7 +1296,7 @@ mutation($parent_id: ID!, $child_id: ID!) {
 }
 ]]
 
-M.update_issue_issue_type = [[
+  M.update_issue_issue_type = [[
 mutation($issue_id: ID!, $issue_type_id: ID) {
   updateIssueIssueType(input: {issueId: $issue_id, issueTypeId: $issue_type_id}) {
     issue {
@@ -1265,5 +1309,6 @@ mutation($issue_id: ID!, $issue_type_id: ID) {
   }
 }
 ]]
+end
 
 return M

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -1,26 +1,34 @@
 local fragments = require "octo.gh.fragments"
+local config = require "octo.config"
 
 local M = {}
 
----@class octo.queries.PendingReviewThreads
----@field data {
----  repository: {
----    pullRequest: {
----      reviews: {
----        nodes: {
----          id: string,
----          viewerDidAuthor: boolean,
----        }[],
----      },
----      reviewThreads: {
----        nodes: octo.ReviewThread[],
----      },
----    },
----  },
----}
+---@class octo.PageInfo
+---@field endCursor string
+---@field hasNextPage boolean
+---@field hasPreviousPage boolean
+---@field startCursor string
 
--- https://docs.github.com/en/graphql/reference/objects#pullrequestreviewthread
-M.pending_review_threads = [[
+M.setup = function()
+  ---@class octo.queries.PendingReviewThreads
+  ---@field data {
+  ---  repository: {
+  ---    pullRequest: {
+  ---      reviews: {
+  ---        nodes: {
+  ---          id: string,
+  ---          viewerDidAuthor: boolean,
+  ---        }[],
+  ---      },
+  ---      reviewThreads: {
+  ---        nodes: octo.ReviewThread[],
+  ---      },
+  ---    },
+  ---  },
+  ---}
+
+  -- https://docs.github.com/en/graphql/reference/objects#pullrequestreviewthread
+  M.pending_review_threads = [[
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest (number: $number){
@@ -45,28 +53,25 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 ]] .. fragments.reaction_groups .. fragments.review_thread_information .. fragments.review_thread_comment
 
----@class octo.ReviewThread : octo.ReviewThreadInformationFragment
---- @field comments {
----   nodes: octo.ReviewThreadCommentFragment[],
----   pageInfo: {
----     hasNextPage: boolean,
----     endCursor: string,
----   },
---- }
+  ---@class octo.ReviewThread : octo.ReviewThreadInformationFragment
+  --- @field comments {
+  ---   nodes: octo.ReviewThreadCommentFragment[],
+  ---   pageInfo: octo.PageInfo,
+  --- }
 
----@class octo.queries.ReviewThreads
----@field data {
----  repository: {
----    pullRequest: {
----      reviewThreads: {
----        nodes: octo.ReviewThread[],
----      },
----    },
----  },
----}
+  ---@class octo.queries.ReviewThreads
+  ---@field data {
+  ---  repository: {
+  ---    pullRequest: {
+  ---      reviewThreads: {
+  ---        nodes: octo.ReviewThread[],
+  ---      },
+  ---    },
+  ---  },
+  ---}
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#pullrequestreviewthread
-M.review_threads = [[
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#pullrequestreviewthread
+  M.review_threads = [[
 query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
@@ -89,54 +94,54 @@ query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
 }
 ]] .. fragments.reaction_groups .. fragments.review_thread_information .. fragments.review_thread_comment
 
----@class octo.PullRequestTimelineItemsConnection : octo.fragments.PullRequestTimelineItemsConnection
----@field pageInfo { hasNextPage: boolean, endCursor: string }
+  ---@class octo.PullRequestTimelineItemsConnection : octo.fragments.PullRequestTimelineItemsConnection
+  ---@field pageInfo octo.PageInfo
 
----@class octo.PullRequest : octo.ReactionGroupsFragment
----@field id string
----@field isDraft boolean
----@field number integer
----@field state string
----@field title string
----@field body string
----@field createdAt string
----@field closedAt string
----@field updatedAt string
----@field url string
----@field closingIssuesReferences { totalCount: number, nodes: octo.fragments.Issue[] }
----@field headRepository { nameWithOwner: string }
----@field files { nodes: { path: string, viewerViewedState: ViewedState }[] }
----@field merged boolean
----@field mergedBy { name: string }|{ login: string }|{ login: string, isViewer: boolean }
----@field participants { nodes: { login: string }[] }
----@field additions integer
----@field deletions integer
----@field commits { totalCount: integer }
----@field changedFiles integer
----@field headRefName string
----@field headRefOid string
----@field baseRefName string
----@field baseRefOid string
----@field baseRepository { name: string, nameWithOwner: string }
----@field milestone { title: string, state: string }
----@field author { login: string }
----@field authorAssociation string
----@field viewerDidAuthor boolean
----@field viewerCanUpdate boolean
----@field projectItems? octo.fragments.ProjectsV2Connection
----@field timelineItems octo.PullRequestTimelineItemsConnection
----@field reviewDecision string
----@field reviewThreads { nodes: octo.ReviewThread[] }
----@field labels octo.fragments.LabelConnection
----@field assignees octo.fragments.AssigneeConnection
----@field reviewRequests { totalCount: integer, nodes: { requestedReviewer: { name: string }|{ login: string }|{ login: string, isViewer: boolean } }[] }
----@field statusCheckRollup { state: string }
----@field mergeStateStatus string
----@field mergeable string
----@field autoMergeRequest { enabledBy: { login: string }, mergeMethod: string }
+  ---@class octo.PullRequest : octo.ReactionGroupsFragment
+  ---@field id string
+  ---@field isDraft boolean
+  ---@field number integer
+  ---@field state string
+  ---@field title string
+  ---@field body string
+  ---@field createdAt string
+  ---@field closedAt string
+  ---@field updatedAt string
+  ---@field url string
+  ---@field headRepository { nameWithOwner: string }
+  ---@field files { nodes: { path: string, viewerViewedState: ViewedState }[] }
+  ---@field merged boolean
+  ---@field mergedBy { name: string }|{ login: string }|{ login: string, isViewer: boolean }
+  ---@field participants { nodes: { login: string }[] }
+  ---@field additions integer
+  ---@field deletions integer
+  ---@field commits { totalCount: integer }
+  ---@field changedFiles integer
+  ---@field headRefName string
+  ---@field headRefOid string
+  ---@field baseRefName string
+  ---@field baseRefOid string
+  ---@field baseRepository { name: string, nameWithOwner: string }
+  ---@field milestone { title: string, state: string }
+  ---@field author { login: string }
+  ---@field authorAssociation string
+  ---@field viewerDidAuthor boolean
+  ---@field viewerCanUpdate boolean
+  ---@field projectItems? octo.fragments.ProjectsV2Connection
+  ---@field timelineItems octo.PullRequestTimelineItemsConnection
+  ---@field reviewDecision string
+  ---@field reviewThreads { nodes: octo.ReviewThread[] }
+  ---@field labels octo.fragments.LabelConnection
+  ---@field assignees octo.fragments.AssigneeConnection
+  ---@field reviewRequests { totalCount: integer, nodes: { requestedReviewer: { name: string }|{ login: string }|{ login: string, isViewer: boolean } }[] }
+  ---@field statusCheckRollup { state: string }
+  ---@field mergeStateStatus string
+  ---@field mergeable string
+  ---@field autoMergeRequest { enabledBy: { login: string }, mergeMethod: string }
+  ---@field closingIssuesReferences { totalCount: integer, nodes: octo.Issue[], edges: { cursor: string, node: octo.Issue }[], pageInfo: octo.PageInfo }
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#pullrequest
-M.pull_request = [[
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#pullrequest
+  M.pull_request = [[
 query($endCursor: String) {
   repository(owner: "%s", name: "%s") {
     pullRequest(number: %d) {
@@ -151,12 +156,6 @@ query($endCursor: String) {
       updatedAt
       url
       headRepository { nameWithOwner }
-      closingIssuesReferences(first: 10) {
-        totalCount
-        nodes {
-          ...IssueFields
-        }
-      }
       files(first:100) {
         nodes {
           path
@@ -253,21 +252,28 @@ query($endCursor: String) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.ready_for_review_event .. fragments.reopened_event .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.review_requested_event .. fragments.merged_event .. fragments.renamed_title_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.deployed_event .. fragments.head_ref_deleted_event .. fragments.head_ref_restored_event .. fragments.head_ref_force_pushed_event .. fragments.auto_squash_enabled_event .. fragments.added_to_project_v2_event .. fragments.removed_from_project_v2_event .. fragments.project_v2_item_status_changed_event
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.ready_for_review_event .. fragments.reopened_event .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.review_requested_event .. fragments.merged_event .. fragments.renamed_title_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.deployed_event .. fragments.head_ref_deleted_event .. fragments.head_ref_restored_event .. fragments.head_ref_force_pushed_event .. fragments.auto_squash_enabled_event
 
----@class octo.IssueTimelineItemConnection : octo.fragments.IssueTimelineItemsConnection
---- @field pageInfo { hasNextPage: boolean, endCursor: string }
+  if config.values.default_to_projects_v2 then
+    M.pull_request = M.pull_request
+      .. fragments.added_to_project_v2_event
+      .. fragments.removed_from_project_v2_event
+      .. fragments.project_v2_item_status_changed_event
+  end
 
----@class octo.Issue : octo.fragments.IssueInformation, octo.ReactionGroupsFragment
----@field participants { nodes: { login: string }[] }
----@field parent octo.fragments.Issue
----@field projectItems? octo.fragments.ProjectsV2Connection
----@field timelineItems octo.IssueTimelineItemConnection
----@field labels octo.fragments.LabelConnection
----@field assignees octo.fragments.AssigneeConnection
+  ---@class octo.IssueTimelineItemConnection : octo.fragments.IssueTimelineItemsConnection
+  --- @field pageInfo octo.PageInfo
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#issue
-M.issue = [[
+  ---@class octo.Issue : octo.fragments.IssueInformation, octo.ReactionGroupsFragment
+  ---@field participants { nodes: { login: string }[] }
+  ---@field parent octo.fragments.Issue
+  ---@field projectItems? octo.fragments.ProjectsV2Connection
+  ---@field timelineItems octo.IssueTimelineItemConnection
+  ---@field labels octo.fragments.LabelConnection
+  ---@field assignees octo.fragments.AssigneeConnection
+
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#issue
+  M.issue = [[
 query($endCursor: String) {
   repository(owner: "%s", name: "%s") {
     issue(number: %d) {
@@ -298,10 +304,17 @@ query($endCursor: String) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label .. fragments.label_connection .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.renamed_title_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event .. fragments.added_to_project_v2_event .. fragments.project_v2_item_status_changed_event .. fragments.removed_from_project_v2_event
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label .. fragments.label_connection .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.renamed_title_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event
 
--- https://docs.github.com/en/graphql/reference/unions#issueorpullrequest
-M.issue_kind = [[
+  if config.values.default_to_projects_v2 then
+    M.issue = M.issue
+      .. fragments.added_to_project_v2_event
+      .. fragments.removed_from_project_v2_event
+      .. fragments.project_v2_item_status_changed_event
+  end
+
+  -- https://docs.github.com/en/graphql/reference/unions#issueorpullrequest
+  M.issue_kind = [[
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     issueOrPullRequest(number: $number) {
@@ -311,12 +324,12 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 ]]
 
----@class octo.DiscussionSummary : octo.fragments.DiscussionInfo
----@field createdAt string
----@field body string
----@field labels octo.fragments.LabelConnection
+  ---@class octo.DiscussionSummary : octo.fragments.DiscussionInfo
+  ---@field createdAt string
+  ---@field body string
+  ---@field labels octo.fragments.LabelConnection
 
-M.discussion_summary = [[
+  M.discussion_summary = [[
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     discussion(number: $number) {
@@ -330,37 +343,37 @@ query($owner: String!, $name: String!, $number: Int!) {
   }
 }
 ]] .. fragments.discussion_info .. fragments.label_connection .. fragments.label
----@class octo.PullRequestSummary
----@field __typename "PullRequest"
----@field headRefName string
----@field baseRefName string
----@field createdAt string
----@field state string
----@field number integer
----@field title string
----@field body string
----@field repository { nameWithOwner: string }
----@field author { login: string }
----@field authorAssociation string
----@field labels octo.fragments.LabelConnection
+  ---@class octo.PullRequestSummary
+  ---@field __typename "PullRequest"
+  ---@field headRefName string
+  ---@field baseRefName string
+  ---@field createdAt string
+  ---@field state string
+  ---@field number integer
+  ---@field title string
+  ---@field body string
+  ---@field repository { nameWithOwner: string }
+  ---@field author { login: string }
+  ---@field authorAssociation string
+  ---@field labels octo.fragments.LabelConnection
 
----@class octo.IssueSummary
----@field __typename "Issue"
----@field createdAt string
----@field state string
----@field stateReason string
----@field number integer
----@field title string
----@field body string
----@field repository { nameWithOwner: string }
----@field author { login: string }
----@field authorAssociation string
----@field labels octo.fragments.LabelConnection
+  ---@class octo.IssueSummary
+  ---@field __typename "Issue"
+  ---@field createdAt string
+  ---@field state string
+  ---@field stateReason string
+  ---@field number integer
+  ---@field title string
+  ---@field body string
+  ---@field repository { nameWithOwner: string }
+  ---@field author { login: string }
+  ---@field authorAssociation string
+  ---@field labels octo.fragments.LabelConnection
 
----@alias octo.IssueOrPullRequestSummary octo.PullRequestSummary|octo.IssueSummary
+  ---@alias octo.IssueOrPullRequestSummary octo.PullRequestSummary|octo.IssueSummary
 
--- https://docs.github.com/en/graphql/reference/unions#issueorpullrequest
-M.issue_summary = [[
+  -- https://docs.github.com/en/graphql/reference/unions#issueorpullrequest
+  M.issue_summary = [[
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     issueOrPullRequest(number: $number) {
@@ -400,8 +413,8 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 ]] .. fragments.label_connection .. fragments.label
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#repository
-M.repository_id = [[
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#repository
+  M.repository_id = [[
 query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     id
@@ -409,14 +422,14 @@ query($owner: String!, $name: String!) {
 }
 ]]
 
----@class octo.queries.RepositoryTemplates.data.repository
----@field issueTemplates { body: string, about: string, name: string, title: string }[]
----@field pullRequestTemplates { body: string, filename: string }[]
+  ---@class octo.queries.RepositoryTemplates.data.repository
+  ---@field issueTemplates { body: string, about: string, name: string, title: string }[]
+  ---@field pullRequestTemplates { body: string, filename: string }[]
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#repository
--- https://docs.github.com/en/graphql/reference/objects#issuetemplate
--- https://docs.github.com/en/graphql/reference/objects#pullrequesttemplate
-M.repository_templates = [[
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#repository
+  -- https://docs.github.com/en/graphql/reference/objects#issuetemplate
+  -- https://docs.github.com/en/graphql/reference/objects#pullrequesttemplate
+  M.repository_templates = [[
 query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     issueTemplates { body about name title  }
@@ -425,29 +438,29 @@ query($owner: String!, $name: String!) {
 }
 ]]
 
----https://docs.github.com/en/graphql/reference/input-objects#issuefilters
----@class octo.queries.IssueFilters
----@field assignee? string
----@field createdBy? string
----@field labels? string[]
----@field mentioned? string
----@field milestone string
----@field milestoneNumber? string
----@field since? string
----@field states? string[]
----@field type? string
----@field viewerSubscribed? boolean
+  ---https://docs.github.com/en/graphql/reference/input-objects#issuefilters
+  ---@class octo.queries.IssueFilters
+  ---@field assignee? string
+  ---@field createdBy? string
+  ---@field labels? string[]
+  ---@field mentioned? string
+  ---@field milestone string
+  ---@field milestoneNumber? string
+  ---@field since? string
+  ---@field states? string[]
+  ---@field type? string
+  ---@field viewerSubscribed? boolean
 
---- https://docs.github.com/en/graphql/reference/input-objects#issueorder
----@class octo.queries.IssueOrder
----@field direction string
----@field field string
+  --- https://docs.github.com/en/graphql/reference/input-objects#issueorder
+  ---@class octo.queries.IssueOrder
+  ---@field direction string
+  ---@field field string
 
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#issue
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/input-objects#issueorder
--- https://docs.github.com/en/free-pro-team@latest/graphql/reference/input-objects#issuefilters
--- filter eg: labels: ["help wanted", "bug"]
-M.issues = [[
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#issue
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/input-objects#issueorder
+  -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/input-objects#issuefilters
+  -- filter eg: labels: ["help wanted", "bug"]
+  M.issues = [[
 query(
   $owner: String!,
   $name: String!,
@@ -476,9 +489,9 @@ query(
 }
 ]]
 
----
+  ---
 
-M.pull_requests = [[
+  M.pull_requests = [[
 query(
   $owner: String!,
   $name: String!,
@@ -518,7 +531,7 @@ query(
 }
 ]]
 
-M.search_count = [[
+  M.search_count = [[
 query($prompt: String!, $type: SearchType = ISSUE) {
   search(query: $prompt, type: $type, last: 100) {
     issueCount
@@ -526,7 +539,7 @@ query($prompt: String!, $type: SearchType = ISSUE) {
 }
 ]]
 
-M.search = [[
+  M.search = [[
 query($prompt: String!, $type: SearchType = ISSUE, $last: Int = 100) {
   search(query: $prompt, type: $type, last: $last) {
     nodes {
@@ -574,7 +587,7 @@ query($prompt: String!, $type: SearchType = ISSUE, $last: Int = 100) {
 }
 ]] .. fragments.discussion_info .. fragments.repository
 
-M.discussions = [[
+  M.discussions = [[
 query(
   $owner: String!,
   $name: String!,
@@ -604,7 +617,7 @@ query(
 }
 ]] .. fragments.discussion_info
 
-M.discussion_categories = [[
+  M.discussion_categories = [[
 query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     discussionCategories(first: 20) {
@@ -617,24 +630,21 @@ query($owner: String!, $name: String!) {
   }
 }
 ]]
----@class octo.DiscussionComment : octo.fragments.DiscussionComment
----@field replies {
----  totalCount: integer,
----  nodes: octo.fragments.DiscussionComment[],
----  pageInfo: {
----    hasNextPage: boolean,
----    endCursor: string,
----  },
----}
+  ---@class octo.DiscussionComment : octo.fragments.DiscussionComment
+  ---@field replies {
+  ---  totalCount: integer,
+  ---  nodes: octo.fragments.DiscussionComment[],
+  ---  pageInfo: octo.PageInfo,
+  ---}
 
----@class octo.Discussion : octo.fragments.DiscussionDetails
----@field labels octo.fragments.LabelConnection
----@field comments {
----  totalCount: integer,
----  nodes: octo.DiscussionComment[],
----}
+  ---@class octo.Discussion : octo.fragments.DiscussionDetails
+  ---@field labels octo.fragments.LabelConnection
+  ---@field comments {
+  ---  totalCount: integer,
+  ---  nodes: octo.DiscussionComment[],
+  ---}
 
-M.discussion = [[
+  M.discussion = [[
 query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
   repository(owner: $owner, name: $name) {
     discussion(number: $number) {
@@ -663,27 +673,27 @@ query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
 }
 ]] .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.discussion_info .. fragments.discussion_details .. fragments.discussion_comment
 
----@class octo.Release : octo.ReactionGroupsFragment
---- @field id string
---- @field name string
---- @field tagName string
---- @field tagCommit { abbreviatedOid: string }
---- @field url string
---- @field isPrerelease boolean
---- @field isLatest boolean
---- @field publishedAt string
---- @field description string
---- @field author { login: string }
---- @field releaseAssets {
----   nodes: {
----     name: string,
----     downloadUrl: string,
----     downloadCount: number,
----     size: number,
----     updatedAt: string,
----   }[] }
+  ---@class octo.Release : octo.ReactionGroupsFragment
+  --- @field id string
+  --- @field name string
+  --- @field tagName string
+  --- @field tagCommit { abbreviatedOid: string }
+  --- @field url string
+  --- @field isPrerelease boolean
+  --- @field isLatest boolean
+  --- @field publishedAt string
+  --- @field description string
+  --- @field author { login: string }
+  --- @field releaseAssets {
+  ---   nodes: {
+  ---     name: string,
+  ---     downloadUrl: string,
+  ---     downloadCount: number,
+  ---     size: number,
+  ---     updatedAt: string,
+  ---   }[] }
 
-M.release = [[
+  M.release = [[
 query($owner: String!, $name: String!, $tag: String!) {
   repository(owner: $owner, name: $name) {
     release(tagName: $tag) {
@@ -716,8 +726,8 @@ query($owner: String!, $name: String!, $tag: String!) {
 }
 ]] .. fragments.reaction_groups
 
--- https://docs.github.com/en/graphql/reference/objects#projectv2
-M.projects_v2 = [[
+  -- https://docs.github.com/en/graphql/reference/objects#projectv2
+  M.projects_v2 = [[
 query($owner: String!, $name: String!, $viewer: String!) {
   repository(owner: $owner, name: $name) {
     projects: projectsV2(first: 100) {
@@ -806,8 +816,8 @@ query($owner: String!, $name: String!, $viewer: String!) {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/objects#label
-M.labels = [[
+  -- https://docs.github.com/en/graphql/reference/objects#label
+  M.labels = [[
 query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     labels(first: 100) {
@@ -817,7 +827,7 @@ query($owner: String!, $name: String!) {
 }
 ]] .. fragments.label_connection .. fragments.label
 
-M.issue_labels = [[
+  M.issue_labels = [[
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     issue(number: $number) {
@@ -829,7 +839,7 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 ]] .. fragments.label_connection .. fragments.label
 
-M.discussion_labels = [[
+  M.discussion_labels = [[
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     discussion(number: $number) {
@@ -841,7 +851,7 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 ]] .. fragments.label_connection .. fragments.label
 
-M.pull_request_labels = [[
+  M.pull_request_labels = [[
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
@@ -853,7 +863,7 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 ]] .. fragments.label_connection .. fragments.label
 
-M.pull_request_reviewers = [[
+  M.pull_request_reviewers = [[
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
@@ -882,7 +892,7 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 ]]
 
-M.issue_assignees = [[
+  M.issue_assignees = [[
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     issue(number: $number) {
@@ -894,7 +904,7 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 ]] .. fragments.assignee_connection
 
-M.pull_request_assignees = [[
+  M.pull_request_assignees = [[
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
@@ -905,29 +915,29 @@ query($owner: String!, $name: String!, $number: Int!) {
   }
 }
 ]] .. fragments.assignee_connection
----@class octo.UserProfile
----@field login string
----@field bio string
----@field company string
----@field followers { totalCount: integer }
----@field following { totalCount: integer }
----@field hovercard { contexts: { message: string }[] }
----@field hasSponsorsListing boolean
----@field isEmployee boolean
----@field isViewer boolean
----@field location string
----@field organizations { nodes: { name: string }[] }
----@field name string
----@field status { emoji: string, message: string }
----@field twitterUsername string
----@field websiteUrl string
+  ---@class octo.UserProfile
+  ---@field login string
+  ---@field bio string
+  ---@field company string
+  ---@field followers { totalCount: integer }
+  ---@field following { totalCount: integer }
+  ---@field hovercard { contexts: { message: string }[] }
+  ---@field hasSponsorsListing boolean
+  ---@field isEmployee boolean
+  ---@field isViewer boolean
+  ---@field location string
+  ---@field organizations { nodes: { name: string }[] }
+  ---@field name string
+  ---@field status { emoji: string, message: string }
+  ---@field twitterUsername string
+  ---@field websiteUrl string
 
----@class octo.queries.UserProfile
----@field data {
----  user: octo.UserProfile,
----}
+  ---@class octo.queries.UserProfile
+  ---@field data {
+  ---  user: octo.UserProfile,
+  ---}
 
-M.user_profile = [[
+  M.user_profile = [[
 query($login: String!) {
   user(login: $login) {
     login
@@ -964,7 +974,7 @@ query($login: String!) {
 }
 ]]
 
-M.changed_files = [[
+  M.changed_files = [[
 query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
@@ -984,7 +994,7 @@ query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
 }
 ]]
 
-M.file_content = [[
+  M.file_content = [[
 query($owner: String!, $name: String!, $expression: String!) {
   repository(owner: $owner, name: $name) {
     object(expression: $expression) {
@@ -996,7 +1006,7 @@ query($owner: String!, $name: String!, $expression: String!) {
 }
 ]]
 
-M.directory_file_content = [[
+  M.directory_file_content = [[
 query($owner: String!, $name: String!, $expression: String!) {
   repository(owner: $owner, name: $name) {
     object(expression: $expression) {
@@ -1015,12 +1025,12 @@ query($owner: String!, $name: String!, $expression: String!) {
 }
 ]]
 
----@class octo.queries.ReactionsForObject
----@field data {
----  node: octo.fragments.ReactionGroupsUsers,
----}
+  ---@class octo.queries.ReactionsForObject
+  ---@field data {
+  ---  node: octo.fragments.ReactionGroupsUsers,
+  ---}
 
-M.reactions_for_object = [[
+  M.reactions_for_object = [[
 query($id: ID!) {
   node(id: $id) {
     ... on Issue {
@@ -1048,7 +1058,7 @@ query($id: ID!) {
 }
 ]] .. fragments.reaction_groups_users
 
-M.mentionable_users = [[
+  M.mentionable_users = [[
 query($owner: String!, $name: String!, $endCursor: String) {
   repository(owner: $owner, name: $name) {
       mentionableUsers(first: 100, after: $endCursor) {
@@ -1066,7 +1076,7 @@ query($owner: String!, $name: String!, $endCursor: String) {
 }
 ]]
 
-M.assignable_users = [[
+  M.assignable_users = [[
 query($owner: String!, $name: String! $endCursor: String) {
   repository(owner: $owner, name: $name) {
     assignableUsers(first: 100, after: $endCursor) {
@@ -1084,7 +1094,7 @@ query($owner: String!, $name: String! $endCursor: String) {
 }
 ]]
 
-M.users = [[
+  M.users = [[
 query($prompt: String!, $endCursor: String) {
   search(query: $prompt, type: USER, first: 100) {
     nodes {
@@ -1112,7 +1122,7 @@ query($prompt: String!, $endCursor: String) {
 }
 ]]
 
-M.repos = [[
+  M.repos = [[
 query($login: String!, $endCursor: String) {
   repositoryOwner(login: $login) {
     repositories(first: 10, after: $endCursor, ownerAffiliations: [COLLABORATOR, ORGANIZATION_MEMBER, OWNER]) {
@@ -1127,23 +1137,23 @@ query($login: String!, $endCursor: String) {
   }
 }
 ]] .. fragments.repository
----@class octo.Repository : octo.fragments.Repository
----@field pushedAt string
----@field defaultBranchRef { name: string }
----@field securityPolicyUrl string
----@field isLocked boolean
----@field lockReason string
----@field isMirror boolean
----@field mirrorUrl string
----@field hasProjectsEnabled boolean
----@field hasDiscussionsEnabled boolean
----@field projectsUrl string
----@field homepageUrl string
----@field primaryLanguage { name: string, color: string }
----@field refs { nodes: { name: string }[] }
----@field languages { nodes: { name: string, color: string }[] }
+  ---@class octo.Repository : octo.fragments.Repository
+  ---@field pushedAt string
+  ---@field defaultBranchRef { name: string }
+  ---@field securityPolicyUrl string
+  ---@field isLocked boolean
+  ---@field lockReason string
+  ---@field isMirror boolean
+  ---@field mirrorUrl string
+  ---@field hasProjectsEnabled boolean
+  ---@field hasDiscussionsEnabled boolean
+  ---@field projectsUrl string
+  ---@field homepageUrl string
+  ---@field primaryLanguage { name: string, color: string }
+  ---@field refs { nodes: { name: string }[] }
+  ---@field languages { nodes: { name: string, color: string }[] }
 
-M.repository = [[
+  M.repository = [[
 query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     ...RepositoryFragment
@@ -1179,7 +1189,7 @@ query($owner: String!, $name: String!) {
 }
 ]] .. fragments.repository
 
-M.gists = [[
+  M.gists = [[
 query($privacy: GistPrivacy = ALL, $endCursor: String) {
   viewer {
     gists(first: 100, privacy: $privacy, after: $endCursor) {
@@ -1207,8 +1217,8 @@ query($privacy: GistPrivacy = ALL, $endCursor: String) {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/queries#user
-M.user = [[
+  -- https://docs.github.com/en/graphql/reference/queries#user
+  M.user = [[
 query($login: String!) {
   user(login: $login) {
     id
@@ -1216,8 +1226,8 @@ query($login: String!) {
 }
 ]]
 
--- https://docs.github.com/en/graphql/reference/objects#pullrequestreviewthread
-M.repo_labels = [[
+  -- https://docs.github.com/en/graphql/reference/objects#pullrequestreviewthread
+  M.repo_labels = [[
 query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     labels(first: 100) {
@@ -1227,7 +1237,7 @@ query($owner: String!, $name: String!) {
 }
 ]] .. fragments.label_connection .. fragments.label
 
-M.open_milestones = [[
+  M.open_milestones = [[
 query($name: String!, $owner: String!, $n_milestones: Int!) {
   repository(owner: $owner, name: $name) {
     milestones(first: $n_milestones, states: [OPEN]) {
@@ -1242,7 +1252,7 @@ query($name: String!, $owner: String!, $n_milestones: Int!) {
 }
 ]]
 
-M.comment_url = [[
+  M.comment_url = [[
 query($id: ID!) {
   node(id: $id) {
     ... on IssueComment {
@@ -1261,13 +1271,13 @@ query($id: ID!) {
 }
 ]]
 
----@class octo.IssueType
----@field id string
----@field name string
----@field description string
----@field color string
+  ---@class octo.IssueType
+  ---@field id string
+  ---@field name string
+  ---@field description string
+  ---@field color string
 
-M.issue_types = [[
+  M.issue_types = [[
 query($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     issueTypes(first: 100) {
@@ -1281,5 +1291,6 @@ query($owner: String!, $name: String!) {
   }
 }
 ]]
+end
 
 return M


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

There are issues using Octo on GitHub Enterprice instances after merging pwntester/octo.nvim/pull/1215. Now configuration setting `default_to_projects_v2` also disables sending v2 events into Github API.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #1234 

### Describe how you did it


### Describe how to verify it




### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
