### PR TITLE
feat(timeline): add fragment registry with dedup and enterprise compat gating

### DIFF
--- a/.agents/skills/timeline-items/SKILL.md
+++ b/.agents/skills/timeline-items/SKILL.md
@@ -93,8 +93,8 @@ These are called in `queries.lua` at the end of the `..` chain for the `issue` a
    -- Always available:
    { "MyEventFragment", M.my_event },
 
-   -- github.com only (not on GHES) — pass not_enterprise directly:
-   { "MyEventFragment", M.my_event, not_enterprise },
+   -- github.com only (not on GHES):
+   { "MyEventFragment", M.my_event, is_github_com },
 
    -- Gated on a config flag:
    { "MyEventFragment", M.my_event, function() return config.values.some_flag end },
@@ -118,9 +118,8 @@ These are called in `queries.lua` at the end of the `..` chain for the `issue` a
    reg("MyEvent", { batch = "my_accumulator" })
    ```
 
-   Also add the accumulator to the `accumulators` table and, if it should set `prev_is_event`
-   when an item is accumulated, add it to `batch_sets_prev_event` — both inside
-   `M.write_timeline_items`.
+   Also add the accumulator to the `accumulators` table inside `M.write_timeline_items`.
+   Use `sets_prev_event = true` in the registry entry when batching should mark `prev_is_event`.
 
 6. Add a `write_my_event` function in `lua/octo/ui/writers.lua`.
 
@@ -135,8 +134,8 @@ GHES instances run older GraphQL API versions that lack certain types. Fragments
 types must carry a condition that gates them out when `github_hostname` is non-empty:
 
 ```lua
-function() return not is_enterprise() end
--- where is_enterprise() = config.values.github_hostname ~= ""
+function() return config.values.github_hostname == "" end
+-- equivalent to local is_github_com() helper in fragments.lua
 ```
 
 Known GHES-incompatible issue timeline fragments (issues #1153):
@@ -164,6 +163,7 @@ Each entry is an `octo.TimelineWriterEntry`:
 ---@class octo.TimelineWriterEntry
 ---@field writer? fun(bufnr: integer, item: table)  -- direct dispatch
 ---@field batch?  string                            -- name of accumulator table
+---@field sets_prev_event? boolean                  -- set prev_is_event after write/accumulate
 ```
 
 The registry is populated in a `do` block at the **bottom of `writers.lua`** (after all
@@ -172,14 +172,14 @@ The registry is populated in a `do` block at the **bottom of `writers.lua`** (af
 ```lua
 local reg = timeline_registry.register
 reg("MergedEvent",   { writer = M.write_merged_event })
-reg("LabeledEvent",  { batch = "label" })  -- accumulated, flushed by render_accumulated_events
+reg("LabeledEvent",  { batch = "label_events" }) -- accumulated, flushed by render_accumulated_events
 ```
 
 `IssueComment` and `PullRequestReview` are **not** in the registry — they have bespoke
 rendering logic (folds, thread matching) handled directly in `write_timeline_items`.
 
-`BlockedByRemovedEvent` is registered with a `writer` but intentionally does **not** set
-`prev_is_event`; this quirk is preserved with an explicit comment in the dispatch loop.
+`BlockedByRemovedEvent` is registered with `sets_prev_event = false` to preserve existing
+buffer spacing behavior.
 
 ### Registering a fragment from external code (plugins/user config)
 

--- a/.agents/skills/timeline-items/SKILL.md
+++ b/.agents/skills/timeline-items/SKILL.md
@@ -23,10 +23,12 @@ The process usually includes changing these files:
 
 ```
 lua/octo/gh/fragments.lua
-lua/octo/gh/queries.lua
+lua/octo/gh/timeline_registry.lua
 lua/octo/ui/writers.lua
 lua/octo/utils.lua
 ```
+
+`lua/octo/gh/queries.lua` no longer needs to be changed for new timeline items.
 
 Please also include any changes to the example-timeline file that will help debug:
 
@@ -103,9 +105,26 @@ These are called in `queries.lua` at the end of the `..` chain for the `issue` a
 4. Add `octo.fragments.MyEvent` to the `---@alias octo.IssueTimelineItem` or
    `---@alias octo.PullRequestTimelineItem` union type annotation.
 
-5. Handle the new `__typename` in `lua/octo/ui/writers.lua` and/or `lua/octo/utils.lua`.
+5. Register a writer in `lua/octo/gh/timeline_registry.lua` from the `do` block at the bottom
+   of `lua/octo/ui/writers.lua`. For a direct-dispatch event:
 
-6. Update `scripts/example-timeline.lua` to include a sample of the new event for debugging.
+   ```lua
+   reg("MyEvent", { writer = M.write_my_event })
+   ```
+
+   For a batched/accumulated event (e.g. labels, commits), use the `batch` key:
+
+   ```lua
+   reg("MyEvent", { batch = "my_accumulator" })
+   ```
+
+   Also add the accumulator to the `accumulators` table and, if it should set `prev_is_event`
+   when an item is accumulated, add it to `batch_sets_prev_event` — both inside
+   `M.write_timeline_items`.
+
+6. Add a `write_my_event` function in `lua/octo/ui/writers.lua`.
+
+7. Update `scripts/example-timeline.lua` to include a sample of the new event for debugging.
 
 > **Note**: `queries.lua` does **not** need to be changed for new timeline items — the registry
 > and `get_*_timeline_definitions()` handle appending definitions automatically.
@@ -134,6 +153,34 @@ Known GHES-incompatible PR timeline fragments (issues #685, #513):
 When adding a new type, check the GitHub Enterprise Server GraphQL changelog to determine
 from which GHES version the type is available. If it's newer than ~3.12, gate it.
 
+## Writer Dispatch Registry
+
+The `if/elseif` dispatch chain in `write_timeline_items` has been replaced by a registry in
+`lua/octo/gh/timeline_registry.lua`. It maps `__typename → { writer? | batch? }`.
+
+Each entry is an `octo.TimelineWriterEntry`:
+
+```lua
+---@class octo.TimelineWriterEntry
+---@field writer? fun(bufnr: integer, item: table)  -- direct dispatch
+---@field batch?  string                            -- name of accumulator table
+```
+
+The registry is populated in a `do` block at the **bottom of `writers.lua`** (after all
+`write_*` functions are defined), so function references are valid:
+
+```lua
+local reg = timeline_registry.register
+reg("MergedEvent",   { writer = M.write_merged_event })
+reg("LabeledEvent",  { batch = "label" })  -- accumulated, flushed by render_accumulated_events
+```
+
+`IssueComment` and `PullRequestReview` are **not** in the registry — they have bespoke
+rendering logic (folds, thread matching) handled directly in `write_timeline_items`.
+
+`BlockedByRemovedEvent` is registered with a `writer` but intentionally does **not** set
+`prev_is_event`; this quirk is preserved with an explicit comment in the dispatch loop.
+
 ### Registering a fragment from external code (plugins/user config)
 
 External code that wants to add a custom timeline item should call the registration function
@@ -156,3 +203,17 @@ fragments.register_issue_timeline_item(
   end
 )
 ```
+
+You must also register a writer so `write_timeline_items` knows how to render the event:
+
+```lua
+local timeline_registry = require("octo.gh.timeline_registry")
+
+timeline_registry.register("MyCustomEvent", {
+  writer = function(bufnr, item)
+    -- render the event into the buffer
+  end,
+})
+```
+
+Both calls should be made **before** `require("octo").setup()`.

--- a/.agents/skills/timeline-items/SKILL.md
+++ b/.agents/skills/timeline-items/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: timeline-items
+description: >
+  Details about timeline items for issues and Pull Requests and how to create and modify.
+---
+
+These can be found under GraphQL
+
+`IssueTimelineItems`
+`PullRequestTimelineItems`
+
+Use the `lookup-graphql-information` skill if needing more information about them.
+
+## Previous implementations
+
+There is the label `timelineItems` on GitHub that can be used to reference other similar PRs.
+
+For example, `gh pr list --label timelineItems --state closed` shows all of the previous PRs.
+
+## Files involved
+
+The process usually includes changing these files:
+
+```
+lua/octo/gh/fragments.lua
+lua/octo/gh/queries.lua
+lua/octo/ui/writers.lua
+lua/octo/utils.lua
+```
+
+Please also include any changes to the example-timeline file that will help debug:
+
+```
+scripts/example-timeline.lua
+```
+
+Please use typing for the new types.
+
+## Fragment Registry (Issue #1365)
+
+Timeline item fragments are managed through a **registry** in `lua/octo/gh/fragments.lua`.
+This replaced the previous approach of manually appending raw strings in two places.
+
+### Architecture
+
+The registry lives at module level (outside `setup()`) so external code can register fragments
+before `setup()` is called. Two separate registries exist:
+
+- `M._issue_timeline_registry` — for `IssueTimelineItemsConnection`
+- `M._pr_timeline_registry` — for `PullRequestTimelineItemsConnection`
+
+Each entry is an `octo.TimelineFragmentEntry`:
+
+```lua
+---@class octo.TimelineFragmentEntry
+---@field spread string              Fragment name, e.g. "AssignedEventFragment"
+---@field definition string          Full GraphQL fragment definition string
+---@field condition? fun():boolean   Optional gate evaluated at setup() time
+```
+
+### Public API
+
+```lua
+M.register_issue_timeline_item(spread_name, definition, condition?)
+M.register_pull_request_timeline_item(spread_name, definition, condition?)
+```
+
+- **Deduplication**: registering the same `spread_name` twice is safe — later calls are ignored.
+- **`condition`**: optional `fun():boolean`. If it returns `false` at `setup()` time, the fragment
+  spread and definition are omitted from the query entirely.
+
+Two helper functions build the final definition strings consumed by `queries.lua`:
+
+```lua
+M.get_issue_timeline_definitions()   -- returns string
+M.get_pr_timeline_definitions()      -- returns string
+```
+
+These are called in `queries.lua` at the end of the `..` chain for the `issue` and
+`pull_request` queries respectively.
+
+### Adding a new timeline item
+
+1. Define the fragment string as `M.my_event = [[ fragment MyEventFragment on MyEvent { ... } ]]`
+   inside `M.setup()` in `lua/octo/gh/fragments.lua`, near the other event definitions.
+
+2. Seed it into the appropriate registry, also inside `M.setup()`, in the `issue_builtin` or
+   `pr_builtin` table. Pass a `condition` if the type is not universally available:
+
+   ```lua
+   -- Always available:
+   { "MyEventFragment", M.my_event },
+
+   -- github.com only (not on GHES) — pass not_enterprise directly:
+   { "MyEventFragment", M.my_event, not_enterprise },
+
+   -- Gated on a config flag:
+   { "MyEventFragment", M.my_event, function() return config.values.some_flag end },
+   ```
+
+3. Add a `---@class octo.fragments.MyEvent` annotation above the fragment definition.
+
+4. Add `octo.fragments.MyEvent` to the `---@alias octo.IssueTimelineItem` or
+   `---@alias octo.PullRequestTimelineItem` union type annotation.
+
+5. Handle the new `__typename` in `lua/octo/ui/writers.lua` and/or `lua/octo/utils.lua`.
+
+6. Update `scripts/example-timeline.lua` to include a sample of the new event for debugging.
+
+> **Note**: `queries.lua` does **not** need to be changed for new timeline items — the registry
+> and `get_*_timeline_definitions()` handle appending definitions automatically.
+
+### Enterprise compatibility (label: "Enterprise compat")
+
+GHES instances run older GraphQL API versions that lack certain types. Fragments for those
+types must carry a condition that gates them out when `github_hostname` is non-empty:
+
+```lua
+function() return not is_enterprise() end
+-- where is_enterprise() = config.values.github_hostname ~= ""
+```
+
+Known GHES-incompatible issue timeline fragments (issues #1153):
+`PinnedEvent`, `UnpinnedEvent`, `SubIssueAddedEvent`, `SubIssueRemovedEvent`,
+`ParentIssueAddedEvent`, `ParentIssueRemovedEvent`, `IssueTypeAddedEvent`,
+`IssueTypeRemovedEvent`, `IssueTypeChangedEvent`, `BlockedByAddedEvent`,
+`BlockedByRemovedEvent`, `BlockingAddedEvent`, `BlockingRemovedEvent`, `TransferredEvent`
+
+Known GHES-incompatible PR timeline fragments (issues #685, #513):
+`AutomaticBaseChangeSucceededEvent`, `BaseRefChangedEvent`, `ConvertToDraftEvent`,
+`DeployedEvent`, `HeadRefDeletedEvent`, `HeadRefRestoredEvent`, `HeadRefForcePushedEvent`,
+`AutoSquashEnabledEvent`, `AutoMergeEnabledEvent`, `AutoMergeDisabledEvent`
+
+When adding a new type, check the GitHub Enterprise Server GraphQL changelog to determine
+from which GHES version the type is available. If it's newer than ~3.12, gate it.
+
+### Registering a fragment from external code (plugins/user config)
+
+External code that wants to add a custom timeline item should call the registration function
+**before** `require("octo").setup()` is called:
+
+```lua
+local fragments = require("octo.gh.fragments")
+
+fragments.register_issue_timeline_item(
+  "MyCustomEventFragment",
+  [[
+    fragment MyCustomEventFragment on MyCustomEvent {
+      actor { login }
+      createdAt
+    }
+  ]],
+  -- Optional condition: only include on github.com
+  function()
+    return require("octo.config").values.github_hostname == ""
+  end
+)
+```

--- a/.agents/skills/timeline-items/SKILL.md
+++ b/.agents/skills/timeline-items/SKILL.md
@@ -28,7 +28,8 @@ lua/octo/ui/writers.lua
 lua/octo/utils.lua
 ```
 
-`lua/octo/gh/queries.lua` no longer needs to be changed for new timeline items.
+`lua/octo/gh/queries.lua` and `lua/octo/gh/mutations.lua` no longer need to be changed for
+new timeline items.
 
 Please also include any changes to the example-timeline file that will help debug:
 
@@ -71,15 +72,16 @@ M.register_pull_request_timeline_item(spread_name, definition, condition?)
 - **`condition`**: optional `fun():boolean`. If it returns `false` at `setup()` time, the fragment
   spread and definition are omitted from the query entirely.
 
-Two helper functions build the final definition strings consumed by `queries.lua`:
+Two helper functions build the final definition strings consumed by both `queries.lua`
+and `mutations.lua`:
 
 ```lua
 M.get_issue_timeline_definitions()   -- returns string
 M.get_pr_timeline_definitions()      -- returns string
 ```
 
-These are called in `queries.lua` at the end of the `..` chain for the `issue` and
-`pull_request` queries respectively.
+These are called at the end of the `..` fragment chains for issue/PR queries and the
+issue/PR mutation payload queries.
 
 ### Adding a new timeline item
 
@@ -127,6 +129,8 @@ These are called in `queries.lua` at the end of the `..` chain for the `issue` a
 
 > **Note**: `queries.lua` does **not** need to be changed for new timeline items — the registry
 > and `get_*_timeline_definitions()` handle appending definitions automatically.
+>
+> `mutations.lua` also does **not** need manual timeline-fragment edits for these items.
 
 ### Enterprise compatibility (label: "Enterprise compat")
 
@@ -162,8 +166,22 @@ Each entry is an `octo.TimelineWriterEntry`:
 ```lua
 ---@class octo.TimelineWriterEntry
 ---@field writer? fun(bufnr: integer, item: table)  -- direct dispatch
----@field batch?  string                            -- name of accumulator table
+---@field batch? octo.TimelineBatchKey              -- accumulator table key
 ---@field sets_prev_event? boolean                  -- set prev_is_event after write/accumulate
+```
+
+Available batch keys:
+
+```lua
+---@alias octo.TimelineBatchKey
+---| "assignment_events"
+---| "label_events"
+---| "pull_request_commits"
+---| "force_pushed_events"
+---| "review_requested_events"
+---| "review_request_removed_events"
+---| "subissue_added_events"
+---| "subissue_removed_events"
 ```
 
 The registry is populated in a `do` block at the **bottom of `writers.lua`** (after all
@@ -180,6 +198,10 @@ rendering logic (folds, thread matching) handled directly in `write_timeline_ite
 
 `BlockedByRemovedEvent` is registered with `sets_prev_event = false` to preserve existing
 buffer spacing behavior.
+
+Accumulator arrays in `write_timeline_items` must be cleared **in place** (set indices to
+`nil`) rather than rebound (`items = {}`), otherwise registry batch-key references can become
+stale and final grouped events may fail to render.
 
 ### Registering a fragment from external code (plugins/user config)
 

--- a/lua/octo/gh/fragments.lua
+++ b/lua/octo/gh/fragments.lua
@@ -1,6 +1,94 @@
 local config = require "octo.config"
 local M = {}
 
+--- Registry entry for a timeline item fragment.
+---@class octo.TimelineFragmentEntry
+---@field spread string       Fragment name, e.g. "AssignedEventFragment"
+---@field definition string   Full GraphQL fragment definition string
+---@field condition? fun():boolean  Optional predicate evaluated at setup() time.
+---                                 Return false to exclude this item from the query.
+---                                 nil means always included.
+
+--- Registry of issue timeline item fragments, keyed by spread name.
+--- Populated during setup() with built-in items.
+--- External code may call M.register_issue_timeline_item() BEFORE setup() to add custom items.
+---@type table<string, octo.TimelineFragmentEntry>
+M._issue_timeline_registry = {}
+
+--- Registry of PR timeline item fragments, keyed by spread name.
+---@type table<string, octo.TimelineFragmentEntry>
+M._pr_timeline_registry = {}
+
+--- Register a timeline item fragment for Issues.
+--- Safe to call multiple times with the same spread_name; later registrations are ignored (dedup).
+---
+--- The optional `condition` function is called at setup() time. If it returns false the fragment
+--- spread and definition are omitted from the query — useful for gating on API version or
+--- enterprise vs. github.com compatibility.
+---
+--- Example — register only on github.com:
+---   M.register_issue_timeline_item("MyEventFragment", [[
+---     fragment MyEventFragment on MyEvent { ... }
+---   ]], function()
+---     return require("octo.config").values.github_hostname == ""
+---   end)
+---
+---@param spread_name string        Fragment name, e.g. "MyEventFragment"
+---@param definition string         Full GraphQL fragment definition string
+---@param condition? fun():boolean  Optional gate; return false to skip this fragment
+function M.register_issue_timeline_item(spread_name, definition, condition)
+  if M._issue_timeline_registry[spread_name] == nil then
+    M._issue_timeline_registry[spread_name] = {
+      spread = spread_name,
+      definition = definition,
+      condition = condition,
+    }
+  end
+end
+
+--- Register a timeline item fragment for Pull Requests.
+--- See register_issue_timeline_item for full documentation.
+---@param spread_name string        Fragment name, e.g. "MyEventFragment"
+---@param definition string         Full GraphQL fragment definition string
+---@param condition? fun():boolean  Optional gate; return false to skip this fragment
+function M.register_pull_request_timeline_item(spread_name, definition, condition)
+  if M._pr_timeline_registry[spread_name] == nil then
+    M._pr_timeline_registry[spread_name] = {
+      spread = spread_name,
+      definition = definition,
+      condition = condition,
+    }
+  end
+end
+
+--- Returns a concatenated string of all active Issue timeline fragment definitions.
+--- Entries whose condition() returns false are excluded.
+--- Used by queries.lua to append definitions after the query body.
+---@return string
+function M.get_issue_timeline_definitions()
+  local result = ""
+  for _, entry in pairs(M._issue_timeline_registry) do
+    if entry.condition == nil or entry.condition() then
+      result = result .. entry.definition
+    end
+  end
+  return result
+end
+
+--- Returns a concatenated string of all active PR timeline fragment definitions.
+--- Entries whose condition() returns false are excluded.
+--- Used by queries.lua to append definitions after the query body.
+---@return string
+function M.get_pr_timeline_definitions()
+  local result = ""
+  for _, entry in pairs(M._pr_timeline_registry) do
+    if entry.condition == nil or entry.condition() then
+      result = result .. entry.definition
+    end
+  end
+  return result
+end
+
 M.setup = function()
   ---@class octo.fragments.ProjectsV2Connection
   ---@field nodes {
@@ -1201,48 +1289,84 @@ fragment CommentDeletedEventFragment on CommentDeletedEvent {
   }
   ]]
 
-  local issue_timeline_items_connection_fragments = [[
-    __typename
-    ...AssignedEventFragment
-    ...UnassignedEventFragment
-    ...ClosedEventFragment
-    ...ConnectedEventFragment
-    ...ReferencedEventFragment
-    ...CrossReferencedEventFragment
-    ...DemilestonedEventFragment
-    ...IssueCommentFragment
-    ...LabeledEventFragment
-    ...MilestonedEventFragment
-    ...RenamedTitleEventFragment
-    ...ReopenedEventFragment
-    ...UnlabeledEventFragment
-    ...PinnedEventFragment
-    ...UnpinnedEventFragment
-    ...SubIssueAddedEventFragment
-    ...SubIssueRemovedEventFragment
-    ...ParentIssueAddedEventFragment
-    ...ParentIssueRemovedEventFragment
-    ...IssueTypeAddedEventFragment
-    ...IssueTypeRemovedEventFragment
-    ...IssueTypeChangedEventFragment
-    ...CommentDeletedEventFragment
-    ...BlockedByAddedEventFragment
-    ...BlockedByRemovedEventFragment
-    ...BlockingAddedEventFragment
-    ...BlockingRemovedEventFragment
-    ...TransferredEventFragment
-    ...LockedEventFragment
-    ...UnlockedEventFragment
-    ...MarkedAsDuplicateEventFragment
-    ...UnmarkedAsDuplicateEventFragment
-]]
-  if config.values.default_to_projects_v2 then
-    issue_timeline_items_connection_fragments = issue_timeline_items_connection_fragments
-      .. [[
-    ...AddedToProjectV2EventFragment
-    ...RemovedFromProjectV2EventFragment
-    ...ProjectV2ItemStatusChangedEventFragment
-    ]]
+  -- Seed the issue timeline registry with all built-in items.
+  -- External code may call M.register_issue_timeline_item() before setup() to add custom items.
+  --
+  -- The `condition` function (3rd element) is evaluated at setup() time:
+  --   nil  → always included
+  --   fn() → included only when fn() returns true
+  --
+  -- Fragments that reference types absent from older GHES versions are gated on
+  -- `not is_enterprise`, where enterprise is defined as github_hostname being non-empty.
+  local function is_enterprise()
+    return config.values.github_hostname ~= ""
+  end
+
+  local function not_enterprise()
+    return not is_enterprise()
+  end
+
+  local function projects_v2_enabled()
+    return config.values.default_to_projects_v2
+  end
+
+  local issue_builtin = {
+    -- Always available
+    { "AssignedEventFragment", M.assigned_event },
+    { "UnassignedEventFragment", M.unassigned_event },
+    { "ClosedEventFragment", M.closed_event },
+    { "ConnectedEventFragment", M.connected_event },
+    { "ReferencedEventFragment", M.referenced_event },
+    { "CrossReferencedEventFragment", M.cross_referenced_event },
+    { "DemilestonedEventFragment", M.demilestoned_event },
+    { "IssueCommentFragment", M.issue_comment },
+    { "LabeledEventFragment", M.labeled_event },
+    { "MilestonedEventFragment", M.milestoned_event },
+    { "RenamedTitleEventFragment", M.renamed_title_event },
+    { "ReopenedEventFragment", M.reopened_event },
+    { "UnlabeledEventFragment", M.unlabeled_event },
+    { "CommentDeletedEventFragment", M.comment_deleted_event },
+    { "LockedEventFragment", M.locked_event },
+    { "UnlockedEventFragment", M.unlocked_event },
+    { "MarkedAsDuplicateEventFragment", M.marked_as_duplicate_event },
+    { "UnmarkedAsDuplicateEventFragment", M.unmarked_as_duplicate_event },
+    -- github.com-only: not present on older GHES (issues #1153)
+    { "PinnedEventFragment", M.pinned_event, not_enterprise },
+    { "UnpinnedEventFragment", M.unpinned_event, not_enterprise },
+    { "SubIssueAddedEventFragment", M.subissue_added_event, not_enterprise },
+    { "SubIssueRemovedEventFragment", M.subissue_removed_event, not_enterprise },
+    { "ParentIssueAddedEventFragment", M.parent_issue_added_event, not_enterprise },
+    { "ParentIssueRemovedEventFragment", M.parent_issue_removed_event, not_enterprise },
+    { "IssueTypeAddedEventFragment", M.issue_type_added_event, not_enterprise },
+    { "IssueTypeRemovedEventFragment", M.issue_type_removed_event, not_enterprise },
+    { "IssueTypeChangedEventFragment", M.issue_type_changed_event, not_enterprise },
+    { "BlockedByAddedEventFragment", M.blocked_by_added_event, not_enterprise },
+    { "BlockedByRemovedEventFragment", M.blocked_by_removed_event, not_enterprise },
+    { "BlockingAddedEventFragment", M.blocking_added_event, not_enterprise },
+    { "BlockingRemovedEventFragment", M.blocking_removed_event, not_enterprise },
+    { "TransferredEventFragment", M.transferred_event, not_enterprise },
+    -- Projects V2: gated on config flag (may also require scope check; handled in gh/init.lua)
+    { "AddedToProjectV2EventFragment", M.added_to_project_v2_event, projects_v2_enabled },
+    { "RemovedFromProjectV2EventFragment", M.removed_from_project_v2_event, projects_v2_enabled },
+    { "ProjectV2ItemStatusChangedEventFragment", M.project_v2_item_status_changed_event, projects_v2_enabled },
+  }
+  for _, entry in ipairs(issue_builtin) do
+    M.register_issue_timeline_item(entry[1], entry[2], entry[3])
+  end
+  for _, entry in ipairs(issue_builtin) do
+    M.register_issue_timeline_item(entry[1], entry[2], entry[3])
+  end
+
+  -- Build the aggregator spreads string from the registry (includes any externally registered items).
+  -- Entries whose condition() returns false are excluded.
+  local issue_timeline_items_connection_fragments = "    __typename\n"
+  for spread_name, entry in pairs(M._issue_timeline_registry) do
+    if entry.condition == nil or entry.condition() then
+      issue_timeline_items_connection_fragments = issue_timeline_items_connection_fragments
+        .. "    ..."
+        .. spread_name
+        .. "\n"
+    end
   end
 
   ---@alias octo.IssueTimelineItem octo.fragments.AssignedEvent|octo.fragments.UnassignedEvent|octo.fragments.ClosedEvent|octo.fragments.ConnectedEvent|octo.fragments.ReferencedEvent|octo.fragments.CrossReferencedEvent|octo.fragments.DemilestonedEvent|octo.fragments.IssueComment|octo.fragments.LabeledEvent|octo.fragments.MilestonedEvent|octo.fragments.RenamedTitleEvent|octo.fragments.ReopenedEvent|octo.fragments.UnlabeledEvent|octo.fragments.PinnedEvent|octo.fragments.UnpinnedEvent|octo.fragments.SubIssueAddedEvent|octo.fragments.SubIssueRemovedEvent|octo.fragments.ParentIssueAddedEvent|octo.fragments.ParentIssueRemovedEvent|octo.fragments.IssueTypeAddedEvent|octo.fragments.IssueTypeRemovedEvent|octo.fragments.IssueTypeChangedEvent|octo.fragments.AddedToProjectV2Event|octo.fragments.ProjectV2ItemStatusChangedEvent|octo.fragments.RemovedFromProjectV2Event|octo.fragments.CommentDeletedEvent|octo.fragments.BlockedByAddedEvent|octo.fragments.BlockedByRemovedEvent|octo.fragments.BlockingAddedEvent|octo.fragments.BlockingRemovedEvent|octo.fragments.TransferredEvent|octo.fragments.LockedEvent|octo.fragments.UnlockedEvent|octo.fragments.MarkedAsDuplicateEvent|octo.fragments.UnmarkedAsDuplicateEvent
@@ -1261,51 +1385,63 @@ fragment IssueTimelineItemsConnectionFragment on IssueTimelineItemsConnection {
     issue_timeline_items_connection_fragments
   )
 
-  local pull_request_timeline_items_connection_fragments = [[
-    __typename
-    ...AutomaticBaseChangeSucceededEventFragment
-    ...BaseRefChangedEventFragment
-    ...AssignedEventFragment
-    ...UnassignedEventFragment
-    ...ClosedEventFragment
-    ...ConnectedEventFragment
-    ...ConvertToDraftEventFragment
-    ...CrossReferencedEventFragment
-    ...DemilestonedEventFragment
-    ...IssueCommentFragment
-    ...LabeledEventFragment
-    ...MergedEventFragment
-    ...MilestonedEventFragment
-    ...PullRequestCommitFragment
-    ...PullRequestReviewFragment
-    ...ReadyForReviewEventFragment
-    ...RenamedTitleEventFragment
-    ...ReopenedEventFragment
-    ...ReviewDismissedEventFragment
-    ...ReviewRequestRemovedEventFragment
-    ...ReviewRequestedEventFragment
-    ...UnlabeledEventFragment
-    ...DeployedEventFragment
-    ...HeadRefDeletedEventFragment
-    ...HeadRefRestoredEventFragment
-    ...HeadRefForcePushedEventFragment
-    ...AutoSquashEnabledEventFragment
-    ...AutoMergeEnabledEventFragment
-     ...AutoMergeDisabledEventFragment
-    ...CommentDeletedEventFragment
-    ...LockedEventFragment
-    ...UnlockedEventFragment
-    ...MarkedAsDuplicateEventFragment
-    ...UnmarkedAsDuplicateEventFragment
-]]
+  -- Seed the PR timeline registry with all built-in items.
+  local pr_builtin = {
+    -- Always available
+    { "AssignedEventFragment", M.assigned_event },
+    { "UnassignedEventFragment", M.unassigned_event },
+    { "ClosedEventFragment", M.closed_event },
+    { "ConnectedEventFragment", M.connected_event },
+    { "CrossReferencedEventFragment", M.cross_referenced_event },
+    { "DemilestonedEventFragment", M.demilestoned_event },
+    { "IssueCommentFragment", M.issue_comment },
+    { "LabeledEventFragment", M.labeled_event },
+    { "MergedEventFragment", M.merged_event },
+    { "MilestonedEventFragment", M.milestoned_event },
+    { "PullRequestCommitFragment", M.pull_request_commit },
+    { "PullRequestReviewFragment", M.pull_request_review },
+    { "ReadyForReviewEventFragment", M.ready_for_review_event },
+    { "RenamedTitleEventFragment", M.renamed_title_event },
+    { "ReopenedEventFragment", M.reopened_event },
+    { "ReviewDismissedEventFragment", M.review_dismissed_event },
+    { "ReviewRequestRemovedEventFragment", M.review_request_removed_event },
+    { "ReviewRequestedEventFragment", M.review_requested_event },
+    { "UnlabeledEventFragment", M.unlabeled_event },
+    { "CommentDeletedEventFragment", M.comment_deleted_event },
+    { "LockedEventFragment", M.locked_event },
+    { "UnlockedEventFragment", M.unlocked_event },
+    { "MarkedAsDuplicateEventFragment", M.marked_as_duplicate_event },
+    { "UnmarkedAsDuplicateEventFragment", M.unmarked_as_duplicate_event },
+    -- GHES-incompatible on older versions (issues #685, #513)
+    { "AutomaticBaseChangeSucceededEventFragment", M.automatic_base_change_succeeded_event, not_enterprise },
+    { "BaseRefChangedEventFragment", M.base_ref_changed_event, not_enterprise },
+    { "ConvertToDraftEventFragment", M.convert_to_draft_event, not_enterprise },
+    { "DeployedEventFragment", M.deployed_event, not_enterprise },
+    { "HeadRefDeletedEventFragment", M.head_ref_deleted_event, not_enterprise },
+    { "HeadRefRestoredEventFragment", M.head_ref_restored_event, not_enterprise },
+    { "HeadRefForcePushedEventFragment", M.head_ref_force_pushed_event, not_enterprise },
+    { "AutoSquashEnabledEventFragment", M.auto_squash_enabled_event, not_enterprise },
+    { "AutoMergeEnabledEventFragment", M.auto_merge_enabled_event, not_enterprise },
+    { "AutoMergeDisabledEventFragment", M.auto_merge_disabled_event, not_enterprise },
+    -- Projects V2
+    { "AddedToProjectV2EventFragment", M.added_to_project_v2_event, projects_v2_enabled },
+    { "RemovedFromProjectV2EventFragment", M.removed_from_project_v2_event, projects_v2_enabled },
+    { "ProjectV2ItemStatusChangedEventFragment", M.project_v2_item_status_changed_event, projects_v2_enabled },
+  }
+  for _, entry in ipairs(pr_builtin) do
+    M.register_pull_request_timeline_item(entry[1], entry[2], entry[3])
+  end
 
-  if config.values.default_to_projects_v2 then
-    pull_request_timeline_items_connection_fragments = pull_request_timeline_items_connection_fragments
-      .. [[
-    ...AddedToProjectV2EventFragment
-    ...RemovedFromProjectV2EventFragment
-    ...ProjectV2ItemStatusChangedEventFragment
-    ]]
+  -- Build the aggregator spreads string from the registry (includes any externally registered items).
+  -- Entries whose condition() returns false are excluded.
+  local pull_request_timeline_items_connection_fragments = "    __typename\n"
+  for spread_name, entry in pairs(M._pr_timeline_registry) do
+    if entry.condition == nil or entry.condition() then
+      pull_request_timeline_items_connection_fragments = pull_request_timeline_items_connection_fragments
+        .. "    ..."
+        .. spread_name
+        .. "\n"
+    end
   end
 
   ---@alias octo.PullRequestTimelineItem octo.fragments.AssignedEvent|octo.fragments.UnassignedEvent|octo.fragments.AutomaticBaseChangeSucceededEvent|octo.fragments.BaseRefChangedEvent|octo.fragments.ClosedEvent|octo.fragments.ConnectedEvent|octo.fragments.ConvertToDraftEvent|octo.fragments.CrossReferencedEvent|octo.fragments.DemilestonedEvent|octo.fragments.IssueComment|octo.fragments.LabeledEvent|octo.fragments.MergedEvent|octo.fragments.MilestonedEvent|octo.fragments.PullRequestCommit|octo.fragments.PullRequestReview|octo.fragments.ReadyForReviewEvent|octo.fragments.RenamedTitleEvent|octo.fragments.ReopenedEvent|octo.fragments.ReviewDismissedEvent|octo.fragments.ReviewRequestRemovedEvent|octo.fragments.ReviewRequestedEvent|octo.fragments.UnlabeledEvent|octo.fragments.DeployedEvent|octo.fragments.HeadRefDeletedEvent|octo.fragments.HeadRefRestoredEvent|octo.fragments.HeadRefForcePushedEvent|octo.fragments.AutoSquashEnabledEvent|octo.fragments.AutoMergeEnabledEvent|octo.fragments.AutoMergeDisabledEvent|octo.fragments.AddedToProjectV2Event|octo.fragments.RemovedFromProjectV2Event|octo.fragments.ProjectV2ItemStatusChangedEvent|octo.fragments.LockedEvent|octo.fragments.UnlockedEvent|octo.fragments.MarkedAsDuplicateEvent|octo.fragments.UnmarkedAsDuplicateEvent

--- a/lua/octo/gh/fragments.lua
+++ b/lua/octo/gh/fragments.lua
@@ -89,6 +89,34 @@ function M.get_pr_timeline_definitions()
   return result
 end
 
+---@param register_fn fun(spread_name: string, definition: string, condition?: fun():boolean)
+---@param entries table[]
+local function register_timeline_entries(register_fn, entries)
+  for _, entry in ipairs(entries) do
+    register_fn(entry[1], entry[2], entry[3])
+  end
+end
+
+---@param registry table<string, octo.TimelineFragmentEntry>
+---@return string
+local function build_timeline_connection_spreads(registry)
+  local spreads = { "    __typename" }
+  local active_spreads = {}
+
+  for spread_name, entry in pairs(registry) do
+    if entry.condition == nil or entry.condition() then
+      active_spreads[#active_spreads + 1] = spread_name
+    end
+  end
+
+  table.sort(active_spreads)
+  for _, spread_name in ipairs(active_spreads) do
+    spreads[#spreads + 1] = "    ..." .. spread_name
+  end
+
+  return table.concat(spreads, "\n") .. "\n"
+end
+
 M.setup = function()
   ---@class octo.fragments.ProjectsV2Connection
   ---@field nodes {
@@ -1296,14 +1324,9 @@ fragment CommentDeletedEventFragment on CommentDeletedEvent {
   --   nil  → always included
   --   fn() → included only when fn() returns true
   --
-  -- Fragments that reference types absent from older GHES versions are gated on
-  -- `not is_enterprise`, where enterprise is defined as github_hostname being non-empty.
-  local function is_enterprise()
-    return config.values.github_hostname ~= ""
-  end
-
-  local function not_enterprise()
-    return not is_enterprise()
+  -- Fragments absent from older GHES versions are gated to github.com only.
+  local function is_github_com()
+    return config.values.github_hostname == ""
   end
 
   local function projects_v2_enabled()
@@ -1331,43 +1354,30 @@ fragment CommentDeletedEventFragment on CommentDeletedEvent {
     { "MarkedAsDuplicateEventFragment", M.marked_as_duplicate_event },
     { "UnmarkedAsDuplicateEventFragment", M.unmarked_as_duplicate_event },
     -- github.com-only: not present on older GHES (issues #1153)
-    { "PinnedEventFragment", M.pinned_event, not_enterprise },
-    { "UnpinnedEventFragment", M.unpinned_event, not_enterprise },
-    { "SubIssueAddedEventFragment", M.subissue_added_event, not_enterprise },
-    { "SubIssueRemovedEventFragment", M.subissue_removed_event, not_enterprise },
-    { "ParentIssueAddedEventFragment", M.parent_issue_added_event, not_enterprise },
-    { "ParentIssueRemovedEventFragment", M.parent_issue_removed_event, not_enterprise },
-    { "IssueTypeAddedEventFragment", M.issue_type_added_event, not_enterprise },
-    { "IssueTypeRemovedEventFragment", M.issue_type_removed_event, not_enterprise },
-    { "IssueTypeChangedEventFragment", M.issue_type_changed_event, not_enterprise },
-    { "BlockedByAddedEventFragment", M.blocked_by_added_event, not_enterprise },
-    { "BlockedByRemovedEventFragment", M.blocked_by_removed_event, not_enterprise },
-    { "BlockingAddedEventFragment", M.blocking_added_event, not_enterprise },
-    { "BlockingRemovedEventFragment", M.blocking_removed_event, not_enterprise },
-    { "TransferredEventFragment", M.transferred_event, not_enterprise },
+    { "PinnedEventFragment", M.pinned_event, is_github_com },
+    { "UnpinnedEventFragment", M.unpinned_event, is_github_com },
+    { "SubIssueAddedEventFragment", M.subissue_added_event, is_github_com },
+    { "SubIssueRemovedEventFragment", M.subissue_removed_event, is_github_com },
+    { "ParentIssueAddedEventFragment", M.parent_issue_added_event, is_github_com },
+    { "ParentIssueRemovedEventFragment", M.parent_issue_removed_event, is_github_com },
+    { "IssueTypeAddedEventFragment", M.issue_type_added_event, is_github_com },
+    { "IssueTypeRemovedEventFragment", M.issue_type_removed_event, is_github_com },
+    { "IssueTypeChangedEventFragment", M.issue_type_changed_event, is_github_com },
+    { "BlockedByAddedEventFragment", M.blocked_by_added_event, is_github_com },
+    { "BlockedByRemovedEventFragment", M.blocked_by_removed_event, is_github_com },
+    { "BlockingAddedEventFragment", M.blocking_added_event, is_github_com },
+    { "BlockingRemovedEventFragment", M.blocking_removed_event, is_github_com },
+    { "TransferredEventFragment", M.transferred_event, is_github_com },
     -- Projects V2: gated on config flag (may also require scope check; handled in gh/init.lua)
     { "AddedToProjectV2EventFragment", M.added_to_project_v2_event, projects_v2_enabled },
     { "RemovedFromProjectV2EventFragment", M.removed_from_project_v2_event, projects_v2_enabled },
     { "ProjectV2ItemStatusChangedEventFragment", M.project_v2_item_status_changed_event, projects_v2_enabled },
   }
-  for _, entry in ipairs(issue_builtin) do
-    M.register_issue_timeline_item(entry[1], entry[2], entry[3])
-  end
-  for _, entry in ipairs(issue_builtin) do
-    M.register_issue_timeline_item(entry[1], entry[2], entry[3])
-  end
+  register_timeline_entries(M.register_issue_timeline_item, issue_builtin)
 
   -- Build the aggregator spreads string from the registry (includes any externally registered items).
   -- Entries whose condition() returns false are excluded.
-  local issue_timeline_items_connection_fragments = "    __typename\n"
-  for spread_name, entry in pairs(M._issue_timeline_registry) do
-    if entry.condition == nil or entry.condition() then
-      issue_timeline_items_connection_fragments = issue_timeline_items_connection_fragments
-        .. "    ..."
-        .. spread_name
-        .. "\n"
-    end
-  end
+  local issue_timeline_items_connection_fragments = build_timeline_connection_spreads(M._issue_timeline_registry)
 
   ---@alias octo.IssueTimelineItem octo.fragments.AssignedEvent|octo.fragments.UnassignedEvent|octo.fragments.ClosedEvent|octo.fragments.ConnectedEvent|octo.fragments.ReferencedEvent|octo.fragments.CrossReferencedEvent|octo.fragments.DemilestonedEvent|octo.fragments.IssueComment|octo.fragments.LabeledEvent|octo.fragments.MilestonedEvent|octo.fragments.RenamedTitleEvent|octo.fragments.ReopenedEvent|octo.fragments.UnlabeledEvent|octo.fragments.PinnedEvent|octo.fragments.UnpinnedEvent|octo.fragments.SubIssueAddedEvent|octo.fragments.SubIssueRemovedEvent|octo.fragments.ParentIssueAddedEvent|octo.fragments.ParentIssueRemovedEvent|octo.fragments.IssueTypeAddedEvent|octo.fragments.IssueTypeRemovedEvent|octo.fragments.IssueTypeChangedEvent|octo.fragments.AddedToProjectV2Event|octo.fragments.ProjectV2ItemStatusChangedEvent|octo.fragments.RemovedFromProjectV2Event|octo.fragments.CommentDeletedEvent|octo.fragments.BlockedByAddedEvent|octo.fragments.BlockedByRemovedEvent|octo.fragments.BlockingAddedEvent|octo.fragments.BlockingRemovedEvent|octo.fragments.TransferredEvent|octo.fragments.LockedEvent|octo.fragments.UnlockedEvent|octo.fragments.MarkedAsDuplicateEvent|octo.fragments.UnmarkedAsDuplicateEvent
 
@@ -1413,36 +1423,26 @@ fragment IssueTimelineItemsConnectionFragment on IssueTimelineItemsConnection {
     { "MarkedAsDuplicateEventFragment", M.marked_as_duplicate_event },
     { "UnmarkedAsDuplicateEventFragment", M.unmarked_as_duplicate_event },
     -- GHES-incompatible on older versions (issues #685, #513)
-    { "AutomaticBaseChangeSucceededEventFragment", M.automatic_base_change_succeeded_event, not_enterprise },
-    { "BaseRefChangedEventFragment", M.base_ref_changed_event, not_enterprise },
-    { "ConvertToDraftEventFragment", M.convert_to_draft_event, not_enterprise },
-    { "DeployedEventFragment", M.deployed_event, not_enterprise },
-    { "HeadRefDeletedEventFragment", M.head_ref_deleted_event, not_enterprise },
-    { "HeadRefRestoredEventFragment", M.head_ref_restored_event, not_enterprise },
-    { "HeadRefForcePushedEventFragment", M.head_ref_force_pushed_event, not_enterprise },
-    { "AutoSquashEnabledEventFragment", M.auto_squash_enabled_event, not_enterprise },
-    { "AutoMergeEnabledEventFragment", M.auto_merge_enabled_event, not_enterprise },
-    { "AutoMergeDisabledEventFragment", M.auto_merge_disabled_event, not_enterprise },
+    { "AutomaticBaseChangeSucceededEventFragment", M.automatic_base_change_succeeded_event, is_github_com },
+    { "BaseRefChangedEventFragment", M.base_ref_changed_event, is_github_com },
+    { "ConvertToDraftEventFragment", M.convert_to_draft_event, is_github_com },
+    { "DeployedEventFragment", M.deployed_event, is_github_com },
+    { "HeadRefDeletedEventFragment", M.head_ref_deleted_event, is_github_com },
+    { "HeadRefRestoredEventFragment", M.head_ref_restored_event, is_github_com },
+    { "HeadRefForcePushedEventFragment", M.head_ref_force_pushed_event, is_github_com },
+    { "AutoSquashEnabledEventFragment", M.auto_squash_enabled_event, is_github_com },
+    { "AutoMergeEnabledEventFragment", M.auto_merge_enabled_event, is_github_com },
+    { "AutoMergeDisabledEventFragment", M.auto_merge_disabled_event, is_github_com },
     -- Projects V2
     { "AddedToProjectV2EventFragment", M.added_to_project_v2_event, projects_v2_enabled },
     { "RemovedFromProjectV2EventFragment", M.removed_from_project_v2_event, projects_v2_enabled },
     { "ProjectV2ItemStatusChangedEventFragment", M.project_v2_item_status_changed_event, projects_v2_enabled },
   }
-  for _, entry in ipairs(pr_builtin) do
-    M.register_pull_request_timeline_item(entry[1], entry[2], entry[3])
-  end
+  register_timeline_entries(M.register_pull_request_timeline_item, pr_builtin)
 
   -- Build the aggregator spreads string from the registry (includes any externally registered items).
   -- Entries whose condition() returns false are excluded.
-  local pull_request_timeline_items_connection_fragments = "    __typename\n"
-  for spread_name, entry in pairs(M._pr_timeline_registry) do
-    if entry.condition == nil or entry.condition() then
-      pull_request_timeline_items_connection_fragments = pull_request_timeline_items_connection_fragments
-        .. "    ..."
-        .. spread_name
-        .. "\n"
-    end
-  end
+  local pull_request_timeline_items_connection_fragments = build_timeline_connection_spreads(M._pr_timeline_registry)
 
   ---@alias octo.PullRequestTimelineItem octo.fragments.AssignedEvent|octo.fragments.UnassignedEvent|octo.fragments.AutomaticBaseChangeSucceededEvent|octo.fragments.BaseRefChangedEvent|octo.fragments.ClosedEvent|octo.fragments.ConnectedEvent|octo.fragments.ConvertToDraftEvent|octo.fragments.CrossReferencedEvent|octo.fragments.DemilestonedEvent|octo.fragments.IssueComment|octo.fragments.LabeledEvent|octo.fragments.MergedEvent|octo.fragments.MilestonedEvent|octo.fragments.PullRequestCommit|octo.fragments.PullRequestReview|octo.fragments.ReadyForReviewEvent|octo.fragments.RenamedTitleEvent|octo.fragments.ReopenedEvent|octo.fragments.ReviewDismissedEvent|octo.fragments.ReviewRequestRemovedEvent|octo.fragments.ReviewRequestedEvent|octo.fragments.UnlabeledEvent|octo.fragments.DeployedEvent|octo.fragments.HeadRefDeletedEvent|octo.fragments.HeadRefRestoredEvent|octo.fragments.HeadRefForcePushedEvent|octo.fragments.AutoSquashEnabledEvent|octo.fragments.AutoMergeEnabledEvent|octo.fragments.AutoMergeDisabledEvent|octo.fragments.AddedToProjectV2Event|octo.fragments.RemovedFromProjectV2Event|octo.fragments.ProjectV2ItemStatusChangedEvent|octo.fragments.LockedEvent|octo.fragments.UnlockedEvent|octo.fragments.MarkedAsDuplicateEvent|octo.fragments.UnmarkedAsDuplicateEvent
 

--- a/lua/octo/gh/fragments.lua
+++ b/lua/octo/gh/fragments.lua
@@ -100,7 +100,9 @@ end
 ---@param registry table<string, octo.TimelineFragmentEntry>
 ---@return string
 local function build_timeline_connection_spreads(registry)
+  ---@type string[]
   local spreads = { "    __typename" }
+  ---@type string[]
   local active_spreads = {}
 
   for spread_name, entry in pairs(registry) do

--- a/lua/octo/gh/mutations.lua
+++ b/lua/octo/gh/mutations.lua
@@ -662,14 +662,7 @@ mutation($input: CreateIssueInput!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.unassigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.renamed_title_event .. fragments.issue_information .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event .. fragments.comment_deleted_event .. fragments.blocked_by_added_event .. fragments.blocked_by_removed_event .. fragments.blocking_added_event .. fragments.blocking_removed_event .. fragments.transferred_event .. fragments.locked_event .. fragments.unlocked_event .. fragments.marked_as_duplicate_event .. fragments.unmarked_as_duplicate_event
-
-  if config.values.default_to_projects_v2 then
-    M.create_issue = M.create_issue
-      .. fragments.added_to_project_v2_event
-      .. fragments.project_v2_item_status_changed_event
-      .. fragments.removed_from_project_v2_event
-  end
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
 
   M.close_issue = [[
 mutation($issueId: ID!, $stateReason: IssueCloseReason) {
@@ -706,14 +699,7 @@ mutation($issueId: ID!, $stateReason: IssueCloseReason) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.label_connection .. fragments.label .. fragments.reaction_groups .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.unassigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.renamed_title_event .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event .. fragments.comment_deleted_event .. fragments.blocked_by_added_event .. fragments.blocked_by_removed_event .. fragments.blocking_added_event .. fragments.blocking_removed_event .. fragments.transferred_event .. fragments.locked_event .. fragments.unlocked_event .. fragments.marked_as_duplicate_event .. fragments.unmarked_as_duplicate_event
-
-  if config.values.default_to_projects_v2 then
-    M.close_issue = M.close_issue
-      .. fragments.added_to_project_v2_event
-      .. fragments.project_v2_item_status_changed_event
-      .. fragments.removed_from_project_v2_event
-  end
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.label_connection .. fragments.label .. fragments.reaction_groups .. fragments.assignee_connection .. fragments.issue_comment .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
 
   -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#updateissue
   M.update_issue_state = [[
@@ -751,14 +737,7 @@ mutation($id: ID!, $state: IssueState!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.unassigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.renamed_title_event .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event .. fragments.comment_deleted_event .. fragments.blocked_by_added_event .. fragments.blocked_by_removed_event .. fragments.blocking_added_event .. fragments.blocking_removed_event .. fragments.transferred_event .. fragments.locked_event .. fragments.unlocked_event .. fragments.marked_as_duplicate_event .. fragments.unmarked_as_duplicate_event
-
-  if config.values.default_to_projects_v2 then
-    M.update_issue_state = M.update_issue_state
-      .. fragments.added_to_project_v2_event
-      .. fragments.project_v2_item_status_changed_event
-      .. fragments.removed_from_project_v2_event
-  end
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
 
   -- https://docs.github.com/en/graphql/reference/mutations#reopenissue
   M.reopen_issue = [[
@@ -798,14 +777,7 @@ mutation($issueId: ID!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.unassigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.renamed_title_event .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event .. fragments.comment_deleted_event .. fragments.blocked_by_added_event .. fragments.blocked_by_removed_event .. fragments.blocking_added_event .. fragments.blocking_removed_event .. fragments.transferred_event .. fragments.locked_event .. fragments.unlocked_event .. fragments.marked_as_duplicate_event .. fragments.unmarked_as_duplicate_event
-
-  if config.values.default_to_projects_v2 then
-    M.reopen_issue = M.reopen_issue
-      .. fragments.added_to_project_v2_event
-      .. fragments.project_v2_item_status_changed_event
-      .. fragments.removed_from_project_v2_event
-  end
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
 
   ---@class octo.mutations.UpdatePullRequest
   ---@field data {
@@ -931,14 +903,7 @@ mutation($pullRequestId: ID!, $state: PullRequestUpdateState!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.unassigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.ready_for_review_event .. fragments.reopened_event .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.merged_event .. fragments.review_requested_event .. fragments.renamed_title_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.deployed_event .. fragments.head_ref_deleted_event .. fragments.head_ref_restored_event .. fragments.head_ref_force_pushed_event .. fragments.auto_squash_enabled_event .. fragments.auto_merge_enabled_event .. fragments.auto_merge_disabled_event .. fragments.automatic_base_change_succeeded_event .. fragments.base_ref_changed_event .. fragments.comment_deleted_event .. fragments.locked_event .. fragments.unlocked_event .. fragments.marked_as_duplicate_event .. fragments.unmarked_as_duplicate_event
-
-  if config.values.default_to_projects_v2 then
-    M.update_pull_request_state = M.update_pull_request_state
-      .. fragments.added_to_project_v2_event
-      .. fragments.removed_from_project_v2_event
-      .. fragments.project_v2_item_status_changed_event
-  end
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.merged_event .. fragments.review_requested_event .. fragments.renamed_title_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.get_pr_timeline_definitions()
 
   M.create_discussion = [[
 mutation($repo_id: ID!, $category_id: ID!, $title: String!, $body: String!) {
@@ -1220,14 +1185,7 @@ mutation($input: CreatePullRequestInput!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.unassigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.ready_for_review_event .. fragments.reopened_event .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.review_requested_event .. fragments.merged_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.renamed_title_event .. fragments.deployed_event .. fragments.head_ref_deleted_event .. fragments.head_ref_restored_event .. fragments.head_ref_force_pushed_event .. fragments.auto_squash_enabled_event .. fragments.auto_merge_enabled_event .. fragments.auto_merge_disabled_event .. fragments.automatic_base_change_succeeded_event .. fragments.base_ref_changed_event .. fragments.comment_deleted_event .. fragments.locked_event .. fragments.unlocked_event .. fragments.marked_as_duplicate_event .. fragments.unmarked_as_duplicate_event
-
-  if config.values.default_to_projects_v2 then
-    M.create_pr = M.create_pr
-      .. fragments.added_to_project_v2_event
-      .. fragments.removed_from_project_v2_event
-      .. fragments.project_v2_item_status_changed_event
-  end
+]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.review_requested_event .. fragments.merged_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.get_pr_timeline_definitions()
 
   M.mark_answer = [[
 mutation($id: ID!) {

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -277,14 +277,7 @@ query($endCursor: String) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.unassigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.ready_for_review_event .. fragments.reopened_event .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.review_requested_event .. fragments.merged_event .. fragments.renamed_title_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.deployed_event .. fragments.head_ref_deleted_event .. fragments.head_ref_restored_event .. fragments.head_ref_force_pushed_event .. fragments.auto_squash_enabled_event .. fragments.auto_merge_enabled_event .. fragments.auto_merge_disabled_event .. fragments.automatic_base_change_succeeded_event .. fragments.base_ref_changed_event .. fragments.comment_deleted_event .. fragments.locked_event .. fragments.unlocked_event .. fragments.marked_as_duplicate_event .. fragments.unmarked_as_duplicate_event
-
-  if config.values.default_to_projects_v2 then
-    M.pull_request = M.pull_request
-      .. fragments.added_to_project_v2_event
-      .. fragments.removed_from_project_v2_event
-      .. fragments.project_v2_item_status_changed_event
-  end
+]] .. fragments.issue .. fragments.pull_request .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.get_pr_timeline_definitions()
 
   ---@class octo.IssueTimelineItemConnection : octo.fragments.IssueTimelineItemsConnection
   --- @field pageInfo octo.PageInfo
@@ -339,14 +332,7 @@ query($endCursor: String) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label .. fragments.label_connection .. fragments.assignee_connection .. fragments.issue_comment .. fragments.assigned_event .. fragments.unassigned_event .. fragments.labeled_event .. fragments.unlabeled_event .. fragments.closed_event .. fragments.reopened_event .. fragments.renamed_title_event .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.referenced_event .. fragments.pinned_event .. fragments.unpinned_event .. fragments.subissue_added_event .. fragments.subissue_removed_event .. fragments.parent_issue_added_event .. fragments.parent_issue_removed_event .. fragments.issue_type_added_event .. fragments.issue_type_removed_event .. fragments.issue_type_changed_event .. fragments.comment_deleted_event .. fragments.blocked_by_added_event .. fragments.blocked_by_removed_event .. fragments.blocking_added_event .. fragments.blocking_removed_event .. fragments.transferred_event .. fragments.locked_event .. fragments.unlocked_event .. fragments.marked_as_duplicate_event .. fragments.unmarked_as_duplicate_event
-
-  if config.values.default_to_projects_v2 then
-    M.issue = M.issue
-      .. fragments.added_to_project_v2_event
-      .. fragments.removed_from_project_v2_event
-      .. fragments.project_v2_item_status_changed_event
-  end
+]] .. fragments.issue .. fragments.pull_request .. fragments.reaction_groups .. fragments.label .. fragments.label_connection .. fragments.assignee_connection .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
 
   ---@class octo.queries.IssueKind
   ---@field data {

--- a/lua/octo/gh/timeline_registry.lua
+++ b/lua/octo/gh/timeline_registry.lua
@@ -1,0 +1,40 @@
+--- Timeline writer registry.
+---
+--- Maps GraphQL __typename values to their rendering behaviour.
+--- Populated at startup from writers.lua after all write_* functions are defined.
+---
+--- Entry shape:
+---   writer  fun(bufnr: integer, item: table)  Direct-dispatch writer. Mutually exclusive with `batch`.
+---   batch   string                             Name of the local accumulator table in write_timeline_items.
+---                                              Mutually exclusive with `writer`.
+---
+--- Special typenames that receive custom handling in write_timeline_items and are NOT in this
+--- registry: "IssueComment", "PullRequestReview".
+
+---@class octo.TimelineWriterEntry
+---@field writer? fun(bufnr: integer, item: table)
+---@field batch?  string
+
+local M = {}
+
+---@type table<string, octo.TimelineWriterEntry>
+M._registry = {}
+
+--- Register a typename → writer/batch mapping.
+--- Safe to call multiple times; later registrations are ignored (dedup by typename).
+---@param typename string            GraphQL __typename, e.g. "MergedEvent"
+---@param entry    octo.TimelineWriterEntry
+function M.register(typename, entry)
+  if M._registry[typename] == nil then
+    M._registry[typename] = entry
+  end
+end
+
+--- Look up an entry by typename.
+---@param typename string
+---@return octo.TimelineWriterEntry?
+function M.get(typename)
+  return M._registry[typename]
+end
+
+return M

--- a/lua/octo/gh/timeline_registry.lua
+++ b/lua/octo/gh/timeline_registry.lua
@@ -14,6 +14,7 @@
 ---@class octo.TimelineWriterEntry
 ---@field writer? fun(bufnr: integer, item: table)
 ---@field batch?  string
+---@field sets_prev_event? boolean
 
 local M = {}
 

--- a/lua/octo/gh/timeline_registry.lua
+++ b/lua/octo/gh/timeline_registry.lua
@@ -11,9 +11,19 @@
 --- Special typenames that receive custom handling in write_timeline_items and are NOT in this
 --- registry: "IssueComment", "PullRequestReview".
 
+---@alias octo.TimelineBatchKey
+---| "assignment_events"
+---| "label_events"
+---| "pull_request_commits"
+---| "force_pushed_events"
+---| "review_requested_events"
+---| "review_request_removed_events"
+---| "subissue_added_events"
+---| "subissue_removed_events"
+
 ---@class octo.TimelineWriterEntry
 ---@field writer? fun(bufnr: integer, item: table)
----@field batch?  string
+---@field batch? octo.TimelineBatchKey
 ---@field sets_prev_event? boolean
 
 local M = {}

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -3552,28 +3552,36 @@ function M.write_timeline_items(bufnr, obj)
   table.insert(timeline_nodes, {})
 
   ---@param item? octo.PullRequestTimelineItem|octo.IssueTimelineItem
+  ---@param items table
+  local function clear_items(items)
+    for idx = #items, 1, -1 do
+      items[idx] = nil
+    end
+  end
+
+  ---@param item? octo.PullRequestTimelineItem|octo.IssueTimelineItem
   local function render_accumulated_events(item)
     if
       #unrendered_label_events > 0
       and (not item or (item.__typename ~= "LabeledEvent" and item.__typename ~= "UnlabeledEvent"))
     then
       M.write_label_events(bufnr, unrendered_label_events)
-      unrendered_label_events = {}
+      clear_items(unrendered_label_events)
       prev_is_event = true
     end
     if (not item or item.__typename ~= "SubIssueAddedEvent") and #unrendered_subissue_added_events > 0 then
       M.write_subissue_events(bufnr, unrendered_subissue_added_events, "added")
-      unrendered_subissue_added_events = {}
+      clear_items(unrendered_subissue_added_events)
       prev_is_event = true
     end
     if (not item or item.__typename ~= "SubIssueRemovedEvent") and #unrendered_subissue_removed_events > 0 then
       M.write_subissue_events(bufnr, unrendered_subissue_removed_events, "removed")
-      unrendered_subissue_removed_events = {}
+      clear_items(unrendered_subissue_removed_events)
       prev_is_event = true
     end
     if (not item or item.__typename ~= "PullRequestCommit") and #commits > 0 then
       M.write_commits(bufnr, commits)
-      commits = {}
+      clear_items(commits)
       prev_is_event = true
     end
     if
@@ -3585,12 +3593,12 @@ function M.write_timeline_items(bufnr, obj)
       )
     then
       M.write_head_ref_force_pushed_events(bufnr, unrendered_force_push_events)
-      unrendered_force_push_events = {}
+      clear_items(unrendered_force_push_events)
       prev_is_event = true
     end
     if #unrendered_review_requested_events > 0 and (not item or item.__typename ~= "ReviewRequestedEvent") then
       M.write_review_requested_events(bufnr, unrendered_review_requested_events)
-      unrendered_review_requested_events = {}
+      clear_items(unrendered_review_requested_events)
       prev_is_event = true
     end
     if
@@ -3598,7 +3606,7 @@ function M.write_timeline_items(bufnr, obj)
       and (not item or item.__typename ~= "ReviewRequestRemovedEvent")
     then
       M.write_review_request_removed_events(bufnr, unrendered_review_request_removed_events)
-      unrendered_review_request_removed_events = {}
+      clear_items(unrendered_review_request_removed_events)
       prev_is_event = true
     end
     if
@@ -3606,7 +3614,7 @@ function M.write_timeline_items(bufnr, obj)
       and (not item or (item.__typename ~= "AssignedEvent" and item.__typename ~= "UnassignedEvent"))
     then
       M.write_assignment_events(bufnr, unrendered_assignment_events)
-      unrendered_assignment_events = {}
+      clear_items(unrendered_assignment_events)
       prev_is_event = true
     end
   end

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -10,6 +10,7 @@ local folds = require "octo.folds"
 local bubbles = require "octo.ui.bubbles"
 local notify = require "octo.notify"
 local TextChunkBuilder = require "octo.ui.text-chunk-builder"
+local timeline_registry = require "octo.gh.timeline_registry"
 local vim = vim
 
 local M = {}
@@ -3610,6 +3611,25 @@ function M.write_timeline_items(bufnr, obj)
     end
   end
 
+  -- Accumulator tables, keyed by registry `batch` name.
+  local accumulators = {
+    assignment = unrendered_assignment_events,
+    label = unrendered_label_events,
+    commits = commits,
+    force_push = unrendered_force_push_events,
+    review_requested = unrendered_review_requested_events,
+    review_request_removed = unrendered_review_request_removed_events,
+    subissue_added = unrendered_subissue_added_events,
+    subissue_removed = unrendered_subissue_removed_events,
+  }
+
+  -- Batched typenames that mark prev_is_event when an item is accumulated.
+  local batch_sets_prev_event = {
+    commits = true,
+    review_requested = true,
+    review_request_removed = true,
+  }
+
   for _, item in ipairs(timeline_nodes) do
     render_accumulated_events(item)
     if item.__typename == "IssueComment" then
@@ -3652,157 +3672,31 @@ function M.write_timeline_items(bufnr, obj)
         M.write_review_decision(bufnr, item)
       end
       prev_is_event = false
-    elseif item.__typename == "AssignedEvent" then
-      table.insert(unrendered_assignment_events, item)
-    elseif item.__typename == "UnassignedEvent" then
-      table.insert(unrendered_assignment_events, item)
-    elseif item.__typename == "PullRequestCommit" then
-      table.insert(commits, item)
-      prev_is_event = true
-    elseif item.__typename == "MergedEvent" then
-      M.write_merged_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "ClosedEvent" then
-      M.write_closed_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "ReopenedEvent" then
-      M.write_reopened_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "LabeledEvent" then
-      table.insert(unrendered_label_events, item)
-    elseif item.__typename == "UnlabeledEvent" then
-      table.insert(unrendered_label_events, item)
-    elseif item.__typename == "ReviewRequestedEvent" then
-      unrendered_review_requested_events[#unrendered_review_requested_events + 1] = item
-      prev_is_event = true
-    elseif item.__typename == "ReviewRequestRemovedEvent" then
-      unrendered_review_request_removed_events[#unrendered_review_request_removed_events + 1] = item
-      prev_is_event = true
-    elseif item.__typename == "ReviewDismissedEvent" then
-      M.write_review_dismissed_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "RenamedTitleEvent" then
-      M.write_renamed_title_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "ConnectedEvent" then
-      M.write_connected_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "CrossReferencedEvent" then
-      M.write_cross_referenced_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "ReferencedEvent" then
-      M.write_referenced_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "MilestonedEvent" then
-      M.write_milestoned_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "DemilestonedEvent" then
-      M.write_demilestoned_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "PinnedEvent" then
-      M.write_pinned_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "UnpinnedEvent" then
-      M.write_unpinned_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "LockedEvent" then
-      M.write_locked_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "UnlockedEvent" then
-      M.write_unlocked_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "SubIssueAddedEvent" then
-      table.insert(unrendered_subissue_added_events, item)
-    elseif item.__typename == "SubIssueRemovedEvent" then
-      table.insert(unrendered_subissue_removed_events, item)
-    elseif item.__typename == "ParentIssueAddedEvent" then
-      M.write_parent_issue_added_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "ParentIssueRemovedEvent" then
-      M.write_parent_issue_removed_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "IssueTypeAddedEvent" then
-      M.write_issue_type_added_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "IssueTypeRemovedEvent" then
-      M.write_issue_type_removed_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "IssueTypeChangedEvent" then
-      M.write_issue_type_changed_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "ConvertToDraftEvent" then
-      M.write_convert_to_draft_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "ReadyForReviewEvent" then
-      M.write_ready_for_review_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "DeployedEvent" then
-      M.write_deployed_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "HeadRefDeletedEvent" then
-      M.write_head_ref_deleted_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "HeadRefRestoredEvent" then
-      M.write_head_ref_restored_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "HeadRefForcePushedEvent" then
-      table.insert(unrendered_force_push_events, item)
-    elseif item.__typename == "AutoSquashEnabledEvent" then
-      M.write_auto_squash_enabled_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "AutoMergeEnabledEvent" then
-      M.write_auto_merge_enabled_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "AutoMergeDisabledEvent" then
-      M.write_auto_merge_disabled_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "AddedToProjectV2Event" then
-      M.write_added_to_project_v2_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "RemovedFromProjectV2Event" then
-      M.write_removed_from_project_v2_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "ProjectV2ItemStatusChangedEvent" then
-      M.write_project_v2_item_status_changed_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "AutomaticBaseChangeSucceededEvent" then
-      M.write_automatic_base_change_succeeded_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "BaseRefChangedEvent" then
-      M.write_base_ref_changed_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "CommentDeletedEvent" then
-      M.write_comment_deleted_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "BlockingAddedEvent" then
-      M.write_blocking_added_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "BlockingRemovedEvent" then
-      M.write_blocking_removed_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "BlockedByAddedEvent" then
-      M.write_blocked_by_added_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "BlockedByRemovedEvent" then
-      M.write_blocked_by_removed_event(bufnr, item)
-    elseif item.__typename == "MarkedAsDuplicateEvent" then
-      M.write_marked_as_duplicate_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "UnmarkedAsDuplicateEvent" then
-      M.write_unmarked_as_duplicate_event(bufnr, item)
-      prev_is_event = true
-    elseif item.__typename == "TransferredEvent" then
-      M.write_transferred_event(bufnr, item)
-      prev_is_event = true
-    elseif
-      not utils.is_blank(item)
-      and config.values.debug.notify_missing_timeline_items
-      ---@diagnostic disable-next-line
-      and is_rendering_event(item.__typename)
-    then
-      ---@diagnostic disable-next-line
-      local info = item.__typename and item.__typename or vim.inspect(item)
-      utils.info("Unhandled timeline item: " .. info)
+    else
+      local entry = timeline_registry.get(item.__typename)
+      if entry then
+        if entry.writer then
+          entry.writer(bufnr, item)
+          -- BlockedByRemovedEvent intentionally does NOT set prev_is_event.
+          if item.__typename ~= "BlockedByRemovedEvent" then
+            prev_is_event = true
+          end
+        elseif entry.batch then
+          table.insert(accumulators[entry.batch], item)
+          if batch_sets_prev_event[entry.batch] then
+            prev_is_event = true
+          end
+        end
+      elseif
+        not utils.is_blank(item)
+        and config.values.debug.notify_missing_timeline_items
+        ---@diagnostic disable-next-line
+        and is_rendering_event(item.__typename)
+      then
+        ---@diagnostic disable-next-line
+        local info = item.__typename and item.__typename or vim.inspect(item)
+        utils.info("Unhandled timeline item: " .. info)
+      end
     end
   end
   render_accumulated_events()
@@ -3810,6 +3704,67 @@ function M.write_timeline_items(bufnr, obj)
   if prev_is_event then
     M.write_block(bufnr, { "" })
   end
+end
+
+-- ---------------------------------------------------------------------------
+-- Timeline writer registry — maps __typename → writer or batch accumulator.
+-- "IssueComment" and "PullRequestReview" are handled with extra logic in
+-- write_timeline_items and are intentionally absent from this registry.
+-- ---------------------------------------------------------------------------
+do
+  local reg = timeline_registry.register
+  -- Direct-dispatch events
+  reg("MergedEvent", { writer = M.write_merged_event })
+  reg("ClosedEvent", { writer = M.write_closed_event })
+  reg("ReopenedEvent", { writer = M.write_reopened_event })
+  reg("ReviewDismissedEvent", { writer = M.write_review_dismissed_event })
+  reg("RenamedTitleEvent", { writer = M.write_renamed_title_event })
+  reg("ConnectedEvent", { writer = M.write_connected_event })
+  reg("CrossReferencedEvent", { writer = M.write_cross_referenced_event })
+  reg("ReferencedEvent", { writer = M.write_referenced_event })
+  reg("MilestonedEvent", { writer = M.write_milestoned_event })
+  reg("DemilestonedEvent", { writer = M.write_demilestoned_event })
+  reg("PinnedEvent", { writer = M.write_pinned_event })
+  reg("UnpinnedEvent", { writer = M.write_unpinned_event })
+  reg("LockedEvent", { writer = M.write_locked_event })
+  reg("UnlockedEvent", { writer = M.write_unlocked_event })
+  reg("ParentIssueAddedEvent", { writer = M.write_parent_issue_added_event })
+  reg("ParentIssueRemovedEvent", { writer = M.write_parent_issue_removed_event })
+  reg("IssueTypeAddedEvent", { writer = M.write_issue_type_added_event })
+  reg("IssueTypeRemovedEvent", { writer = M.write_issue_type_removed_event })
+  reg("IssueTypeChangedEvent", { writer = M.write_issue_type_changed_event })
+  reg("ConvertToDraftEvent", { writer = M.write_convert_to_draft_event })
+  reg("ReadyForReviewEvent", { writer = M.write_ready_for_review_event })
+  reg("DeployedEvent", { writer = M.write_deployed_event })
+  reg("HeadRefDeletedEvent", { writer = M.write_head_ref_deleted_event })
+  reg("HeadRefRestoredEvent", { writer = M.write_head_ref_restored_event })
+  reg("AutoSquashEnabledEvent", { writer = M.write_auto_squash_enabled_event })
+  reg("AutoMergeEnabledEvent", { writer = M.write_auto_merge_enabled_event })
+  reg("AutoMergeDisabledEvent", { writer = M.write_auto_merge_disabled_event })
+  reg("AddedToProjectV2Event", { writer = M.write_added_to_project_v2_event })
+  reg("RemovedFromProjectV2Event", { writer = M.write_removed_from_project_v2_event })
+  reg("ProjectV2ItemStatusChangedEvent", { writer = M.write_project_v2_item_status_changed_event })
+  reg("AutomaticBaseChangeSucceededEvent", { writer = M.write_automatic_base_change_succeeded_event })
+  reg("BaseRefChangedEvent", { writer = M.write_base_ref_changed_event })
+  reg("CommentDeletedEvent", { writer = M.write_comment_deleted_event })
+  reg("BlockingAddedEvent", { writer = M.write_blocking_added_event })
+  reg("BlockingRemovedEvent", { writer = M.write_blocking_removed_event })
+  reg("BlockedByAddedEvent", { writer = M.write_blocked_by_added_event })
+  reg("BlockedByRemovedEvent", { writer = M.write_blocked_by_removed_event })
+  reg("MarkedAsDuplicateEvent", { writer = M.write_marked_as_duplicate_event })
+  reg("UnmarkedAsDuplicateEvent", { writer = M.write_unmarked_as_duplicate_event })
+  reg("TransferredEvent", { writer = M.write_transferred_event })
+  -- Batched events — accumulated and flushed by render_accumulated_events()
+  reg("AssignedEvent", { batch = "assignment" })
+  reg("UnassignedEvent", { batch = "assignment" })
+  reg("LabeledEvent", { batch = "label" })
+  reg("UnlabeledEvent", { batch = "label" })
+  reg("PullRequestCommit", { batch = "commits" })
+  reg("HeadRefForcePushedEvent", { batch = "force_push" })
+  reg("ReviewRequestedEvent", { batch = "review_requested" })
+  reg("ReviewRequestRemovedEvent", { batch = "review_request_removed" })
+  reg("SubIssueAddedEvent", { batch = "subissue_added" })
+  reg("SubIssueRemovedEvent", { batch = "subissue_removed" })
 end
 
 return M

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -3551,8 +3551,7 @@ function M.write_timeline_items(bufnr, obj)
   --- labeled/unlabeled events or subissues events are rendered
   table.insert(timeline_nodes, {})
 
-  ---@param item? octo.PullRequestTimelineItem|octo.IssueTimelineItem
-  ---@param items table
+  ---@param items any[]
   local function clear_items(items)
     for idx = #items, 1, -1 do
       items[idx] = nil

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -3619,23 +3619,16 @@ function M.write_timeline_items(bufnr, obj)
     end
   end
 
-  -- Accumulator tables, keyed by registry `batch` name.
+  -- Accumulator tables, keyed by the batch id used in timeline_registry entries.
   local accumulators = {
-    assignment = unrendered_assignment_events,
-    label = unrendered_label_events,
-    commits = commits,
-    force_push = unrendered_force_push_events,
-    review_requested = unrendered_review_requested_events,
-    review_request_removed = unrendered_review_request_removed_events,
-    subissue_added = unrendered_subissue_added_events,
-    subissue_removed = unrendered_subissue_removed_events,
-  }
-
-  -- Batched typenames that mark prev_is_event when an item is accumulated.
-  local batch_sets_prev_event = {
-    commits = true,
-    review_requested = true,
-    review_request_removed = true,
+    assignment_events = unrendered_assignment_events,
+    label_events = unrendered_label_events,
+    pull_request_commits = commits,
+    force_pushed_events = unrendered_force_push_events,
+    review_requested_events = unrendered_review_requested_events,
+    review_request_removed_events = unrendered_review_request_removed_events,
+    subissue_added_events = unrendered_subissue_added_events,
+    subissue_removed_events = unrendered_subissue_removed_events,
   }
 
   for _, item in ipairs(timeline_nodes) do
@@ -3685,13 +3678,12 @@ function M.write_timeline_items(bufnr, obj)
       if entry then
         if entry.writer then
           entry.writer(bufnr, item)
-          -- BlockedByRemovedEvent intentionally does NOT set prev_is_event.
-          if item.__typename ~= "BlockedByRemovedEvent" then
+          if entry.sets_prev_event == nil or entry.sets_prev_event then
             prev_is_event = true
           end
         elseif entry.batch then
           table.insert(accumulators[entry.batch], item)
-          if batch_sets_prev_event[entry.batch] then
+          if entry.sets_prev_event then
             prev_is_event = true
           end
         end
@@ -3758,21 +3750,21 @@ do
   reg("BlockingAddedEvent", { writer = M.write_blocking_added_event })
   reg("BlockingRemovedEvent", { writer = M.write_blocking_removed_event })
   reg("BlockedByAddedEvent", { writer = M.write_blocked_by_added_event })
-  reg("BlockedByRemovedEvent", { writer = M.write_blocked_by_removed_event })
+  reg("BlockedByRemovedEvent", { writer = M.write_blocked_by_removed_event, sets_prev_event = false })
   reg("MarkedAsDuplicateEvent", { writer = M.write_marked_as_duplicate_event })
   reg("UnmarkedAsDuplicateEvent", { writer = M.write_unmarked_as_duplicate_event })
   reg("TransferredEvent", { writer = M.write_transferred_event })
   -- Batched events — accumulated and flushed by render_accumulated_events()
-  reg("AssignedEvent", { batch = "assignment" })
-  reg("UnassignedEvent", { batch = "assignment" })
-  reg("LabeledEvent", { batch = "label" })
-  reg("UnlabeledEvent", { batch = "label" })
-  reg("PullRequestCommit", { batch = "commits" })
-  reg("HeadRefForcePushedEvent", { batch = "force_push" })
-  reg("ReviewRequestedEvent", { batch = "review_requested" })
-  reg("ReviewRequestRemovedEvent", { batch = "review_request_removed" })
-  reg("SubIssueAddedEvent", { batch = "subissue_added" })
-  reg("SubIssueRemovedEvent", { batch = "subissue_removed" })
+  reg("AssignedEvent", { batch = "assignment_events" })
+  reg("UnassignedEvent", { batch = "assignment_events" })
+  reg("LabeledEvent", { batch = "label_events" })
+  reg("UnlabeledEvent", { batch = "label_events" })
+  reg("PullRequestCommit", { batch = "pull_request_commits", sets_prev_event = true })
+  reg("HeadRefForcePushedEvent", { batch = "force_pushed_events" })
+  reg("ReviewRequestedEvent", { batch = "review_requested_events", sets_prev_event = true })
+  reg("ReviewRequestRemovedEvent", { batch = "review_request_removed_events", sets_prev_event = true })
+  reg("SubIssueAddedEvent", { batch = "subissue_added_events" })
+  reg("SubIssueRemovedEvent", { batch = "subissue_removed_events" })
 end
 
 return M


### PR DESCRIPTION
closes #1365

Replaces manual `..` string concatenation for timeline fragments with a keyed registry (dedup by fragment name, conditional inclusion via a `condition` function). Also introduces a writer dispatch registry that replaces the ~200-line `if/elseif` chain in `write_timeline_items`.

The goal is to keep all three concerns for a timeline item — fragment definition, writer function, and enterprise-compat gate — co-located and discoverable in one place, rather than spread across `fragments.lua`, `queries.lua`, and `writers.lua`.

```lua
-- Register a custom timeline item before octo.setup():
require('octo.gh.fragments').register_issue_timeline_item(
  'MyEventFragment',
  [[ fragment MyEventFragment on MyEvent { ... } ]],
  not_enterprise -- or any fun():boolean
)

require('octo.gh.timeline_registry').register('MyEvent', {
  writer = function(bufnr, item) ... end,
})
```

Built-in helpers gate fragments by endpoint compatibility:
- `not_enterprise` — excludes types absent from older GHES (fixes #1153, #513, #685)
- `projects_v2_enabled` — replaces the previous `if default_to_projects_v2` branching