### PR TITLE
feat(Snacks): rich user picker

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2726,11 +2726,11 @@ function M.add_user(subject, logins)
     end
     cb(user_ids)
   else
-    picker.users(function(user_id)
-      if type(user_id) == "string" then
-        cb { user_id }
+    picker.users(function(user_ids)
+      if type(user_ids) == "string" then
+        cb { user_ids }
       else
-        cb(user_id)
+        cb(user_ids)
       end
     end)
   end

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2727,7 +2727,11 @@ function M.add_user(subject, logins)
     cb(user_ids)
   else
     picker.users(function(user_id)
-      cb { user_id }
+      if type(user_id) == "string" then
+        cb { user_id }
+      else
+        cb(user_id)
+      end
     end)
   end
 end

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -1121,6 +1121,8 @@ query($owner: String!, $name: String!, $endCursor: String) {
         id
         login
         name
+        pronouns
+        avatarUrl
       }
     }
   }
@@ -1139,6 +1141,8 @@ query($owner: String!, $name: String! $endCursor: String) {
         id
         login
         name
+        pronouns
+        avatarUrl
       }
     }
   }
@@ -1152,6 +1156,9 @@ query($prompt: String!, $endCursor: String) {
       ... on User {
         id
         login
+        name
+        pronouns
+        avatarUrl
       }
       ... on Organization {
         id

--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -1468,6 +1468,7 @@ function M.users(cb)
                   end
                 end
               end
+              ctx.async:resume()
             end,
           },
         }

--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -1450,8 +1450,10 @@ function M.users(cb)
                       id = user.id,
                       login = user.login,
                       name = user.name,
-                      text = user.login,
                       kind = "user",
+                      pronouns = user.pronouns or "",
+                      avatarUrl = user.avatarUrl or "",
+                      ft = "markdown",
                     }
                   elseif user.teams and user.teams.totalCount > 0 then
                     for _, team in ipairs(user.teams.nodes) do
@@ -1494,8 +1496,12 @@ function M.users(cb)
   if not custom_actions_defined["confirm"] then
     ---@type snacks.picker.Action.fn
     final_actions["confirm"] = function(picker, item)
+      items = {}
+      for _, item in ipairs(picker:selected { fallback = true }) do
+        items[#items + 1] = item.id
+      end
       picker:close()
-      cb(item.id)
+      cb(items)
     end
   end
 
@@ -1522,7 +1528,33 @@ function M.users(cb)
     layout = {
       preset = "select",
       -- Ensure preview window is shown
-      hidden = {},
+      layout = {
+        backdrop = false,
+        width = 0.5,
+        min_width = 80,
+        max_width = 100,
+        height = 0.4,
+        min_height = 2,
+        box = "horizontal",
+        border = true,
+        title = "{title}",
+        title_pos = "center",
+        {
+          box = "vertical",
+          border = "right",
+          { win = "input", height = 1, border = "bottom" },
+          { win = "list", border = "none" },
+        },
+        {
+          win = "preview",
+          title = "{preview}",
+          height = 0,
+          width = 0.5,
+          wo = {
+            number = false,
+          },
+        },
+      },
     },
     preview = function(ctx)
       local item = ctx.item
@@ -1534,10 +1566,14 @@ function M.users(cb)
       local lines = {}
       if item.kind == "user" then
         lines = {
-          "User: " .. item.login,
-          "ID: " .. item.id,
-          "Type: " .. item.kind,
+          item["name"] ~= vim.NIL and item["name"] or "",
+          item["pronouns"] ~= vim.NIL and ("_" .. item["pronouns"] .. "_") or "",
+          "",
+          "Username: `" .. item["login"] .. "`",
+          "![](" .. item["avatarUrl"] .. ")",
         }
+        -- vim.bo[ctx.preview.win.buf] = "markdown"
+        ctx.preview:highlight { ft = "markdown" }
       elseif item.kind == "team" then
         lines = {
           "Name: " .. item.name,


### PR DESCRIPTION
### Describe what this PR does / why we need it
Improves the Snack user picker with a rich user preview.

Sometimes it's hard to know which users you're adding for review. This change shows the user's name, pronouns and profile picture to make it easier!

Embedded images are included with `Snacks` for supported terminals. [Documentation](https://github.com/folke/snacks.nvim/blob/main/docs/image.md)

<img width="884" height="551" alt="image" src="https://github.com/user-attachments/assets/c29c317c-13a3-4075-8759-108ee85cefcc" />


### Does this pull request fix one issue?
NONE

### Describe how you did it
Updated the GraphQL user queries, before using a Markdown template string to render the data.

### Describe how to verify it
`:Octo reviewer add` to launch the prompt, with `opts.picker = "snacks"`

### Special notes for reviews
Please let me know if the format should change or any details could be added
from user profiles, I've tried to keep it somewhat minimal.

I'll also try and add this for teams too in a future PR!

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt