### PR TITLE
feat(pr): group force push event by author

### DIFF
--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -256,7 +256,14 @@ function OctoBuffer:render_issue()
       commits = {}
       prev_is_event = true
     end
-    if (not item or item.__typename ~= "HeadRefForcePushedEvent") and #unrendered_force_push_events > 0 then
+    if
+      #unrendered_force_push_events > 0
+      and (
+        not item
+        or item.__typename ~= "HeadRefForcePushedEvent"
+        or item.actor.login ~= unrendered_force_push_events[1].actor.login
+      )
+    then
       writers.write_head_ref_force_pushed_events(self.bufnr, unrendered_force_push_events)
       unrendered_force_push_events = {}
       prev_is_event = true


### PR DESCRIPTION
### Describe what this PR does / why we need it

multiple force pushes can happen from different authors, so best to distinguish them when grouping.
