### PR TITLE
feat(cursor preview): add support for markdown urls

### DIFF
--- a/lua/octo/constants.lua
+++ b/lua/octo/constants.lua
@@ -28,6 +28,7 @@ M.LONG_ISSUE_PATTERN = "([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(%d+)"
 M.SHORT_ISSUE_PATTERN = "[^%w%d]+#(%d+)"
 M.SHORT_ISSUE_LINE_BEGINNING_PATTERN = "^#(%d+)"
 M.URL_ISSUE_PATTERN = "[htps]+://([^/]+)/([^/]+/[^/]+)/([pulisedcton]+)/(%d+)"
+M.MARKDOWN_URL_PATTERN = "%[[^%]]+%]%(([^)]+)%)"
 M.URL_RELEASE_PATTERN = "[htps]+://([^/]+)/([^/]+/[^/]+)/(releases)/tag/([^/]+)"
 
 M.USER_PATTERN = "@([%w-_]+)"

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1157,7 +1157,7 @@ end
 
 ---@param current_repo string
 function M.extract_issue_at_cursor(current_repo)
-  ---@type string?, integer?
+  ---@type string?, string?
   local repo, number = M.extract_pattern_at_cursor(constants.LONG_ISSUE_PATTERN)
   if not repo or not number then
     number = M.extract_pattern_at_cursor(constants.SHORT_ISSUE_PATTERN)
@@ -1173,6 +1173,13 @@ function M.extract_issue_at_cursor(current_repo)
   end
   if not repo or not number then
     _, repo, _, number = M.extract_pattern_at_cursor(constants.URL_ISSUE_PATTERN)
+  end
+  if not repo or not number then
+    local url = M.extract_pattern_at_cursor(constants.MARKDOWN_URL_PATTERN)
+    if url then
+      ---@type string?, string?, string?, string?
+      _, repo, _, number = url:match(constants.URL_ISSUE_PATTERN)
+    end
   end
   return repo, number
 end


### PR DESCRIPTION
### Describe what this PR does / why we need it

Cursor previews for markdown urls (e.g `[test](https://github.com/pwntester/octo.nvim/issues/123)`) only work if you're on the url part. However, since we conceal by default, the url is concealed and it's hard to use the cursor preview and goto_issue keymap. Thus this pr parses the markdown url to extract the issue information needed for these to work.

