### PR TITLE
fix(mappings): pass buffer context to commits and changed_files pickers

### DIFF
--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -238,9 +238,9 @@ return {
   checkout_pr = function()
     require("octo.commands").commands.pr.checkout()
   end,
-  list_commits = function()
-    require("octo.picker").commits()
-  end,
+  list_commits = context.within_pr(function(buffer)
+    require("octo.picker").commits(buffer)
+  end),
   review_commits = function()
     local current_review = reviews.get_current_review()
     if not current_review then
@@ -250,9 +250,9 @@ return {
       current_review:focus_commit(right, left)
     end)
   end,
-  list_changed_files = function()
-    require("octo.picker").changed_files()
-  end,
+  list_changed_files = context.within_pr(function(buffer)
+    require("octo.picker").changed_files(buffer)
+  end),
   show_pr_diff = function()
     require("octo.commands").show_pr_diff()
   end,


### PR DESCRIPTION
## Describe what this PR does / why we need it

The `list_commits` and `list_changed_files` mapping functions in `lua/octo/mappings.lua` were calling picker functions without passing the buffer context, causing them to fail when invoked via their default keybindings through LazyVim (`<localleader>pc` and `<localleader>pf`).

The picker functions (`commits` and `changed_files`) require `opts` with `repo` and `number` properties, but were receiving `nil` instead.

## Does this pull request fix one issue?

Nope! Almost opened one but decided it was a simple fix so why not contribute 😄 

## Describe how you did it

Wrapped both mapping functions with `context.within_pr(function(buffer) ... end)` which:
1. Validates the current buffer is a PR buffer (shows error if not)
2. Passes the buffer object to the picker function
3. Matches the established pattern already used in `commands.lua` (lines 615-620)

## Describe how to verify it

1. Open a PR buffer with `:Octo pr list` and select a PR
2. Press `<localleader>pc` - should now open the commits picker
3. Press `<localleader>pf` - should now open the changed files picker
4. Both should show the correct data for the current PR

## Special notes for reviews

The `context` module is already imported at line 1 of `mappings.lua`, so no new dependencies are introduced.

## Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt (not needed - no behavior change, just bug fix)