### PR TITLE
fix: use utils.get_current_buffer() for snacks changed_files picker

### DIFF
--- a/lua/octo/pickers/snacks/provider.lua
+++ b/lua/octo/pickers/snacks/provider.lua
@@ -1091,11 +1091,14 @@ function M.search(opts)
   end
 end
 
----@param opts {repo: string, number: integer, title: string?}
-function M.changed_files(opts)
+function M.changed_files()
+  local buffer = utils.get_current_buffer()
+  if not buffer or not buffer:isPullRequest() then
+    return
+  end
   gh.api.get {
     "/repos/{repo}/pulls/{number}/files",
-    format = { repo = opts.repo, number = opts.number },
+    format = { repo = buffer.repo, number = buffer.number },
     opts = {
       paginate = true,
       cb = gh.create_callback {
@@ -1157,7 +1160,7 @@ function M.changed_files(opts)
           end
 
           Snacks.picker.pick {
-            title = opts.title or "Changed Files",
+            title = buffer.title or "Changed Files",
             items = results,
             format = function(item, _)
               local ret = {} ---@type snacks.picker.Highlight[]


### PR DESCRIPTION
### Describe what this PR does / why we need it
The files changed picker for Snacks was trying to reference an `opts` table that wasn't being passed as an argument.

This PR fetches the fields needed from the current buffer instead.


### Does this pull request fix one issue?

Fixes #1415

### Describe how you did it
Used existing util function, as used in other functions.

### Describe how to verify it
`opts.picker = "snacks"`, open PR buffer, and open the changed files picker with `<localleader>pf`

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [~] Documentation updates in README.md and doc/octo.txt (none needed)