### PR TITLE
fix(review): use more specific hash for file comparison

### DIFF
--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -237,8 +237,6 @@ function FileEntry:fetch(sync)
   self.right_fetching = true
   local right_sha = current_review.layout.right.commit
   local left_sha = current_review.layout.left.commit
-  local right_abbrev = current_review.layout.right:abbrev()
-  local left_abbrev = current_review.layout.left:abbrev()
 
   -- handle renamed files
   if self.status == "R" and self.previous_path then
@@ -253,7 +251,7 @@ function FileEntry:fetch(sync)
       self.right_fetching = false
     end)
   else
-    utils.get_file_contents(self.pull_request.repo, right_abbrev, right_path, function(lines)
+    utils.get_file_contents(self.pull_request.repo, right_sha, right_path, function(lines)
       self.right_lines = lines
       self.right_fetched = true
       self.right_fetching = false
@@ -268,7 +266,7 @@ function FileEntry:fetch(sync)
       self.left_fetching = false
     end)
   else
-    utils.get_file_contents(self.pull_request.repo, left_abbrev, left_path, function(lines)
+    utils.get_file_contents(self.pull_request.repo, left_sha, left_path, function(lines)
       self.left_lines = lines
       self.left_fetched = true
       self.left_fetching = false
@@ -464,7 +462,7 @@ function FileEntry:place_signs()
           (review_level == "PR" and utils.is_thread_placed_in_buffer(thread, split.bufnr))
           or (
             review_level == "COMMIT"
-            and current_review.layout.right:abbrev() == comment.originalCommit.abbreviatedOid
+            and current_review.layout.right.commit == comment.originalCommit.oid
             and utils.is_thread_placed_in_buffer(thread, split.bufnr)
           )
         then


### PR DESCRIPTION
### Describe what this PR does / why we need it

On a large repo with a lot of commits, I sometimes run into where diff is completely or slightly wrong. I found that we're using the abbreviated sha for comparison, which is not certain to be unique for these large repos so we update it to not use the abbreviated commit sha. Probably best to not use this hard coded `:abbrev()` function in [rev.lua](https://github.com/pwntester/octo.nvim/blob/eaa193c92dd2caea6d7dea51531f6bfc0f5c2c30/lua/octo/reviews/rev.lua#L26) in general, but out of scope for this PR.


### Does this pull request fix one issue?

there's issues like this one https://github.com/pwntester/octo.nvim/issues/544 and this one https://github.com/pwntester/octo.nvim/issues/529. not sure if it fixes them but it has largely fixed the issue for me

### Describe how to verify it

hard to truly verify since it requires a hash collision

