### PR TITLE
fix: locally set window options for file panel

### DIFF
--- a/lua/octo/reviews/file-panel.lua
+++ b/lua/octo/reviews/file-panel.lua
@@ -107,11 +107,12 @@ function FilePanel:open()
   vim.cmd("resize " .. self.size)
   self.winid = vim.api.nvim_get_current_win()
 
+  vim.cmd("buffer " .. self.bufid)
+
   for k, v in pairs(FilePanel.winopts) do
-    vim.api.nvim_set_option_value(k, v, { win = self.winid })
+    vim.api.nvim_set_option_value(k, v, { win = self.winid, scope = "local" })
   end
 
-  vim.cmd("buffer " .. self.bufid)
   vim.cmd ":wincmd ="
 end
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Follow-up to https://github.com/pwntester/octo.nvim/pull/1371

As it turns out, I ran into issues with these settings as well :p 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

By adding a parameter.

### Describe how to verify it

 - Octo review browse
 - Go to file panel
 - Fzflua files
 - Pick file (<C-t> to open on a new tab)

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
