### PR TITLE
fix: add buffer nil check for issue create

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1473,7 +1473,11 @@ end
 function M.create_issue(repo)
   local buffer = utils.get_current_buffer()
   if not repo then
-    repo = buffer.repo or utils.get_remote_name()
+    if buffer and buffer.repo then
+      repo = buffer.repo
+    else
+      repo = utils.get_remote_name()
+    end
   end
 
   if not repo then


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Adds a nil check, before accessing buffer.repo, like in other places

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #1289 

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
