### PR TITLE
fix: locally set file window options

### DIFF
--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -596,7 +596,7 @@ end
 function M._configure_windows(left_winid, right_winid)
   for _, id in ipairs { left_winid, right_winid } do
     for k, v in pairs(FileEntry.winopts) do
-      vim.api.nvim_set_option_value(k, v, { win = id })
+      vim.api.nvim_set_option_value(k, v, { win = id, scope = "local" })
     end
   end
 end


### PR DESCRIPTION
### Describe what this PR does / why we need it

When an option is set globally (the default with `nvim_set_option_value`), other windows inherit its value.

If I use a picker to create a new tab with the file I'm reviewing, by that logic, it will inherit all those window options! Most notably, it affects the `foldmethod` option, making me unable to use treesitter's folding on the new tab.

There are some other usages of `nvim_set_option_value` as well. They _probably_ should use `"local"` as well, though I personally haven't run into issues with them (hence I decided to not touch them)

### Does this pull request fix one issue?

None

### Describe how you did it

By adding a parameter.

### Describe how to verify it

- `Octo review browse`
- `Fzflua files`
- Pick file (`<C-t>` to open on a new tab)

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt **N/A**