### PR TITLE
feat(gh): add X-Github-Next-Global-ID header to GraphQL requests

### DIFF
--- a/lua/octo/gh/init.lua
+++ b/lua/octo/gh/init.lua
@@ -215,6 +215,10 @@ local function run(opts)
   if opts.args[1] == "api" then
     table.insert(opts.args, "-H")
     table.insert(opts.args, "Accept: " .. table.concat(headers, ";"))
+    if opts.args[2] == "graphql" then
+      table.insert(opts.args, "-H")
+      table.insert(opts.args, "X-Github-Next-Global-ID: 1")
+    end
     if not require("octo.utils").is_blank(opts.hostname) then
       hostname = opts.hostname
     elseif not require("octo.utils").is_blank(conf.github_hostname) then


### PR DESCRIPTION
Closes #1373

Opts into GitHub's next-generation global node ID format by sending `X-Github-Next-Global-ID: 1` on all GraphQL requests.

```lua
-- gh/init.lua — injected alongside the existing Accept header for graphql calls
if opts.args[2] == "graphql" then
  table.insert(opts.args, "-H")
  table.insert(opts.args, "X-Github-Next-Global-ID: 1")
end
```

GitHub has been emitting deprecation warnings for legacy Base64 node IDs since 2021 and will sunset them at an unspecified future date. octo.nvim treats IDs as opaque strings throughout, so the format change is safe — no decoding or format-specific logic exists in the codebase.

Note: the header is only injected for `gh api graphql` calls, not REST calls, matching the scope of the migration.