### PR TITLE
fix: provide current_review in review_commits mapping

### DIFF
--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -207,7 +207,7 @@ return {
     if not current_review then
       return
     end
-    require("octo.picker").review_commits(function(right, left)
+    require("octo.picker").review_commits(current_review, function(right, left)
       current_review:focus_commit(right, left)
     end)
   end,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

The `review_commits` mapping is not working, it raises the following error:

```
E5108: Error executing lua: ...m/lazy/octo.nvim/lua/octo/pickers/telescope/provider.lua:447: attempt to index local 'current_review' (a function value)
stack traceback:
        ...m/lazy/octo.nvim/lua/octo/pickers/telescope/provider.lua:447: in function 'review_commits'
        ...k/.local/share/nvim/lazy/octo.nvim/lua/octo/mappings.lua:210: in function <...k/.local/share/nvim/lazy/octo.nvim/lua/octo/mappings.lua:205>
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

None

### Describe how you did it

Added `current_review` to the `review_commits` function call

### Describe how to verify it

Start a review and do `<localleader>C` to verify that it works now.

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
