### PR TITLE
fix: use full shas in file contents

### DIFF
--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -237,8 +237,6 @@ function FileEntry:fetch(sync)
   self.right_fetching = true
   local right_sha = current_review.layout.right.commit
   local left_sha = current_review.layout.left.commit
-  local right_abbrev = current_review.layout.right:abbrev()
-  local left_abbrev = current_review.layout.left:abbrev()
 
   -- handle renamed files
   if self.status == "R" and self.previous_path then
@@ -253,7 +251,7 @@ function FileEntry:fetch(sync)
       self.right_fetching = false
     end)
   else
-    utils.get_file_contents(self.pull_request.repo, right_abbrev, right_path, function(lines)
+    utils.get_file_contents(self.pull_request.repo, right_sha, right_path, function(lines)
       self.right_lines = lines
       self.right_fetched = true
       self.right_fetching = false
@@ -268,7 +266,7 @@ function FileEntry:fetch(sync)
       self.left_fetching = false
     end)
   else
-    utils.get_file_contents(self.pull_request.repo, left_abbrev, left_path, function(lines)
+    utils.get_file_contents(self.pull_request.repo, left_sha, left_path, function(lines)
       self.left_lines = lines
       self.left_fetched = true
       self.left_fetching = false


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This resolves https://github.com/pwntester/octo.nvim/issues/1447. I honestly am not sure what the difference in using the full sha is but this resolved my specific issue I was having.

### Does this pull request fix one issue?
yes

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #1447 

### Describe how you did it
I used an AI agent giving it the context of the PR I was having issues with the octo checkout from lazy.nvim and it came up with this fix. To be completely honest right now I'm now sure why this solves the issue other than some potential github API bug around short vs long hashes. I scanned through the code base and there shouldn't have been any kind of short hash collision on the hashes being used.

### Describe how to verify it
Unfortunately I was never able to reproduce this on a public repo so not sure how to list instructions here 😅

### Special notes for reviews

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
