### PR TITLE
feat(completion): support completion overrides for `Octo search`

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ require"octo".setup {
   search_completion = {
     overrides = {                               -- key is a qualifier, value is an array table or a function
       -- repo = {},                             -- example: disable completion for "repo:"
-      -- org  = { 'org-a', 'org-b' },           -- example: use static values for "org:" completion
+      -- org  = { "org-a", "org-b" },           -- example: use static values for "org:" completion
       -- commenter = function(argLead, cmdLine) -- example: use custom logic for "commenter:" completion
       --   -- custom logic
       --   return result_table

--- a/README.md
+++ b/README.md
@@ -524,6 +524,16 @@ require"octo".setup {
       open_in_browser = { lhs = "<C-b>", desc = "open release in browser" },
     },
   },
+  search_completion = {
+    overrides = {                               -- key is a qualifier, value is an array table or a function
+      -- repo = {},                             -- example: disable completion for "repo:"
+      -- org  = { 'org-a', 'org-b' },           -- example: use static values for "org:" completion
+      -- commenter = function(argLead, cmdLine) -- example: use custom logic for "commenter:" completion
+      --   -- custom logic
+      --   return result_table
+      -- end,
+    },
+  },
 }
 ```
 
@@ -795,6 +805,9 @@ Also, you can use [`cmp-emoji`](https://github.com/hrsh7th/cmp-emoji) or [`blink
 
 The term `GitHub color` refers to the colors used in the WebUI.
 The (addition) `viewer` means the user of the plugin or more precisely the user authenticated via the `gh` CLI tool used to retrieve the data from GitHub.
+
+Completion for `:Octo search` arguments can be overridden for each specific qualifier using `search_completion.overrides` config option.
+Example usecase: disable completion functionality that requires remote calls to GitHub server.
 
 ## 📺 Demos
 

--- a/README.md
+++ b/README.md
@@ -524,8 +524,8 @@ require"octo".setup {
       open_in_browser = { lhs = "<C-b>", desc = "open release in browser" },
     },
   },
-  search_completion = {
-    overrides = {                               -- key is a qualifier, value is an array table or a function
+  search = {
+    completion_overrides = {                    -- key is a qualifier, value is an array table or a function
       -- repo = {},                             -- example: disable completion for "repo:"
       -- org  = { "org-a", "org-b" },           -- example: use static values for "org:" completion
       -- commenter = function(argLead, cmdLine) -- example: use custom logic for "commenter:" completion
@@ -806,7 +806,7 @@ Also, you can use [`cmp-emoji`](https://github.com/hrsh7th/cmp-emoji) or [`blink
 The term `GitHub color` refers to the colors used in the WebUI.
 The (addition) `viewer` means the user of the plugin or more precisely the user authenticated via the `gh` CLI tool used to retrieve the data from GitHub.
 
-Completion for `:Octo search` arguments can be overridden for each specific qualifier using `search_completion.overrides` config option.
+Completion for `:Octo search` arguments can be overridden for each specific qualifier using `search.completion_overrides` config option.
 Example usecase: disable completion functionality that requires remote calls to GitHub server.
 
 ## 📺 Demos

--- a/lua/octo/completion/search.lua
+++ b/lua/octo/completion/search.lua
@@ -409,30 +409,32 @@ local qualifiers = {
 --- @param cmdLine string: The command line
 --- @return string[]
 function M.complete(argLead, cmdLine)
-  local function resolve_qualifier_and_action(first, second)
-    local qualifier = type(first) == "number" and second or first
+  local function resolve_qualifier(first, second)
+    return type(first) == "number" and second or first
+  end
 
+  local function resolve_action(qualifier, first, second)
     local override = config.values.search_completion.overrides[qualifier]
     if override ~= nil then
       if type(override) == "function" then
-        return qualifier, override
+        return override
       end
-      return qualifier, function()
+      return function()
         return get_closest_valid(qualifier, override, argLead)
       end
     end
 
     if type(first) == "number" then
-      return qualifier, function()
+      return function()
         return {}
       end
     end
 
     if type(second) == "function" then
-      return qualifier, second
+      return second
     end
 
-    return qualifier, function()
+    return function()
       return get_closest_valid(qualifier, second, argLead)
     end
   end
@@ -440,7 +442,7 @@ function M.complete(argLead, cmdLine)
   if not string.match(argLead, ":") then
     local valid = {}
     for first, second in pairs(qualifiers) do
-      local qualifier = resolve_qualifier_and_action(first, second)
+      local qualifier = resolve_qualifier(first, second)
       if string.match(qualifier, argLead) then
         table.insert(valid, qualifier .. ":")
       end
@@ -451,8 +453,9 @@ function M.complete(argLead, cmdLine)
   local expected_qualifier = string.match(argLead, "([^:]+):")
 
   for first, second in pairs(qualifiers) do
-    local qualifier, action = resolve_qualifier_and_action(first, second)
+    local qualifier = resolve_qualifier(first, second)
     if qualifier == expected_qualifier then
+      local action = resolve_action(qualifier, first, second)
       return action(argLead, cmdLine)
     end
   end

--- a/lua/octo/completion/search.lua
+++ b/lua/octo/completion/search.lua
@@ -414,7 +414,7 @@ function M.complete(argLead, cmdLine)
   end
 
   local function resolve_action(qualifier, first, second)
-    local override = config.values.search_completion.overrides[qualifier]
+    local override = config.values.search.completion_overrides[qualifier]
     if override ~= nil then
       if type(override) == "function" then
         return override

--- a/lua/octo/completion/search.lua
+++ b/lua/octo/completion/search.lua
@@ -5,6 +5,7 @@
 local gh = require "octo.gh"
 local queries = require "octo.gh.queries"
 local utils = require "octo.utils"
+local config = require "octo.config"
 
 local M = {}
 
@@ -408,10 +409,38 @@ local qualifiers = {
 --- @param cmdLine string: The command line
 --- @return string[]
 function M.complete(argLead, cmdLine)
+  local function resolve_qualifier_and_action(first, second)
+    local qualifier = type(first) == "number" and second or first
+
+    local override = config.values.search_completion.overrides[qualifier]
+    if override ~= nil then
+      if type(override) == "function" then
+        return qualifier, override
+      end
+      return qualifier, function()
+        return get_closest_valid(qualifier, override, argLead)
+      end
+    end
+
+    if type(first) == "number" then
+      return qualifier, function()
+        return {}
+      end
+    end
+
+    if type(second) == "function" then
+      return qualifier, second
+    end
+
+    return qualifier, function()
+      return get_closest_valid(qualifier, second, argLead)
+    end
+  end
+
   if not string.match(argLead, ":") then
     local valid = {}
     for first, second in pairs(qualifiers) do
-      local qualifier = type(first) == "number" and second or first
+      local qualifier = resolve_qualifier_and_action(first, second)
       if string.match(qualifier, argLead) then
         table.insert(valid, qualifier .. ":")
       end
@@ -422,22 +451,7 @@ function M.complete(argLead, cmdLine)
   local expected_qualifier = string.match(argLead, "([^:]+):")
 
   for first, second in pairs(qualifiers) do
-    local qualifier, action
-    if type(first) == "number" then
-      qualifier = second
-      action = function()
-        return {}
-      end
-    else
-      qualifier = first
-      action = second
-      if type(action) == "table" then
-        action = function()
-          return get_closest_valid(qualifier, second, argLead)
-        end
-      end
-    end
-
+    local qualifier, action = resolve_qualifier_and_action(first, second)
     if qualifier == expected_qualifier then
       return action(argLead, cmdLine)
     end

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -114,6 +114,9 @@ local M = {}
 ---@class OctoConfigDebug
 ---@field notify_missing_timeline_items boolean
 
+---@class OctoConfigSearchCompletion
+---@field overrides table<string, string[]|fun(argLead: string, cmdLine: string): string[]>
+
 ---@class OctoConfig Octo configuration settings
 ---@field picker OctoPickers
 ---@field picker_config OctoPickerConfig
@@ -158,6 +161,7 @@ local M = {}
 ---@field discussions OctoConfigDiscussions
 ---@field notifications OctoConfigNotifications
 ---@field poll OctoConfigPoll
+---@field search_completion OctoConfigSearchCompletion
 ---@field debug OctoConfigDebug
 
 --- Returns the default octo config values
@@ -533,6 +537,9 @@ function M.get_default_values()
       notify_on_refresh = true,
       notify_on_change = true,
     },
+    search_completion = {
+      overrides = {},
+    },
     debug = {
       notify_missing_timeline_items = false,
     },
@@ -728,6 +735,13 @@ function M.validate_config()
     validate_type(config.snippet_context_lines, "snippet_context_lines", "number")
     validate_type(config.timeout, "timeout", "number")
     validate_type(config.default_to_projects_v2, "default_to_projects_v2", "boolean")
+    if validate_type(config.search_completion, "search_completion", "table") then
+      if validate_type(config.search_completion.overrides, "search_completion.overrides", "table") then
+        for name, value in pairs(config.search_completion.overrides) do
+          validate_type(value, "search_completion.overrides." .. name, { "table", "function" })
+        end
+      end
+    end
     if validate_type(config.suppress_missing_scope, "suppress_missing_scope", "table") then
       validate_type(config.suppress_missing_scope.projects_v2, "suppress_missing_scope.projects_v2", "boolean")
     end

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -114,8 +114,8 @@ local M = {}
 ---@class OctoConfigDebug
 ---@field notify_missing_timeline_items boolean
 
----@class OctoConfigSearchCompletion
----@field overrides table<string, string[]|fun(argLead: string, cmdLine: string): string[]>
+---@class OctoConfigSearch
+---@field completion_overrides table<string, string[]|fun(argLead: string, cmdLine: string): string[]>
 
 ---@class OctoConfig Octo configuration settings
 ---@field picker OctoPickers
@@ -161,7 +161,7 @@ local M = {}
 ---@field discussions OctoConfigDiscussions
 ---@field notifications OctoConfigNotifications
 ---@field poll OctoConfigPoll
----@field search_completion OctoConfigSearchCompletion
+---@field search OctoConfigSearch
 ---@field debug OctoConfigDebug
 
 --- Returns the default octo config values
@@ -537,8 +537,8 @@ function M.get_default_values()
       notify_on_refresh = true,
       notify_on_change = true,
     },
-    search_completion = {
-      overrides = {},
+    search = {
+      completion_overrides = {},
     },
     debug = {
       notify_missing_timeline_items = false,
@@ -735,10 +735,10 @@ function M.validate_config()
     validate_type(config.snippet_context_lines, "snippet_context_lines", "number")
     validate_type(config.timeout, "timeout", "number")
     validate_type(config.default_to_projects_v2, "default_to_projects_v2", "boolean")
-    if validate_type(config.search_completion, "search_completion", "table") then
-      if validate_type(config.search_completion.overrides, "search_completion.overrides", "table") then
-        for name, value in pairs(config.search_completion.overrides) do
-          validate_type(value, "search_completion.overrides." .. name, { "table", "function" })
+    if validate_type(config.search, "search", "table") then
+      if validate_type(config.search.completion_overrides, "search.completion_overrides", "table") then
+        for name, value in pairs(config.search.completion_overrides) do
+          validate_type(value, "search.completion_overrides." .. name, { "table", "function" })
         end
       end
     end

--- a/lua/tests/octo/config_spec.lua
+++ b/lua/tests/octo/config_spec.lua
@@ -211,7 +211,11 @@ describe("Octo config", function()
       end)
 
       it("should return valid when search.completion_overrides has function values", function()
-        config.values.search.completion_overrides = { label = function() return {} end }
+        config.values.search.completion_overrides = {
+          label = function()
+            return {}
+          end,
+        }
         assert.True(vim.tbl_count(require("octo.config").validate_config()) == 0)
       end)
     end)

--- a/lua/tests/octo/config_spec.lua
+++ b/lua/tests/octo/config_spec.lua
@@ -154,6 +154,21 @@ describe("Octo config", function()
         assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
       end)
 
+      it("should return invalid when completion isn't a table", function()
+        config.values.completion = "not a table"
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
+      end)
+
+      it("should return invalid when completion.overrides isn't a table", function()
+        config.values.completion.overrides = "not a table"
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
+      end)
+
+      it("should return invalid when completion.overrides entry isn't a table or function", function()
+        config.values.completion.overrides = { repo = "not valid" }
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
+      end)
+
       it("should return invalid when ui isn't a table", function()
         config.values.ui = "not a table"
         assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
@@ -187,6 +202,16 @@ describe("Octo config", function()
 
     describe("for good configs", function()
       it("should return valid for the default config", function()
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) == 0)
+      end)
+
+      it("should return valid when completion.overrides has table values", function()
+        config.values.completion.overrides = { repo = { "my-org/repo1" } }
+        assert.True(vim.tbl_count(require("octo.config").validate_config()) == 0)
+      end)
+
+      it("should return valid when completion.overrides has function values", function()
+        config.values.completion.overrides = { label = function() return {} end }
         assert.True(vim.tbl_count(require("octo.config").validate_config()) == 0)
       end)
     end)

--- a/lua/tests/octo/config_spec.lua
+++ b/lua/tests/octo/config_spec.lua
@@ -154,18 +154,18 @@ describe("Octo config", function()
         assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
       end)
 
-      it("should return invalid when completion isn't a table", function()
-        config.values.completion = "not a table"
+      it("should return invalid when search isn't a table", function()
+        config.values.search = "not a table"
         assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
       end)
 
-      it("should return invalid when completion.overrides isn't a table", function()
-        config.values.completion.overrides = "not a table"
+      it("should return invalid when search.completion_overrides isn't a table", function()
+        config.values.search.completion_overrides = "not a table"
         assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
       end)
 
-      it("should return invalid when completion.overrides entry isn't a table or function", function()
-        config.values.completion.overrides = { repo = "not valid" }
+      it("should return invalid when search.completion_overrides entry isn't a table or function", function()
+        config.values.search.completion_overrides = { repo = "not valid" }
         assert.True(vim.tbl_count(require("octo.config").validate_config()) ~= 0)
       end)
 
@@ -205,13 +205,13 @@ describe("Octo config", function()
         assert.True(vim.tbl_count(require("octo.config").validate_config()) == 0)
       end)
 
-      it("should return valid when completion.overrides has table values", function()
-        config.values.completion.overrides = { repo = { "my-org/repo1" } }
+      it("should return valid when search.completion_overrides has table values", function()
+        config.values.search.completion_overrides = { repo = { "my-org/repo1" } }
         assert.True(vim.tbl_count(require("octo.config").validate_config()) == 0)
       end)
 
-      it("should return valid when completion.overrides has function values", function()
-        config.values.completion.overrides = { label = function() return {} end }
+      it("should return valid when search.completion_overrides has function values", function()
+        config.values.search.completion_overrides = { label = function() return {} end }
         assert.True(vim.tbl_count(require("octo.config").validate_config()) == 0)
       end)
     end)


### PR DESCRIPTION
### Describe what this PR does / why we need it

Allows overriding completion for individual qualifiers in `:Octo search`

### Does this pull request fix one issue?

Fixes #1479

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
