### PR TITLE
fix: add missing timeout to getting user name

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -68,7 +68,7 @@ function M.get_user_name(remote_hostname)
     args = { "auth", "status", "--hostname", remote_hostname },
     env = get_env(),
   }
-  job:sync()
+  job:sync(config.values.timeout)
   local stderr = table.concat(job:stderr_result(), "\n")
   local stdout = table.concat(job:result(), "\n")
   -- Newer versions of the gh cli have a different message. See #467


### PR DESCRIPTION
### Describe what this PR does / why we need it

We have a `timeout` config to allow for slower connections. However, a `get_user_name` function call doesn't use this `timeout` config, making the config a noop in certain cases. This PR adds the config to that function.
