### PR TITLE
fix(docs): rename NOTE to Note

### DIFF
--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -41,7 +41,7 @@ Any CLI arguments can be passed as well. For example, >lua
 <
 
 This is same as `gh issue list --label "bug" --limit 5 --state "closed"` in
-the terminal. *NOTE:* For parameters with `-`, use an `_` in the key instead.  For
+the terminal. Note: For parameters with `-`, use an `_` in the key instead.  For
 example, `--add-assignee` becomes `add_assignee` in the Lua API.
 
 Consult the GitHub CLI documentation for the available commands and
@@ -139,7 +139,7 @@ This is the same as >terminal
 
     gh api graphql -f query='query { viewer { login } }' --jq '.data.viewer.json'
 <
-in the terminal. *NOTE:* Single character keys are passed with single `-` in
+in the terminal. Note: Single character keys are passed with single `-` in
 the CLI.
 
 Parameterized queries are also possible mirroring the syntax in CLI. Just pass


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Getting this bug after installing the latest version of octo via the `lazy.nvim` package manager:

```
...hare/nvim/lazy/lazy.nvim/lua/lazy/manage/task/plugin.lua:95: Vim:E154: Duplicate tag "NOTE:" in file /Users/me/.local/share/nvim/lazy/octo.nvim/doc/octo.txt
```

I think the `NOTE:` stuff are treated as tags, which there a few in the doc file. I just renamed them to `Note:` which seems to remove the above error (It was `Note:` in a previous commit but changes to `NOTE:` in a recent version)

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

Changed `NOTE:` to `Note:` and verified it removes the above error

### Describe how to verify it

Try to up to the latest version of octo from an older version to see the error. Apply the changes in this PR to see that the error no longer persists.

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
