### PR TITLE
feat: no confirmation with no comments

### DIFF
--- a/lua/octo/gh/fragments.lua
+++ b/lua/octo/gh/fragments.lua
@@ -1113,8 +1113,16 @@ fragment IssueInformationFragment on Issue {
 }
 ]]
 
+  ---State of an individual pull request review comment
   ---https://docs.github.com/en/graphql/reference/enums#pullrequestreviewcommentstate
   ---@alias octo.PullRequestReviewCommentState "PENDING"|"SUBMITTED"
+
+  ---State of a pull request review (the parent of review comments)
+  ---Note: Review threads can contain comments from multiple reviews with different states.
+  ---When filtering for pending comments, check pullRequestReview.state == "PENDING" to ensure
+  ---you're only getting comments from the pending review, not from previously submitted reviews.
+  ---https://docs.github.com/en/graphql/reference/enums#pullrequestreviewstate
+  ---@alias octo.PullRequestReviewState "PENDING"|"COMMENTED"|"APPROVED"|"CHANGES_REQUESTED"|"DISMISSED"
 
   ---@class octo.ReviewThreadCommentFragment : octo.ReactionGroupsFragment
   --- @field id string
@@ -1129,10 +1137,10 @@ fragment IssueInformationFragment on Issue {
   --- @field viewerDidAuthor boolean
   --- @field viewerCanUpdate boolean
   --- @field viewerCanDelete boolean
-  --- @field state string
+  --- @field state octo.PullRequestReviewCommentState
   --- @field url string
   --- @field replyTo { id: string, url: string }
-  --- @field pullRequestReview { id: string, state: octo.PullRequestReviewCommentState }
+  --- @field pullRequestReview { id: string, state: octo.PullRequestReviewState }
   --- @field path string
 
   M.review_thread_comment = [[

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -232,8 +232,7 @@ function Review:initiate(opts)
 end
 
 ---Counts pending comments with non-empty bodies in review threads
----Filters for comments with state "PENDING" (not yet submitted as part of a review)
----@see octo.PullRequestReviewCommentState
+---@see octo.PullRequestReviewState for explanation of why we check pullRequestReview.state
 ---@param threads octo.ReviewThread[]
 ---@return integer count The number of pending comments with content
 local function count_pending_comments(threads)


### PR DESCRIPTION
### Describe what this PR does / why we need it

Skip confirmation prompt when discarding a review with no pending comments. When there are pending comments, show count in confirmation message.

### Does this pull request fix one issue?

Fixes #1262

### Describe how you did it

- Added `count_pending_comments()` helper function that filters review threads for comments with `pullRequestReview.state == "PENDING"` and non-empty body
- Modified `Review:discard()` to only show confirmation when pending comments exist
- Improved confirmation message to show exact count: "X pending comment(s) will be deleted, are you sure?"
- Added `PullRequestReviewState` type alias with documentation explaining review vs comment state filtering

### Describe how to verify it

1. Start a PR review with no comments → discard review → no confirmation shown
2. Start a PR review with 1 comment → discard review → confirmation shows "1 pending comment will be deleted"
3. Start a PR review with multiple comments → discard review → confirmation shows "N pending comments will be deleted"
4. Review with only whitespace comments → treated as empty (no confirmation)

### Special notes for reviews

The key distinction is between `PullRequestReviewState` (parent review) and `PullRequestReviewCommentState` (individual comments). We check `pullRequestReview.state == "PENDING"` because review threads can contain comments from multiple reviews, and we only want to count comments from the current pending review.

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt