### PR TITLE
feat: add semantic PR title validation workflow

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,55 @@
+---
+name: Semantic Pull Request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  semantic-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (default: build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Configure which scopes are allowed (optional)
+          # scopes: |
+          #   core
+          #   ui
+          #   api
+          # Require a scope to be provided
+          requireScope: false
+          # Configure that a scope must always be empty
+          disallowScopes: false
+          # Configure additional validation for the subject
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject must not start with an uppercase character.
+          # If a PR title matches this pattern, validation is skipped
+          # headerPattern: ^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$
+          # Whether to validate that the PR title matches the pattern
+          validateSingleCommit: false
+          # Whether to validate that single-commit PRs match the PR title
+          validateSingleCommitMatchesPrTitle: false


### PR DESCRIPTION
This PR adds a GitHub Action workflow that validates pull request titles against conventional commit format using the `amannn/action-semantic-pull-request` action.

## Changes
- Added `.github/workflows/semantic-pr.yml` workflow
- Validates PR titles follow conventional commit format (feat:, fix:, docs:, etc.)
- Automatically runs on PR open, edit, and synchronize events
- Supports standard conventional commit types

## Benefits
- Ensures consistent PR title formatting
- Helps with automated changelog generation
- Improves project organization and history