### PR TITLE
fix: allow for repo buffer uri parsing

### DIFF
--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -100,7 +100,7 @@ function M.load_buffer(opts)
   local cursor_pos = vim.api.nvim_win_get_cursor(0)
   local bufname = vim.fn.bufname(bufnr)
   local repo, kind, id = string.match(bufname, "octo://(.+)/(.+)/([0-9a-z.]+)")
-  if not repo then
+  if id == "repo" or not repo then
     repo = string.match(bufname, "octo://(.+)/repo")
     if repo then
       kind = "repo"
@@ -113,6 +113,7 @@ function M.load_buffer(opts)
     utils.print_err("Incorrect buffer: " .. bufname)
     return
   end
+
   M.load(repo, kind, id, function(obj)
     vim.api.nvim_buf_call(bufnr, function()
       M.create_buffer(kind, obj, repo, false)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

After the release buffer, the uri parsing logic was not working as expected. This 
brings back the parsing to support repository buffers.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
