### PR TITLE
feat(pr): set buffer and not modifiable for pr diff buffer

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2174,6 +2174,8 @@ function M.show_pr_diff()
         vim.api.nvim_buf_set_lines(wbufnr, 0, -1, false, lines)
         vim.api.nvim_set_current_buf(wbufnr)
         vim.api.nvim_buf_set_option(wbufnr, "filetype", "diff")
+        vim.api.nvim_buf_set_option(wbufnr, "modifiable", false)
+        vim.api.nvim_buf_set_name(wbufnr, "DIFF: " .. buffer:pullRequest().title)
       end
     end,
   }


### PR DESCRIPTION
### Describe what this PR does / why we need it

The PR diff buffer is improved here by:
- setting the buffer name so that it can be easily distinguished and identified
- setting as not `modifiable` to prevent accidental modifications
