### PR TITLE
fix: add reviewer/assignee support for GitHub and Enterprise

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -206,7 +206,7 @@ local function run(opts)
   end
 
   ---@diagnostic disable-next-line: missing-fields
-  local job = Job:new {
+  local job_opts = {
     enable_recording = true,
     command = config.values.gh_cmd,
     args = opts.args,
@@ -224,6 +224,13 @@ local function run(opts)
     end),
     env = env,
   }
+
+  -- Support for passing data via stdin (e.g., for REST API JSON bodies)
+  if opts.writer then
+    job_opts.writer = opts.writer
+  end
+
+  local job = Job:new(job_opts)
   if mode == "sync" then
     job:sync(conf.timeout)
     return table.concat(job:result(), "\n"), table.concat(job:stderr_result(), "\n")

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1769,6 +1769,14 @@ function M.get_user_id(login)
   return id --[[@as string]]
 end
 
+--- Detects if a node ID uses the new format (regular GitHub)
+--- vs the old base64 format (GitHub Enterprise)
+---@param id string
+---@return boolean
+function M.is_new_node_id_format(id)
+  return id and type(id) == "string" and id:match "^%u_" ~= nil
+end
+
 ---@param label string
 function M.get_label_id(label)
   local buffer = M.get_current_buffer()


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fixes adding reviewers to pull requests on regular GitHub (github.com) which was failing while Enterprise GitHub worked. The issue stems from different node ID formats between the two platforms.

### Does this pull request fix one issue?
NONE

### Describe how you did it
Added is_new_node_id_format() to detect GitHub type via node ID:
Regular: U_xxx format → use REST API
Enterprise: base64 format → use GraphQL
Regular GitHub path: Query login from ID, call REST API with usernames
Enterprise path: Use existing GraphQL with JSON-encoded node IDs
Added writer support to gh.run() for stdin JSON body

### Describe how to verify it
Regular GitHub: :Octo reviewer add <username> → should succeed
Enterprise: Same command → should continue working
No "Invalid node ID" or GraphQL errors

### Special notes for reviews
Avoids GraphQL Projects (classic) deprecation
Backward compatible with Enterprise
Auto-detects GitHub type
Uses usernames (REST) for stability on regular GitHub

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
