### PR TITLE
fix: implement --slurp natively to support gh CLI < v2.29.0

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -150,7 +150,7 @@ function M.create_callback(opts)
 end
 
 ---@class RunOpts
----@field args? table
+---@field args? string[]
 ---@field mode? "sync" | "async"
 ---@field cb? fun(stdout: string, stderr: string, status: integer)
 ---@field stream_cb? fun(stdout: string, stderr: string)
@@ -169,7 +169,7 @@ end
 ---@return string JSON array of all pages
 local function native_slurp(output)
   local pages = {}
-  for line in (output .. "\n"):gmatch("([^\n]+)\n?") do
+  for line in (output .. "\n"):gmatch "([^\n]+)\n?" do
     line = vim.trim(line)
     if #line > 0 then
       local ok, decoded = pcall(vim.json.decode, line)
@@ -252,7 +252,9 @@ local function run(opts)
     on_exit = vim.schedule_wrap(function(j_self, status, _)
       if mode == "async" and opts.cb then
         local output = table.concat(j_self:result(), "\n")
-        if do_slurp then output = native_slurp(output) end
+        if do_slurp then
+          output = native_slurp(output)
+        end
         local stderr = table.concat(j_self:stderr_result(), "\n")
         opts.cb(output, stderr, status)
       end
@@ -262,7 +264,9 @@ local function run(opts)
   if mode == "sync" then
     job:sync(conf.timeout)
     local output = table.concat(job:result(), "\n")
-    if do_slurp then output = native_slurp(output) end
+    if do_slurp then
+      output = native_slurp(output)
+    end
     return output, table.concat(job:stderr_result(), "\n")
   else
     job:start()


### PR DESCRIPTION
Fixes #1424

## Problem

`gh` CLI added the `--slurp` flag in v2.29.0, but many distributions (e.g. Debian stable, older Ubuntu LTS) ship versions that predate it. When octo calls `gh api --paginate --slurp` to fetch PR changed files or commit files, the command errors immediately:

```
unknown flag: --slurp
```

Because the error path doesn't resolve the async callback, the `OctoChangedFiles` buffer hangs on `Loading...` indefinitely with no error shown to the user. Attempts to start/resume a review (`Octo review start` / `Octo review resume`) also appear to hang for the same reason.

## Fix

Strip `--slurp` from the args before invoking `gh` and implement the same behaviour natively in Lua.

`gh api --paginate` (without `--slurp`) emits each page as a compact JSON value on its own line. Splitting on newlines, decoding each page, and re-wrapping into an array produces an identical result to what `--slurp` would have returned.

```lua
local function native_slurp(output)
  local pages = {}
  for line in (output .. "\n"):gmatch("([^\n]+)\n?") do
    line = vim.trim(line)
    if #line > 0 then
      local ok, decoded = pcall(vim.json.decode, line)
      if ok then table.insert(pages, decoded) end
    end
  end
  return vim.json.encode(pages)
end
```

## Compatibility

- **Users with `gh >= 2.29.0`**: unaffected — `--slurp` is simply no longer passed to `gh`, and the Lua implementation produces the same output.
- **Users with `gh < 2.29.0`**: the hang is fixed, changed files load correctly.
- No configuration changes required.

## Test plan

- [ ] Open a PR with octo on a system with `gh < 2.29.0` — changed files load instead of hanging
- [ ] Open a PR with octo on a system with `gh >= 2.29.0` — unchanged behaviour
- [ ] `Octo review resume` resolves correctly on both