### PR TITLE
fix: improve default binds for submit_win

### DIFF
--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -449,10 +449,10 @@ function M.get_default_values()
         unresolve_thread = { lhs = "<localleader>rT", desc = "unresolve PR thread" },
       },
       submit_win = {
-        approve_review = { lhs = "<C-a>", desc = "approve review", mode = { "n", "i" } },
-        comment_review = { lhs = "<C-m>", desc = "comment review", mode = { "n", "i" } },
-        request_changes = { lhs = "<C-r>", desc = "request changes review", mode = { "n", "i" } },
-        close_review_tab = { lhs = "<C-c>", desc = "close review tab", mode = { "n", "i" } },
+        approve_review = { lhs = "<C-a>", desc = "approve review", mode = { "n" } },
+        comment_review = { lhs = "<C-m>", desc = "comment review", mode = { "n" } },
+        request_changes = { lhs = "<C-r>", desc = "request changes review", mode = { "n" } },
+        close_review_tab = { lhs = "<C-c>", desc = "close review tab", mode = { "n" } },
       },
       review_diff = {
         submit_review = { lhs = "<localleader>vs", desc = "submit review" },

--- a/lua/octo/ui/window.lua
+++ b/lua/octo/ui/window.lua
@@ -108,14 +108,6 @@ function M.create_centered_float(opts)
     x_offset = x_offset,
   }
 
-  -- window binding
-  local aucmd = string.format(
-    "autocmd BufLeave,BufDelete <buffer=%d> :lua require('octo.ui.window').try_close_wins(%d)",
-    bufnr,
-    winid
-  )
-  vim.cmd(aucmd)
-
   -- mappings
   local mapping_opts = { script = true, silent = true, noremap = true, buffer = bufnr, desc = "Close window" }
   vim.keymap.set("n", "<C-c>", function()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

The default `submit_win` binds make it difficult to write text in the submit PR review window as typing `<Enter>` (`<C-m>` sends the same keycode as `<Enter>`) in insert mode will submit your review instead of moving the cursor to the next line. Also `<C-a>` and `<C-r>` has uses in insert mode that should be usable in the submit_win. These binds are now only set in `normal` mode for the submit_win.

I also removed the autocmd that added a `BufLeave,BufDelete` event handlers to the submit_win as they cause the window to close prematurely when I accept a completion menu item via `<C-y>` in insert mode.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

I've described what I have done above

### Describe how to verify it

Attempt to submit a PR review and verify that you can accept completion menu items and you can press `<Enter>` in insert mode to move the cursor to the next line in the submit_win

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
