### PR TITLE
feat(issue/pr): add subscription status to details

### DIFF
--- a/lua/octo/gh/mutations.lua
+++ b/lua/octo/gh/mutations.lua
@@ -1335,14 +1335,14 @@ mutation($issue_id: ID!, $issue_type_id: ID) {
   ---  updateSubscription: {
   ---    subscribable: {
   ---      id: string,
-  ---      viewerSubscription: "SUBSCRIBED"|"UNSUBSCRIBED"|"IGNORED",
+  ---      viewerSubscription: octo.SubscriptionState,
   ---    },
   ---  },
   ---}
 
   ---@class octo.mutations.UpdateSubscriptionInput
   ---@field subscribable_id string
-  ---@field state "SUBSCRIBED"|"UNSUBSCRIBED"|"IGNORED"
+  ---@field state octo.SubscriptionState
 
   -- https://docs.github.com/en/graphql/reference/mutations#updatesubscription
   M.update_subscription = [[

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -9,6 +9,8 @@ local M = {}
 ---@field hasPreviousPage boolean
 ---@field startCursor string
 
+---@alias octo.SubscriptionState "SUBSCRIBED"|"UNSUBSCRIBED"|"IGNORED"
+
 M.setup = function()
   ---@class octo.queries.PendingReviewThreads
   ---@field data {
@@ -128,6 +130,8 @@ query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
   ---@field authorAssociation string
   ---@field viewerDidAuthor boolean
   ---@field viewerCanUpdate boolean
+  ---@field viewerCanSubscribe boolean
+  ---@field viewerSubscription octo.SubscriptionState
   ---@field projectItems? octo.fragments.ProjectsV2Connection
   ---@field timelineItems octo.PullRequestTimelineItemsConnection
   ---@field reviewDecision string
@@ -202,6 +206,8 @@ query($endCursor: String) {
       authorAssociation
       viewerDidAuthor
       viewerCanUpdate
+      viewerCanSubscribe
+      viewerSubscription
       ...ReactionGroupsFragment
       %s
       timelineItems(first: 100, after: $endCursor) {
@@ -272,6 +278,8 @@ query($endCursor: String) {
   ---@field timelineItems octo.IssueTimelineItemConnection
   ---@field labels octo.fragments.LabelConnection
   ---@field assignees octo.fragments.AssigneeConnection
+  ---@field viewerCanSubscribe boolean
+  ---@field viewerSubscription octo.SubscriptionState
 
   -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#issue
   M.issue = [[
@@ -302,6 +310,8 @@ query($endCursor: String) {
       assignees(first: 20) {
         ...AssigneeConnectionFragment
       }
+      viewerCanSubscribe
+      viewerSubscription
     }
   }
 }
@@ -1154,7 +1164,7 @@ query($login: String!, $endCursor: String) {
   ---@field refs { nodes: { name: string }[] }
   ---@field languages { nodes: { name: string, color: string }[] }
   ---@field viewerHasStarred boolean
-  ---@field viewerSubscription "SUBSCRIBED"|"UNSUBSCRIBED"|"IGNORED"
+  ---@field viewerSubscription octo.SubscriptionState
 
   M.repository = [[
 query($owner: String!, $name: String!) {

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -515,9 +515,23 @@ local function detect_issue_from_url(url)
   return url:find(keyword, 1, true) ~= nil
 end
 
+---@param details [string, string][][]
+---@param subscription_state octo.SubscriptionState
+local function add_subscription_detail(details, subscription_state)
+  local subscribed_label ---@type string
+  if subscription_state == "IGNORED" then
+    subscribed_label = "Never"
+  elseif subscription_state == "SUBSCRIBED" then
+    subscribed_label = "All activity"
+  elseif subscription_state == "UNSUBSCRIBED" then
+    subscribed_label = "Only participating and @mentioned"
+  end
+  add_details_line(details, "Subscribed", subscribed_label)
+end
+
 ---@param bufnr integer
 ---@param issue octo.PullRequest|octo.Issue
----@param update any
+---@param update? true
 function M.write_details(bufnr, issue, update)
   -- clear virtual texts
   vim.api.nvim_buf_clear_namespace(bufnr, constants.OCTO_DETAILS_VT_NS, 0, -1)
@@ -823,6 +837,8 @@ function M.write_details(bufnr, issue, update)
     table.insert(changes_vt, { ")", "OctoDetailsLabel" })
     table.insert(details, changes_vt)
   end
+
+  add_subscription_detail(details, issue.viewerSubscription)
 
   local line = 3
   -- write #details + empty lines


### PR DESCRIPTION
### Describe what this PR does / why we need it

Following up https://github.com/pwntester/octo.nvim/pull/1308 to allow for displaying the current subscription state in the details virtual text for PRs and issues. Following the same labelling scheme as the GitHub UI does.
