### PR TITLE
fix: add Bot fragment to requestedReviewer GraphQL queries

### DIFF
--- a/lua/octo/gh/fragments.lua
+++ b/lua/octo/gh/fragments.lua
@@ -861,6 +861,9 @@ fragment ReviewRequestRemovedEventFragment on ReviewRequestRemovedEvent {
     ... on Mannequin {
       login
     }
+    ... on Bot {
+      login
+    }
     ... on Team {
       name
     }

--- a/lua/octo/gh/mutations.lua
+++ b/lua/octo/gh/mutations.lua
@@ -923,6 +923,7 @@ mutation($pullRequestId: ID!, $state: PullRequestUpdateState!) {
               isViewer
             }
             ... on Mannequin { login }
+            ... on Bot { login }
             ... on Team { name }
           }
         }
@@ -1104,6 +1105,7 @@ mutation($object_id: ID!, $user_ids: [ID!]!) {
               isViewer
             }
             ... on Mannequin { login }
+            ... on Bot { login }
             ... on Team { name }
           }
         }
@@ -1210,6 +1212,7 @@ mutation($input: CreatePullRequestInput!) {
               isViewer
             }
             ... on Mannequin { login }
+            ... on Bot { login }
             ... on Team { name }
           }
         }

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -260,6 +260,7 @@ query($endCursor: String) {
               isViewer
             }
             ... on Mannequin { login }
+            ... on Bot { login }
             ... on Team { name }
           }
         }
@@ -929,6 +930,9 @@ query($owner: String!, $name: String!, $number: Int!) {
             }
             ... on Mannequin {
               id
+              login
+            }
+            ... on Bot {
               login
             }
             ... on Team {


### PR DESCRIPTION
## Summary

- Fixes a crash when opening a PR where GitHub Copilot is a requested reviewer
- Adds `... on Bot { login }` to all `requestedReviewer` inline fragments in the GraphQL queries

## Details

GitHub Copilot is typed as `Bot` in the GitHub GraphQL schema. The `requestedReviewer` inline fragments only covered `User`, `Mannequin`, and `Team` — no `Bot` fragment. When Copilot is a requested reviewer, it matches none of them and `requestedReviewer` returns `{}`, making `login` nil and causing a `table index is nil` crash in `collect_reviewer` (`writers.lua:883`).

The fix adds `... on Bot { login }` to all `requestedReviewer` blocks across:
- `lua/octo/gh/queries.lua` — 2 blocks
- `lua/octo/gh/mutations.lua` — 3 blocks
- `lua/octo/gh/fragments.lua` — 1 block (one block already had it)

## Evidence

- Reproduced locally against a PR with Copilot as a requested reviewer
- Confirmed fix resolves the crash with no other side effects

Fixes #1273