### PR TITLE
fix: cursor hold on issue/pr urls

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1170,7 +1170,7 @@ function M.extract_issue_at_cursor(current_repo)
     end
   end
   if not repo or not number then
-    repo, _, number = M.extract_pattern_at_cursor(constants.URL_ISSUE_PATTERN)
+    _, repo, _, number = M.extract_pattern_at_cursor(constants.URL_ISSUE_PATTERN)
   end
   return repo, number
 end


### PR DESCRIPTION
### Describe what this PR does / why we need it

Cursor hold previews on pr/issue urls were broken from [this change](https://github.com/pwntester/octo.nvim/pull/1301), so this PR handles the extra capture group for the hostname.
