### PR TITLE
fix(writers): resolve no-unknown type warning for max_width

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -316,6 +316,7 @@ function M.write_discussion_poll(bufnr, poll, start_line)
   local total_votes = poll.totalVoteCount
 
   -- First pass: Calculate maximum option text width for alignment
+  ---@type integer
   local max_width = 0
   for _, option in ipairs(options) do
     local prefix = option.viewerHasVoted and "✓ " or "  "


### PR DESCRIPTION
Fixes the Lua Language Server `no-unknown` warning on master.

The `max_width` variable in `write_poll` was missing an explicit type annotation, causing LLS to fail type inference on the `math.max` assignment.

```lua
---@type integer
local max_width = 0
```