### PR TITLE
fix(pr): enter pr checks window on open

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2017,6 +2017,7 @@ function M.pr_checks(buffer)
     local _, wbufnr = window.create_centered_float {
       header = "Checks",
       content = lines,
+      enter = true,
     }
 
     vim.api.nvim_buf_set_keymap(wbufnr, "n", "<CR>", "", {

--- a/lua/octo/ui/window.lua
+++ b/lua/octo/ui/window.lua
@@ -11,6 +11,7 @@ local M = {}
 ---@field height integer
 ---@field y_offset integer
 ---@field x_offset integer
+---@field enter? boolean
 
 ---@param opts octo.BorderHeaderFloatOpts
 function M.create_floating_window(opts)
@@ -21,7 +22,7 @@ function M.create_floating_window(opts)
   if vim.o.winborder ~= "" and vim.o.winborder ~= "none" then
     border = tostring(vim.o.winborder)
   end
-  winid = vim.api.nvim_open_win(bufnr, false, {
+  winid = vim.api.nvim_open_win(bufnr, opts.enter or false, {
     relative = "editor",
     title = opts.header,
     border = border,
@@ -45,6 +46,7 @@ end
 ---@field y_percent? number
 ---@field header? string
 ---@field content? string[]
+---@field enter? boolean
 
 ---@param opts? octo.CenteredFloatOpts
 ---@return integer winid
@@ -106,6 +108,7 @@ function M.create_centered_float(opts)
     height = height,
     y_offset = y_offset,
     x_offset = x_offset,
+    enter = opts.enter,
   }
 
   -- window binding


### PR DESCRIPTION
### Describe what this PR does / why we need it

We currently set that you don't enter the pr checks window on open. I think this worked before, but doesn't work on nightly, and feels like this is the intended behavior. So explicitly set the window to open here.
