### PR TITLE
feat(reviews): allow placing comments outside diff hunks

### DIFF
--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -613,7 +613,7 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
             ---@type octo.mutations.AddPullRequestReviewThread
             local resp = vim.json.decode(output).data.addPullRequestReviewThread
 
-            if utils.is_blank(resp) then
+            if utils.is_blank(resp) or utils.is_blank(resp.thread) then
               utils.error "Failed to create thread"
               return
             end

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -444,8 +444,9 @@ function Review:add_comment(isSuggestion)
     end
   end
   if not diff_hunk then
-    utils.error "Cannot place comments outside diff hunks"
-    return
+    -- The GitHub API does not require comments to be within diff hunks;
+    -- diff_hunk is only used locally and GitHub returns its own in the response.
+    diff_hunk = "@@ -0,0 +0,0 @@"
   end
   if not vim.startswith(diff_hunk, "@@") then
     diff_hunk = "@@ " .. diff_hunk

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -446,7 +446,17 @@ function Review:add_comment(isSuggestion)
   if not diff_hunk then
     -- The GitHub API does not require comments to be within diff hunks;
     -- diff_hunk is only used locally and GitHub returns its own in the response.
-    diff_hunk = "@@ -0,0 +0,0 @@"
+    local best_dist = math.huge
+    for i, range in ipairs(comment_ranges) do
+      local dist = math.min(math.abs(range[1] - line1), math.abs(range[2] - line1))
+      if dist < best_dist then
+        best_dist = dist
+        diff_hunk = file.diffhunks[i]
+      end
+    end
+    if not diff_hunk then
+      diff_hunk = "@@ -0,0 +0,0 @@"
+    end
   end
   if not vim.startswith(diff_hunk, "@@") then
     diff_hunk = "@@ " .. diff_hunk


### PR DESCRIPTION
FULL DISCLOSURE: The actual `src` changes of this PR were done by Claude Code.

However, I had stumbled upon the issue of not being able to add comments outside of hunks, while doing a PR review in nvim using Octo myself. As the changes to my nvim config by Claude Code were applied in my local installation directory at `~/.local/share/nvim/lazy/octo.nvim/lua/octo/reviews/init.lua`, I thought why not contribute back and actually open a PR for it. I hope that's OK.

`pre-commit`, linting, and tests were verified locally. Please don't hesitate to close, if deemed slop. If not, and any changes are required, please let me know, and I'll happily address them (with my very limited Lua knowledge). The current implementation _does_ work for me locally. Many thanks!

### Describe what this PR does / why we need it

Currently, `octo.nvim` blocks placing review comments on lines that fall outside diff hunks with `"Cannot place comments outside diff hunks"`. However, this is a plugin-side restriction — the GitHub GraphQL API ([`AddPullRequestReviewThread`](https://docs.github.com/en/graphql/reference/mutations#addpullrequestreviewthread)) accepts comments on any line of a changed file. The `diff_hunk` is not an input parameter to the [`AddPullRequestReviewThreadInput`](https://docs.github.com/en/graphql/reference/input-objects#addpullrequestreviewthreadinput); it is only returned in the response.

This PR removes that restriction so reviewers can comment on any line visible in the review split, not just lines within diff hunk boundaries.

### Does this pull request fix one issue?

Fixes #1460

### Describe how you did it

In `lua/octo/reviews/init.lua`, replaced the early return with a placeholder `@@ -0,0 +0,0 @@` for the local thread stub display. The GitHub API receives `path`, `line`, and `side` as before — `diff_hunk` was never sent as input, and GitHub returns its own `diffHunk` in the response.

### Describe how to verify it

1. Open a PR review with `:Octo review`
2. Navigate to a line that is outside any diff hunk (e.g., an unchanged line not shown in the diff context)
3. Try to add a comment on that line
4. **Before**: `"Cannot place comments outside diff hunks"` error
5. **After**: Comment is created and submitted to GitHub successfully

### Special notes for reviews

The change is minimal (single block in `init.lua`). The placeholder is only used for the local thread stub — GitHub populates the actual `diffHunk` field in its response, which is what persists.

No new tests are added, as there is no test infrastructure for the review comment placement flow (which would require mocking the full review layout, file splits, and diff state). All existing tests continue to pass.

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt — N/A, no new user-facing API; this removes an incorrect restriction on existing functionality