### PR TITLE
fix(issue/pr): prevent crash on invalid referenced event

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -2550,7 +2550,7 @@ end
 ---@param bufnr integer
 ---@param item octo.fragments.ReferencedEvent
 function M.write_referenced_event(bufnr, item)
-  if utils.is_blank(item.actor) then
+  if utils.is_blank(item.actor) or utils.is_blank(item.commit) then
     return
   end
 


### PR DESCRIPTION
### Describe what this PR does / why we need it

Fixes a wild scenario where octo crashed on an invalid reference event because it didn't have a commit field. It doesn't even show up in the GitHub UI which is even weirder, but at least it handles it, so we probably should too.

Issue in question: https://github.com/anthropics/claude-code/issues/6235

