### PR TITLE
feat(telescope.notifications): cache notification previews

### DIFF
--- a/lua/octo/notifications.lua
+++ b/lua/octo/notifications.lua
@@ -63,17 +63,16 @@ function M.copy_notification_url(notification)
   }
 end
 
----@param bufnr integer
 ---@param owner string
 ---@param name string
 ---@param number string
 ---@param kind string
-function M.populate_preview_buf(bufnr, owner, name, number, kind)
+---@param on_success fun(obj: any): nil
+function M.fetch_preview(owner, name, number, kind, on_success)
   ---@param query string
   ---@param fields table<string, string>
   ---@param jq string
-  ---@param preview fun(obj: any, bufnr: integer): nil
-  local function fetch_and_preview(query, fields, jq, preview)
+  local function inner_fetch(query, fields, jq)
     gh.api.graphql {
       query = query,
       fields = fields,
@@ -82,52 +81,61 @@ function M.populate_preview_buf(bufnr, owner, name, number, kind)
         cb = gh.create_callback {
           failure = utils.print_err,
           success = function(output)
-            if not vim.api.nvim_buf_is_loaded(bufnr) then
-              return
-            end
-
             local ok, obj = pcall(vim.json.decode, output)
             if not ok then
               utils.error("Failed to parse preview data: " .. vim.inspect(output))
               return
             end
-
-            preview(obj, bufnr)
+            on_success(obj)
           end,
         },
       },
     }
   end
-  ---@type string, table<string, string>, string, fun(obj: any, bufnr: integer): nil
-  local query, fields, jq, preview
+  ---@type string, table<string, string>, string
+  local query, fields, jq
 
   if kind == "issue" then
     query = graphql("issue_query", owner, name, number, _G.octo_pv2_fragment)
     fields = {}
     jq = ".data.repository.issue"
-    preview = writers.issue_preview
   elseif kind == "pull_request" then
     query = graphql("pull_request_query", owner, name, number, _G.octo_pv2_fragment)
     fields = {}
     jq = ".data.repository.pullRequest"
-    preview = writers.issue_preview
   elseif kind == "discussion" then
     query = queries.discussion
     fields = { owner = owner, name = name, number = number }
     jq = ".data.repository.discussion"
-    preview = writers.discussion_preview
   elseif kind == "release" then
     -- GraphQL only accepts tags and release notifications give back IDs
     release.get_tag_from_release_id({ owner = owner, repo = name, release_id = number }, function(tag_name)
       query = queries.release
       fields = { owner = owner, name = name, tag = tag_name }
       jq = ".data.repository.release"
-      preview = writers.release_preview
-      fetch_and_preview(query, fields, jq, preview)
+      inner_fetch(query, fields, jq)
     end)
     return
   end
-  fetch_and_preview(query, fields, jq, preview)
+  inner_fetch(query, fields, jq)
+end
+
+---@param kind string
+---@return fun(obj: any, bufnr: integer): nil
+function M.get_preview_fn(kind)
+  ---@type fun(obj: any, bufnr: integer): nil
+  local preview
+  if kind == "issue" then
+    preview = writers.issue_preview
+  elseif kind == "pull_request" then
+    preview = writers.issue_preview
+  elseif kind == "discussion" then
+    preview = writers.discussion_preview
+  elseif kind == "release" then
+    preview = writers.release_preview
+  end
+
+  return preview
 end
 
 return M

--- a/lua/octo/pickers/telescope/previewers.lua
+++ b/lua/octo/pickers/telescope/previewers.lua
@@ -113,10 +113,7 @@ local notification = defaulter(function(opts)
       local bufnr = self.state.bufnr
 
       if self.state.bufname ~= entry.value or vim.api.nvim_buf_line_count(bufnr) == 1 then
-        local number = entry.value ---@type string
-        local owner, name = utils.split_repo(entry.repo)
-
-        notifications.populate_preview_buf(bufnr, owner, name, number, entry.kind)
+        opts.preview_fn(bufnr, entry)
       end
     end,
   }


### PR DESCRIPTION
### Describe what this PR does / why we need it

we fetch notifications each time we hover over them which makes things feel pretty slow. this change makes it so that once we're inside the picker, the notification response used for the notification preview is cached so that it loads instantly when it was already loaded.

this change might be a bit controversial, as it means that `:Telescope resume` will not reload the notifications which means the data might be stale. In this case, we'd probably add some sort of "staleness" check to refetch, or refetch in the background and then replace it. However, in this state, I do already find it pretty useful.
