### PR TITLE
fix(commands): guard against vim.NIL for discussion number lookup

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1223,11 +1223,11 @@ function M.octo(object, action, ...)
           local repo_data = decoded.data.repository
           local iop = repo_data.issueOrPullRequest
           local discussion = repo_data.discussion
-          if iop and iop.__typename == "Issue" then
+          if not utils.is_blank(iop) and iop.__typename == "Issue" then
             utils.get_issue(number, repo)
-          elseif iop and iop.__typename == "PullRequest" then
+          elseif not utils.is_blank(iop) and iop.__typename == "PullRequest" then
             utils.get_pull_request(number, repo)
-          elseif discussion and discussion.__typename == "Discussion" then
+          elseif not utils.is_blank(discussion) and discussion.__typename == "Discussion" then
             utils.get_discussion(number, repo)
           else
             utils.error("No issue, PR, or discussion found with number: " .. number)


### PR DESCRIPTION
Fixes a crash when using `:Octo <number>` to open a discussion.

`vim.json.decode` returns `vim.NIL` (userdata) for null JSON fields, not Lua `nil`. Since `vim.NIL` is truthy, the `iop and iop.__typename` guard didn't protect against indexing it, causing the error:

```
attempt to index local 'iop' (a userdata value)
```

Replaced bare truthiness checks with `not utils.is_blank(...)`, consistent with how the rest of the codebase handles `vim.NIL`.