### PR TITLE
fix: preserve cursor position when hiding thread buffer

### DIFF
--- a/lua/octo/reviews/thread-panel.lua
+++ b/lua/octo/reviews/thread-panel.lua
@@ -103,8 +103,17 @@ function M.hide_thread_buffer(split, file)
       -- if we are not showing the corresponding alternative diff buffer, do so
       vim.api.nvim_win_set_buf(alt_win, alt_buf)
 
+      -- Save cursor position before show_diff (which scrolls to sync windows)
+      local current_win = vim.api.nvim_get_current_win()
+      local cursor_pos = vim.api.nvim_win_get_cursor(current_win)
+
       -- show the diff
       file:show_diff()
+
+      -- Restore cursor position (show_diff scrolls which can disrupt cursor)
+      if vim.api.nvim_win_is_valid(current_win) then
+        pcall(vim.api.nvim_win_set_cursor, current_win, cursor_pos)
+      end
     end
   end
 end


### PR DESCRIPTION



<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

When navigating through PR review diff, moving away from a line with comments causes hide_thread_buffer() to call show_diff(), which executes <C-y> to sync scrollbind. This scroll command disrupts the cursor position, causing it to jump back unexpectedly.



### Does this pull request fix one issue?
Fixes #1421 

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
This PR saves and restores cursor position around the show_diff() call to prevent the problem.

### Describe how to verify it
-   Open a PR that has existing review comments on some lines
-   Start a review with :Octo review start
-   In the right diff buffer, position cursor above a line that has a comment
-   Move cursor down one line at a time using j
-   When the cursor hits a line with a comment, the left buffer shows the comment thread (expected)
-   Move cursor down one more line, it jumps to the following line as expected

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
