### PR TITLE
ci(deps): bump lua ls version and remove unnecessary dep

### DIFF
--- a/.github/workflows/.luarc.json
+++ b/.github/workflows/.luarc.json
@@ -8,8 +8,6 @@
     "library": [
       "$VIMRUNTIME/lua",
       "$PWD/lua",
-      "${3rd}/luv/library",
-      "$PWD/deps/luvit-meta/library",
       "$PWD/deps/snacks.nvim/lua",
       "$PWD/deps/plenary.nvim/lua",
       "$PWD/deps/telescope.nvim/lua",

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         nvim_version: [stable]
-        lua_ls_version: [3.15.0]
+        lua_ls_version: [3.18.2]
     steps:
       - uses: actions/checkout@v6
       - name: Install neovim
@@ -41,7 +41,6 @@ jobs:
             "nvim-telescope/telescope.nvim"
             "ibhagwan/fzf-lua"
             "nvim-tree/nvim-web-devicons"
-            "Bilal2453/luvit-meta"
           )
           for dep in "${DEPS[@]}"; do
             repo_name=$(echo $dep | cut -d'/' -f2)

--- a/lua/octo/polling.lua
+++ b/lua/octo/polling.lua
@@ -19,7 +19,7 @@ local M = {}
 ---@type table<integer, OctoPollingEntry>
 local tracked_buffers = {}
 
----@type uv_timer_t|nil
+---@type uv.uv_timer_t|nil
 local timer = nil
 
 ---Check if an OctoBuffer has unsaved local edits


### PR DESCRIPTION
### Describe what this PR does / why we need it

Attempting to fix CI here by bumping lua-language-server to latest version and also cleaning up some dependencies made unnecessary by newest neovim version (luvit-meta).
