### PR TITLE
feat: add filename to notification picker

### DIFF
--- a/lua/octo/pickers/telescope/entry_maker.lua
+++ b/lua/octo/pickers/telescope/entry_maker.lua
@@ -706,8 +706,22 @@ function M.gen_from_notification(opts)
       return nil
     end
     local ref = notification.subject.url:match "/(%d+)$"
+    local filename
+
+    if notification.kind == "issue" then
+      filename = utils.get_issue_uri(ref, notification.repository.full_name)
+    elseif notification.kind == "pull_request" then
+      filename = utils.get_pull_request_uri(ref, notification.repository.full_name)
+    elseif notification.kind == "discussion" then
+      filename = utils.get_discussion_uri(ref, notification.repository.full_name)
+    elseif notification.kind == "release" then
+      filename = utils.get_release_uri(ref, notification.repository.full_name)
+    else
+      filename = ""
+    end
 
     return {
+      filename = filename,
       value = ref,
       ordinal = notification.subject.title .. " " .. notification.repository.full_name .. " " .. ref,
       display = make_display,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

This adds filename to the picker which allows creating a quickfix list for notifications. Then users can navigate through the list of notifications.

It is recommended to change the next_comment in order to jump to the next notification:

https://github.com/pwntester/octo.nvim/blob/10332cbf6d2f907889c8eb64b8ebe6fff9d0c4ca/lua/octo/config.lua?plain=1#L311-L312

The alternative is to user `:cnext` and `:cprev` commands.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Add the filename to the entry_maker.

### Describe how to verify it

`Octo notification list`, `<C-q>` to create quickfix list, then navigate through it.

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
