### PR TITLE
fix(folds): guard against out-of-range extmark rows in update_details_arrows

### DIFF
--- a/lua/octo/folds.lua
+++ b/lua/octo/folds.lua
@@ -227,6 +227,7 @@ end
 ---@param bufnr integer
 function M.update_details_arrows(bufnr)
   local details_ns = vim.api.nvim_create_namespace "octo_details_folds"
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
   local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, details_ns, 0, -1, { details = true })
   local arrow_closed = "▶"
   local arrow_open = "▼"
@@ -235,6 +236,9 @@ function M.update_details_arrows(bufnr)
   for _, extmark in ipairs(extmarks) do
     local id = extmark[1]
     local row = extmark[2]
+    if row >= line_count then
+      goto continue
+    end
     local details = extmark[4] ---@type vim.api.keyset.extmark_details?
     if not details then
       goto continue


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes a crash in `update_details_arrows` where `nvim_buf_set_extmark` is called with a row index that exceeds the buffer's line count. This happens when refreshing an Octo buffer (`:e`) causes the buffer to reload with fewer lines while stale extmarks still reference the old (now out-of-range) positions.

### Does this pull request fix one issue?

Fixes #1464

### Describe how you did it

Added a bounds check in `update_details_arrows()` that skips any extmark whose row is >= the buffer's current line count. This is a minimal, defensive guard — it only affects the transient state during buffer reload and does not change behavior in normal operation.

### Describe how to verify it

1. Open a PR that contains `<details>` HTML blocks in its body or comments
2. Run `:e` to refresh the buffer repeatedly
3. Confirm no "Invalid 'line': out of range" error appears

### Special notes for reviews

The fix is a 4-line change (1 line to get the line count, 3 lines for the guard). No new dependencies or behavioral changes for the normal case.

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt