### PR TITLE
feat: add option to reference issue when creating from issue buffer

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1614,7 +1614,7 @@ function M.save_issue(opts)
     local has_number = buffer and buffer.number
     local is_referenceable = has_number and (buffer:isIssue() or buffer:isPullRequest() or buffer:isDiscussion())
 
-    local prompt, default_choice, reference_format
+    local msg, choices, default_choice, reference_format
     if is_referenceable then
       local type_name = buffer:isIssue() and "issue" or buffer:isPullRequest() and "pull request" or "discussion"
 
@@ -1627,18 +1627,16 @@ function M.save_issue(opts)
         reference_format = string.format("#%d", buffer.number)
       end
 
-      prompt = string.format(
-        "Creating related issue from %s. How do you want to set the body?\n&Reference (Related to %s)\n&Copy content\n&Empty\n&Cancel",
-        type_name,
-        reference_format
-      )
+      msg = string.format("Creating related issue from %s. How do you want to set the body?", type_name)
+      choices = string.format("&Reference (Related to %s)\n&Copy content\n&Empty\n&Cancel", reference_format)
       default_choice = 1
     else
-      prompt = "Do you want to use the content of the current buffer as the body for the new issue?\n&Yes\n&No\n&Cancel"
+      msg = "Do you want to use the content of the current buffer as the body for the new issue?"
+      choices = "&Yes\n&No\n&Cancel"
       default_choice = 2
     end
 
-    local choice = vim.fn.confirm(prompt, default_choice)
+    local choice = vim.fn.confirm(msg, choices, default_choice)
 
     if is_referenceable then
       if choice == 1 then


### PR DESCRIPTION
### Describe what this PR does / why we need it

When creating a new issue from an issue, pull request, or discussion buffer, offers a more compact option to reference the current item using the appropriate GitHub reference format. Automatically handles both same-repository and cross-repository references.

### Does this pull request fix one issue?

Related to #1284

### Describe how you did it

- Modified `save_issue` function to detect if currently in an issue, pull request, or discussion buffer
- **Smart reference formatting**: Compares buffer repo with target repo
  - Same repo: Uses `#number` format (e.g., "Related to #123")
  - Cross repo: Uses `owner/repo#number` format (e.g., "Related to pwntester/octo.nvim#123")
- When in a referenceable buffer, show three options:
  1. **Reference** (default): Add appropriate reference format to the body
  2. **Copy content**: Copy entire buffer content (previous behavior)
  3. **Empty**: Create with empty body
- Prompt dynamically shows the current buffer type and reference format
- For non-referenceable buffers, maintain the original two-option behavior (Yes/No)
- Default choice is "Reference" for referenceable buffers, making it quick and convenient

### Describe how to verify it

**Test Case 1: Same repository reference**
1. Open any issue in repo A with `Octo issue <number>`
2. Run `Octo issue create` (creating in same repo A)
3. Dialog should show: "Creating related issue from issue. How do you want to set the body? Reference (Related to #123)..."
4. Select "Reference"
5. New issue body: "Related to #123"

**Test Case 2: Cross-repository reference**
1. Open an issue from pwntester/octo.nvim with `Octo issue 100`
2. Run `Octo issue create someuser/other-repo` (creating in different repo)
3. Dialog should show: "Reference (Related to pwntester/octo.nvim#100)..."
4. Select "Reference"
5. New issue body: "Related to pwntester/octo.nvim#100"

**Test Case 3: Fork workflow**
1. Open a PR from your fork with `Octo pr 50`
2. Run `Octo issue create upstream/repo` (creating in upstream)
3. Cross-repo reference should be used: "youruser/yourfork#50"

**Test Case 4: From pull request buffer**
1. Open any PR with `Octo pr <number>`
2. Run `Octo issue create`
3. Dialog should show: "Creating related issue from pull request..."
4. Works same as issues with smart reference formatting

**Test Case 5: From discussion buffer**
1. Open any discussion
2. Run `Octo issue create`
3. Dialog should show: "Creating related issue from discussion..."
4. Works same as issues with smart reference formatting

**Test Case 6: From regular buffer**
1. Open a regular file (not an issue/PR/discussion buffer)
2. Run `Octo issue create <repo>`
3. Original Yes/No/Cancel prompt, unchanged behavior

### Special notes for reviews

This enhancement makes it ergonomic to create related issues from any GitHub item while correctly handling cross-repository references. This is particularly useful for:
- **Fork workflows**: Creating issues in upstream from fork PRs
- **Multi-repo projects**: Referencing issues across related repositories
- **Bug tracking**: Creating issues in one repo that reference PRs/issues in another

GitHub's reference formats:
- `#123` - Links to same repository
- `owner/repo#123` - Links across repositories

Both formats create automatic cross-reference links in GitHub's UI.

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt