### PR TITLE
fix auth handling for SSH aliases and multi-account gh logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,8 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 | actions  |                                                   | Lists all available Octo actions                                                                                                                       |
 | search   | <query>                                           | Search GitHub for issues and PRs matching the [query](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) or Discussions with `is:discussion`|
 | run      | list                                              | List workflow runs                                                                                                                                     |
+| auth     | status                                            | Show authenticated `gh` accounts for the current host                                                                                                  |
+|          | switch [login]                                    | Switch the active `gh` account for the current host                                                                                                    |
 | notification | list                                          | Shows current unread notifications |
 | discussion   | list [repo]                                          | List open discussions for current or specified repo |
 |    | edit <number> [repo] | Edit discussion in current or specified repo |
@@ -845,6 +847,14 @@ It is possible that Octo is trying to authenticate against the origin listed in 
 require('octo').setup({
   ssh_aliases = {["<THE ALIAS YOU HAVE LISTED IN ~/.ssh/config>"] = "github.com"}
 })
+```
+
+If you use multiple `gh` accounts on the same host, Octo uses the active `gh` account and you can inspect or switch it from Neovim:
+
+```
+:Octo auth status
+:Octo auth switch
+:Octo auth switch thedanielfactor
 ```
 
 **Can I use treesitter markdown parser with octo buffers?**

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -148,6 +148,85 @@ function M.setup()
     actions = function()
       M.actions()
     end,
+    auth = {
+      status = function()
+        local remote_hostname = get_hostname_from_buffer() or utils.get_remote_host()
+        local accounts, stderr = gh.get_auth_accounts(remote_hostname)
+
+        if not accounts then
+          utils.error(stderr ~= "" and stderr or "Failed to get GitHub auth status")
+          return
+        end
+
+        if #accounts == 0 then
+          utils.error(string.format("No authenticated GitHub accounts found for %s", remote_hostname or "the current host"))
+          return
+        end
+
+        local lines = {}
+        for _, account in ipairs(accounts) do
+          local marker = account.active and "*" or " "
+          table.insert(lines, string.format("%s %s (%s)", marker, account.login, account.host or remote_hostname))
+        end
+
+        utils.info(table.concat(lines, "\n"))
+      end,
+      switch = function(login)
+        local remote_hostname = get_hostname_from_buffer() or utils.get_remote_host()
+
+        local function on_switch(selected_login)
+          gh.switch_account(remote_hostname, selected_login, function(_, stderr, status)
+            if status ~= 0 then
+              utils.error(stderr ~= "" and stderr or "Failed to switch GitHub account")
+              return
+            end
+
+            vim.g.octo_viewer = gh.get_user_name(remote_hostname)
+
+            if vim.g.octo_viewer then
+              utils.info(string.format("Switched active GitHub account to %s", vim.g.octo_viewer))
+            else
+              utils.info "Switched active GitHub account"
+            end
+          end)
+        end
+
+        if not utils.is_blank(login) then
+          on_switch(login)
+          return
+        end
+
+        local accounts, stderr = gh.get_auth_accounts(remote_hostname)
+        if not accounts then
+          utils.error(stderr ~= "" and stderr or "Failed to get GitHub auth status")
+          return
+        end
+
+        if #accounts == 0 then
+          utils.error(string.format("No authenticated GitHub accounts found for %s", remote_hostname or "the current host"))
+          return
+        end
+
+        vim.ui.select(accounts, {
+          prompt = "Switch GitHub account:",
+          format_item = function(item)
+            local marker = item.active and "* " or "  "
+            return string.format("%s%s", marker, item.login)
+          end,
+        }, function(choice)
+          if not choice then
+            return
+          end
+
+          if choice.active then
+            utils.info(string.format("%s is already the active GitHub account", choice.login))
+            return
+          end
+
+          on_switch(choice.login)
+        end)
+      end,
+    },
     search = function(...)
       M.search(...)
     end,

--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -54,6 +54,88 @@ local function get_env()
   return env
 end
 
+---@param remote_hostname string?
+---@param opts? { active_only?: boolean, json?: boolean }
+---@return string[]
+local function build_auth_status_args(remote_hostname, opts)
+  opts = opts or {}
+  local args = { "auth", "status" }
+
+  if opts.active_only then
+    table.insert(args, "--active")
+  end
+
+  if remote_hostname and remote_hostname ~= "" then
+    table.insert(args, "--hostname")
+    table.insert(args, remote_hostname)
+  end
+
+  if opts.json then
+    table.insert(args, "--json")
+    table.insert(args, "hosts")
+  end
+
+  return args
+end
+
+---@param args string[]
+---@return string, string
+local function run_gh_sync(args)
+  ---@diagnostic disable-next-line: missing-fields
+  local job = Job:new {
+    enable_recording = true,
+    command = config.values.gh_cmd,
+    args = args,
+    env = get_env(),
+  }
+  job:sync(config.values.timeout)
+  return table.concat(job:result(), "\n"), table.concat(job:stderr_result(), "\n")
+end
+
+---@param output string
+---@return string?
+function M.parse_auth_status_user(output)
+  return string.match(output, "Logged in to [^%s]+ as ([^%s]+)")
+    or string.match(output, "Logged in to [^%s]+ account ([^%s]+)")
+end
+
+---@param output string
+---@param remote_hostname string?
+---@return { active?: boolean, gitProtocol?: string, host?: string, login?: string, scopes?: string, state?: string, tokenSource?: string }[]?
+function M.extract_auth_status_accounts(output, remote_hostname)
+  if output == "" then
+    return {}
+  end
+
+  local ok, decoded = pcall(vim.json.decode, output)
+  if not ok or type(decoded) ~= "table" or type(decoded.hosts) ~= "table" then
+    return
+  end
+
+  if remote_hostname and decoded.hosts[remote_hostname] then
+    return decoded.hosts[remote_hostname]
+  end
+
+  local accounts = {}
+  for _, host_accounts in pairs(decoded.hosts) do
+    vim.list_extend(accounts, host_accounts)
+  end
+  return accounts
+end
+
+---@param remote_hostname string?
+---@return { active?: boolean, gitProtocol?: string, host?: string, login?: string, scopes?: string, state?: string, tokenSource?: string }[]?, string?
+function M.get_auth_accounts(remote_hostname)
+  local stdout, stderr = run_gh_sync(build_auth_status_args(remote_hostname, { json = true }))
+  local accounts = M.extract_auth_status_accounts(stdout, remote_hostname)
+
+  if accounts then
+    return accounts, stderr
+  end
+
+  return nil, stderr
+end
+
 ---uses GH to get the name of the authenticated user
 ---@param remote_hostname string?
 function M.get_user_name(remote_hostname)
@@ -61,21 +143,23 @@ function M.get_user_name(remote_hostname)
     remote_hostname = require("octo.utils").get_remote_host()
   end
 
-  ---@diagnostic disable-next-line: missing-fields
-  local job = Job:new {
-    enable_recording = true,
-    command = config.values.gh_cmd,
-    args = { "auth", "status", "--hostname", remote_hostname },
-    env = get_env(),
-  }
-  job:sync(config.values.timeout)
-  local stderr = table.concat(job:stderr_result(), "\n")
-  local stdout = table.concat(job:result(), "\n")
-  -- Newer versions of the gh cli have a different message. See #467
-  local name_err = string.match(stderr, "Logged in to [^%s]+ as ([^%s]+)")
-    or string.match(stderr, "Logged in to [^%s]+ account ([^%s]+)")
-  local name_out = string.match(stdout, "Logged in to [^%s]+ as ([^%s]+)")
-    or string.match(stdout, "Logged in to [^%s]+ account ([^%s]+)")
+  local accounts, stderr = M.get_auth_accounts(remote_hostname)
+  if accounts then
+    for _, account in ipairs(accounts) do
+      if account.active and account.login then
+        return account.login
+      end
+    end
+
+    if accounts[1] and accounts[1].login then
+      return accounts[1].login
+    end
+  end
+
+  local stdout
+  stdout, stderr = run_gh_sync(build_auth_status_args(remote_hostname, { active_only = true }))
+  local name_err = M.parse_auth_status_user(stderr)
+  local name_out = M.parse_auth_status_user(stdout)
 
   if name_err then
     return name_err
@@ -84,6 +168,36 @@ function M.get_user_name(remote_hostname)
   else
     require("octo.utils").error(stderr)
   end
+end
+
+---@param remote_hostname string?
+---@param login string?
+---@param cb? fun(stdout: string, stderr: string, status: integer)
+function M.switch_account(remote_hostname, login, cb)
+  local args = { "auth", "switch" }
+
+  if remote_hostname and remote_hostname ~= "" then
+    table.insert(args, "--hostname")
+    table.insert(args, remote_hostname)
+  end
+
+  if login and login ~= "" then
+    table.insert(args, "--user")
+    table.insert(args, login)
+  end
+
+  ---@diagnostic disable-next-line: missing-fields
+  Job:new({
+    enable_recording = true,
+    command = config.values.gh_cmd,
+    args = args,
+    env = get_env(),
+    on_exit = vim.schedule_wrap(function(j_self, status, _)
+      if cb then
+        cb(table.concat(j_self:result(), "\n"), table.concat(j_self:stderr_result(), "\n"), status)
+      end
+    end),
+  }):start()
 end
 
 local scopes = {} ---@type string[]

--- a/lua/tests/plenary/gh_spec.lua
+++ b/lua/tests/plenary/gh_spec.lua
@@ -367,3 +367,25 @@ describe("CLI commands", function()
     end
   end)
 end)
+
+describe("auth helpers", function()
+  it("extracts accounts from gh auth status json", function()
+    local output = [[{"hosts":{"github.com":[{"state":"success","active":true,"host":"github.com","login":"raymondd-ae"},{"state":"success","active":false,"host":"github.com","login":"thedanielfactor"}]}}]]
+
+    local actual = gh.extract_auth_status_accounts(output, "github.com")
+
+    eq(#actual, 2)
+    eq(actual[1].login, "raymondd-ae")
+    eq(actual[1].active, true)
+    eq(actual[2].login, "thedanielfactor")
+    eq(actual[2].active, false)
+  end)
+
+  it("parses active account from auth status text", function()
+    local output = [[github.com
+  ✓ Logged in to github.com account thedanielfactor (keyring)
+  - Active account: true]]
+
+    eq(gh.parse_auth_status_user(output), "thedanielfactor")
+  end)
+end)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->
### Describe what this PR does / why we need it

This PR fixes Octo auth handling for users with multi-account `gh` setups and SSH alias-based git remotes. It ensures Octo resolves SSH aliases correctly, detects the active `gh` account for the resolved host, and allows switching the active account from inside Neovim.

### Does this pull request fix one issue?

I did not see an issue like this.  I found it while I was trying to use Octo.

### Describe how you did it

I updated Octo to normalize SSH alias hosts through `ssh_aliases` so aliased remotes like `git@TheDanielFactor:owner/repo.git` resolve to `github.com`. I also changed auth detection to query `gh auth status --json hosts` and use the active account for the resolved host instead of relying on the first parsed login. In addition, I added `:Octo auth status` and `:Octo auth switch [login]` to support inspecting and switching accounts directly from Neovim, and documented the workflow in the README.

### Describe how to verify it

1. Configure an SSH alias in `~/.ssh/config` and set the matching alias in Octo's `ssh_aliases` config.
2. Authenticate multiple GitHub accounts with `gh auth login`.
3. Run `gh auth status` and confirm one account is active.
4. Open Neovim in a repo that uses the SSH alias remote.
5. Run `:Octo auth status` and confirm Octo shows accounts for `github.com`.
6. Run `:Octo auth switch` or `:Octo auth switch <login>` and confirm the active account changes as expected.
7. Confirm Octo commands now work with the selected account.

### Special notes for reviews

This change is aimed at setups where the git remote uses an SSH host alias but `gh` auth is stored against `github.com`. The fix keeps the existing `ssh_aliases` behavior and improves how Octo selects the authenticated account when multiple accounts exist for the same host.

### Checklist
- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
