### PR TITLE
chore: add syntax highlighting for graphql queries

### DIFF
--- a/after/queries/lua/injections.scm
+++ b/after/queries/lua/injections.scm
@@ -1,0 +1,40 @@
+; extends
+
+; allow injections in strings with an inject: <lang> comment
+; need three copies of the same query for:
+; - handling variable member assignment to string
+; - variable member assignment to a string concatenated with other strings
+; - the above but with some edge case i'm not sure about
+; reference: https://github.com/folke/snacks.nvim/commit/1d5b12d0c67071320e5572a1f2ac1265904426b3
+((comment
+  content: (comment_content) @injection.language)
+  (#lua-match? @injection.language "inject%s*:%s*%S+")
+  (#gsub! @injection.language "^%s*inject%s*:%s*(%S+).*" "%1")
+  .
+  (_
+    (_
+      (string
+        content: (string_content) @injection.content))))
+
+((comment
+  content: (comment_content) @injection.language)
+  (#lua-match? @injection.language "inject%s*:%s*%S+")
+  (#gsub! @injection.language "^%s*inject%s*:%s*(%S+).*" "%1")
+  .
+  (_
+    (_
+      (_
+        (string
+          content: (string_content) @injection.content)))))
+
+((comment
+  content: (comment_content) @injection.language)
+  (#lua-match? @injection.language "inject%s*:%s*%S+")
+  (#gsub! @injection.language "^%s*inject%s*:%s*(%S+).*" "%1")
+  .
+  (_
+    (_
+      (_
+        (_
+          (string
+            content: (string_content) @injection.content))))))

--- a/lua/octo/gh/fragments.lua
+++ b/lua/octo/gh/fragments.lua
@@ -20,6 +20,7 @@ M.setup = function()
   ---  },
   ---}[]
 
+  -- inject: graphql
   M.projects_v2 = [[
   projectItems(first: 100) {
     nodes {

--- a/lua/octo/gh/mutations.lua
+++ b/lua/octo/gh/mutations.lua
@@ -5,6 +5,7 @@ local M = {}
 
 M.setup = function()
   -- https://docs.github.com/en/graphql/reference/mutations#addreaction
+  -- inject: graphql
   M.add_reaction = [[
 mutation {
   addReaction(input: {subjectId: "%s", content: %s}) {

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -28,6 +28,7 @@ M.setup = function()
   ---}
 
   -- https://docs.github.com/en/graphql/reference/objects#pullrequestreviewthread
+  -- inject: graphql
   M.pending_review_threads = [[
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {


### PR DESCRIPTION
### Describe what this PR does / why we need it

steals this devx nicety from https://github.com/folke/snacks.nvim/commit/1d5b12d0c67071320e5572a1f2ac1265904426b3 to add graphql syntax highlighting to graphql strings. Needed a bit of a hackier solution to accomodate for it, but I think it's worth it since it looks nice.

another note: this doesn't behave well with primitive lazy loading (such as lazy loading on `Octo` user command), but the code snippet below seems to work fine

```lua
vim.api.nvim_create_autocmd({ 'BufReadPre' }, {
  group = lazy_load_octo,
  pattern = '*/octo.nvim/lua/octo/gh/*.lua',
  callback = function()
    require('octo')
  end,
})
```


https://github.com/user-attachments/assets/c448627e-925a-4a27-ac13-5c2255a139be

