### PR TITLE
fix(window): use a single float instead of two floats for title and content

### DIFF
--- a/lua/octo/ui/window.lua
+++ b/lua/octo/ui/window.lua
@@ -17,9 +17,9 @@ function M.create_floating_window(opts)
   local winid, bufnr
   bufnr = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, opts.content or {})
-  local border = vim.o.winborder
-  if border == "" or border == "none" then
-    border = "rounded"
+  local border = "rounded"
+  if vim.o.winborder ~= "" and vim.o.winborder ~= "none" then
+    border = tostring(vim.o.winborder)
   end
   winid = vim.api.nvim_open_win(bufnr, false, {
     relative = "editor",


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Update `window.lua` to create single floating window with a title instead of to seperate floating windows (one for the title, the another for the content). This means we can use the new `vim.o.winborder` to determine what border to use when rendering the floating window.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #1140 

### Describe how you did it

Update the code in `window.lua` to have a single `create_floating_window` function that creates the floating window with the given title.

### Describe how to verify it

Attempt to submit a review, you will see a floating window like the following:

<img width="1063" height="410" alt="image" src="https://github.com/user-attachments/assets/e631953b-87f5-4de3-8add-0404e51443aa" />

Also completion works in the window now too:

<img width="1049" height="403" alt="image" src="https://github.com/user-attachments/assets/5e4251a0-3b6a-4ef9-90bc-5fc2e88af951" />

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
