### PR TITLE
fix(nvim): replace deprecated Neovim APIs

### DIFF
--- a/.github/workflows/.luarc.json
+++ b/.github/workflows/.luarc.json
@@ -19,11 +19,13 @@
   "diagnostics": {
     "severity": {
       "await-in-sync": "Error",
-      "no-unknown": "Warning"
+      "no-unknown": "Warning",
+      "deprecated": "Warning"
     },
     "neededFileStatus": {
       "await-in-sync": "Any",
-      "no-unknown": "Any"
+      "no-unknown": "Any",
+      "deprecated": "Any"
     },
     "unusedLocalExclude": [
       "_*"

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2313,8 +2313,8 @@ function M.show_pr_diff()
         local wbufnr = vim.api.nvim_create_buf(true, true)
         vim.api.nvim_buf_set_lines(wbufnr, 0, -1, false, lines)
         vim.api.nvim_set_current_buf(wbufnr)
-        vim.api.nvim_buf_set_option(wbufnr, "filetype", "diff")
-        vim.api.nvim_buf_set_option(wbufnr, "modifiable", false)
+        vim.bo[wbufnr].filetype = "diff"
+        vim.bo[wbufnr].modifiable = false
         vim.api.nvim_buf_set_name(wbufnr, "DIFF: " .. buffer:pullRequest().title)
       end
     end,

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -13,8 +13,8 @@ Opens a url in your default browser, bypassing gh.
 ]]
 ---@param url string
 function M.open_in_browser_raw(url)
-  local os_name = vim.loop.os_uname().sysname
-  local is_windows = vim.loop.os_uname().version:match "Windows"
+  local os_name = vim.uv.os_uname().sysname
+  local is_windows = vim.uv.os_uname().version:match "Windows"
 
   if os_name == "Darwin" then
     os.execute("open " .. url)
@@ -94,7 +94,7 @@ function M.open_in_browser(kind, repo, number)
 end
 
 local function open_file_if_found(path, line)
-  local stat = vim.loop.fs_stat(path)
+  local stat = vim.uv.fs_stat(path)
   if stat and stat.type then
     vim.cmd("e " .. path)
     vim.api.nvim_win_set_cursor(0, { line, 0 })

--- a/lua/octo/pickers/telescope/previewers.lua
+++ b/lua/octo/pickers/telescope/previewers.lua
@@ -167,7 +167,7 @@ local commit = defaulter(function(opts)
           bufname = self.state.bufname,
           mode = "append",
           callback = function(bufnr, _)
-            vim.api.nvim_buf_set_option(bufnr, "filetype", "diff")
+            vim.bo[bufnr].filetype = "diff"
             vim.api.nvim_buf_add_highlight(bufnr, -1, "OctoDetailsLabel", 0, 0, string.len "Commit:")
             vim.api.nvim_buf_add_highlight(bufnr, -1, "OctoDetailsLabel", 1, 0, string.len "Author:")
             vim.api.nvim_buf_add_highlight(bufnr, -1, "OctoDetailsLabel", 2, 0, string.len "Date:")
@@ -190,7 +190,7 @@ local changed_files = defaulter(function(opts)
         local diff = entry.change.patch
         if diff then
           vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, vim.split(diff, "\n"))
-          vim.api.nvim_buf_set_option(self.state.bufnr, "filetype", "diff")
+          vim.bo[self.state.bufnr].filetype = "diff"
         end
       end
     end,
@@ -231,7 +231,7 @@ local issue_template = defaulter(function(opts)
         local template = entry.template.body
         if template then
           vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, vim.split(template, "\n"))
-          vim.api.nvim_buf_set_option(self.state.bufnr, "filetype", "markdown")
+          vim.bo[self.state.bufnr].filetype = "markdown"
         end
       end
     end,

--- a/lua/octo/workflow_runs.lua
+++ b/lua/octo/workflow_runs.lua
@@ -280,7 +280,7 @@ local function write_zipped_file(stdout)
   return zip_location,
     function()
       local unlink_success, unlink_error = pcall(function()
-        vim.loop.fs_unlink(zip_location)
+        vim.uv.fs_unlink(zip_location)
       end)
 
       if not unlink_success then

--- a/lua/tests/minimal.lua
+++ b/lua/tests/minimal.lua
@@ -1,4 +1,4 @@
-local on_windows = vim.loop.os_uname().version:match "Windows"
+local on_windows = vim.uv.os_uname().version:match "Windows"
 
 local function join_paths(...)
   return table.concat({ ... }, on_windows and "\\" or "/")

--- a/lua/tests/test_utils.lua
+++ b/lua/tests/test_utils.lua
@@ -91,7 +91,7 @@ _G.Test_withfile = function(test_data, cb)
         linenr = value.linenr,
         colnr = 0,
       }
-      if not vim.tbl_islist(value.before) then
+      if not vim.islist(value.before) then
         value.before = { value.before }
       end
       for index, text in pairs(value.before) do
@@ -104,7 +104,7 @@ _G.Test_withfile = function(test_data, cb)
           end
         end
       end
-      if not vim.tbl_islist(value.after) then
+      if not vim.islist(value.after) then
         value.after = { value.after }
       end
       vim.bo.filetype = value.filetype or "text"


### PR DESCRIPTION
Replaces APIs that emit deprecation warnings in Neovim 0.10+, keeping the
codebase aligned with current Neovim conventions.

Also enables the `deprecated` diagnostic in `lua-language-server` CI so
future deprecated API usage is caught automatically at the typecheck step.

## Changes

| Deprecated API | Replacement | Reference |
|---|---|---|
| `vim.loop` | `vim.uv` | [neovim/neovim#22846](https://github.com/neovim/neovim/pull/22846) |
| `vim.tbl_islist` | `vim.islist` | [neovim/neovim#28440](https://github.com/neovim/neovim/pull/28440) |
| `nvim_buf_set_option` | `vim.bo[buf]` accessor | [neovim/neovim#36972](https://github.com/neovim/neovim/pull/36972) |

## CI

Adds `"deprecated": "Warning"` + `"neededFileStatus": "Any"` to `.github/workflows/.luarc.json`.
Neovim's runtime already annotates deprecated APIs with `---@deprecated` (e.g. `vim.loop = vim.uv` in `vim/_core/editor.lua`), so lua-language-server can detect them without any custom stubs. Setting `neededFileStatus` to `"Any"` ensures the diagnostic fires across all workspace files during `--check` mode, not just open buffers.

This does not raise the minimum Neovim version — the project already requires `>= 0.10` and all replacement APIs (`vim.uv`, `vim.islist`, `vim.bo[]`) are available from 0.9/0.10.

## References

- Neovim 0.10 release notes: https://neovim.io/doc/user/news-0.10.html
- `vim.loop` → `vim.uv` rename PR: https://github.com/neovim/neovim/pull/22846
- `vim.tbl_islist` → `vim.islist` rename PR: https://github.com/neovim/neovim/pull/28440
- `nvim_buf_set_option` deprecation in tests: https://github.com/neovim/neovim/pull/36972
- lua-language-server `deprecated` diagnostic: https://luals.github.io/wiki/diagnostics/#deprecated