### PR TITLE
fix: reviewer/assignee add failing with empty args

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2615,7 +2615,7 @@ function M.add_user(subject, logins)
       },
     }
   end
-  if logins then
+  if logins and #logins > 0 then
     local user_ids = {} ---@type string[]
     for _, user in ipairs(logins) do
       local user_id = utils.get_user_id(user)


### PR DESCRIPTION
### Describe what this PR does / why we need it

When `Octo reviewer add` or `Octo assignee add` is called without arguments (to open the Telescope picker), the command fails with:
```
gh: Variable $user_ids of type [ID!]! was provided invalid value
```

This is because `{ ... }` produces an empty table `{}` which is truthy in Lua, so the picker is bypassed and the GraphQL mutation is called with an empty `user_ids` array.

### Does this pull request fix one issue?

Fixes #1425

### Describe how you did it

Changed `if logins then` to `if logins and #logins > 0 then` in `lua/octo/commands.lua` so that an empty args table correctly falls through to the Telescope user picker.

### Describe how to verify it

1. Open a PR with `:Octo pr list`
2. Run `:Octo reviewer add` (no args) — should open the Telescope user picker instead of erroring
3. Run `:Octo assignee add` (no args) — should open the Telescope user picker instead of erroring
4. Run `:Octo reviewer add someuser` (with args) — should still work as before

### Special notes for reviews

One-line change. No new dependencies or documentation updates needed.

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt (N/A — no behavioral change to document)