### PR TITLE
refactor: migrate gh.run graphql calls to gh.api.graphql

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1435,98 +1435,108 @@ function M.delete_comment()
 
   local choice = vim.fn.confirm("Delete comment?", "&Yes\n&No\n&Cancel", 2)
   if choice == 1 then
-    gh.run {
-      args = { "api", "graphql", "-f", string.format("query=%s", query) },
-      cb = function(output)
-        -- TODO: deleting the last review thread comment, it deletes the whole thread and review
-        -- In issue buffers, we should hide the thread snippet
-        local resp = vim.json.decode(output)
+    gh.api.graphql {
+      f = { query = query },
+      opts = {
+        cb = gh.create_callback {
+          success = function(output)
+            -- TODO: deleting the last review thread comment, it deletes the whole thread and review
+            -- In issue buffers, we should hide the thread snippet
+            local resp = vim.json.decode(output)
 
-        -- remove comment lines from the buffer
-        if comment.reactionLine then
-          vim.api.nvim_buf_set_lines(buffer.bufnr, start_line - 2, end_line + 1, false, {})
-          vim.api.nvim_buf_clear_namespace(buffer.bufnr, constants.OCTO_REACTIONS_VT_NS, start_line - 2, end_line + 1)
-        else
-          vim.api.nvim_buf_set_lines(buffer.bufnr, start_line - 2, end_line - 1, false, {})
-        end
-        vim.api.nvim_buf_clear_namespace(buffer.bufnr, comment.namespace, 0, -1)
-        vim.api.nvim_buf_del_extmark(buffer.bufnr, constants.OCTO_COMMENT_NS, comment.extmark)
-        local comments = buffer.commentsMetadata
-        if comments then
-          local updated = {}
-          for _, c in ipairs(comments) do
-            if c.id ~= comment.id then
-              table.insert(updated, c)
+            -- remove comment lines from the buffer
+            if comment.reactionLine then
+              vim.api.nvim_buf_set_lines(buffer.bufnr, start_line - 2, end_line + 1, false, {})
+              vim.api.nvim_buf_clear_namespace(
+                buffer.bufnr,
+                constants.OCTO_REACTIONS_VT_NS,
+                start_line - 2,
+                end_line + 1
+              )
+            else
+              vim.api.nvim_buf_set_lines(buffer.bufnr, start_line - 2, end_line - 1, false, {})
             end
-          end
-          buffer.commentsMetadata = updated
-        end
-
-        if comment.kind == "PullRequestReviewComment" then
-          local review = reviews.get_current_review()
-          if not review then
-            utils.error "Cannot find review for this comment"
-            return
-          end
-
-          local threads = resp.data.deletePullRequestReviewComment.pullRequestReview.pullRequest.reviewThreads.nodes
-
-          -- check if there is still at least a PENDING comment
-          local review_was_deleted = true
-          for _, thread in ipairs(threads) do
-            for _, c in ipairs(thread.comments.nodes) do
-              if c.state == "PENDING" then
-                review_was_deleted = false
-                break
+            vim.api.nvim_buf_clear_namespace(buffer.bufnr, comment.namespace, 0, -1)
+            vim.api.nvim_buf_del_extmark(buffer.bufnr, constants.OCTO_COMMENT_NS, comment.extmark)
+            local comments = buffer.commentsMetadata
+            if comments then
+              local updated = {}
+              for _, c in ipairs(comments) do
+                if c.id ~= comment.id then
+                  table.insert(updated, c)
+                end
               end
+              buffer.commentsMetadata = updated
             end
-          end
-          if review_was_deleted then
-            -- we deleted the last pending comment and therefore GitHub closed the review, create a new one
-            review:create(function(resp)
-              review.id = resp.data.addPullRequestReview.pullRequestReview.id
-              local updated_threads = resp.data.addPullRequestReview.pullRequestReview.pullRequest.reviewThreads.nodes
-              review:update_threads(updated_threads)
-            end)
-          else
-            review:update_threads(threads)
-          end
 
-          -- check if we removed the last comment of a thread
-          local thread_was_deleted = true
-          for _, thread in ipairs(threads) do
-            if threadId == thread.id then
-              thread_was_deleted = false
-              break
-            end
-          end
-          if thread_was_deleted then
-            -- this was the last comment, close the thread buffer
-            -- No comments left
-            utils.error("Deleting buffer " .. tostring(buffer.bufnr))
-            local bufname = vim.api.nvim_buf_get_name(buffer.bufnr)
-            local split = string.match(bufname, "octo://.+/review/[^/]+/threads/([^/]+)/.*")
-            if split then
-              local layout = reviews.get_current_review().layout
-              local file = layout:get_current_file()
-              if not file then
+            if comment.kind == "PullRequestReviewComment" then
+              local review = reviews.get_current_review()
+              if not review then
+                utils.error "Cannot find review for this comment"
                 return
               end
-              local thread_win = file:get_alternative_win(split)
-              local original_buf = file:get_alternative_buf(split)
-              -- move focus to the split containing the diff buffer
-              -- restore the diff buffer so that window is not closed when deleting thread buffer
-              vim.api.nvim_win_set_buf(thread_win, original_buf)
-              -- delete the thread buffer
-              pcall(vim.api.nvim_buf_delete, buffer.bufnr, { force = true })
-              -- refresh signs and virtual text
-              file:place_signs()
-              -- diff buffers
-              file:show_diff()
-            end
-          end
-        end
-      end,
+
+              local threads = resp.data.deletePullRequestReviewComment.pullRequestReview.pullRequest.reviewThreads.nodes
+
+              -- check if there is still at least a PENDING comment
+              local review_was_deleted = true
+              for _, thread in ipairs(threads) do
+                for _, c in ipairs(thread.comments.nodes) do
+                  if c.state == "PENDING" then
+                    review_was_deleted = false
+                    break
+                  end
+                end
+              end
+              if review_was_deleted then
+                -- we deleted the last pending comment and therefore GitHub closed the review, create a new one
+                review:create(function(resp)
+                  review.id = resp.data.addPullRequestReview.pullRequestReview.id
+                  local updated_threads =
+                    resp.data.addPullRequestReview.pullRequestReview.pullRequest.reviewThreads.nodes
+                  review:update_threads(updated_threads)
+                end)
+              else
+                review:update_threads(threads)
+              end
+
+              -- check if we removed the last comment of a thread
+              local thread_was_deleted = true
+              for _, thread in ipairs(threads) do
+                if threadId == thread.id then
+                  thread_was_deleted = false
+                  break
+                end
+              end
+              if thread_was_deleted then
+                -- this was the last comment, close the thread buffer
+                -- No comments left
+                utils.error("Deleting buffer " .. tostring(buffer.bufnr))
+                local bufname = vim.api.nvim_buf_get_name(buffer.bufnr)
+                local split = string.match(bufname, "octo://.+/review/[^/]+/threads/([^/]+)/.*")
+                if split then
+                  local layout = reviews.get_current_review().layout
+                  local file = layout:get_current_file()
+                  if not file then
+                    return
+                  end
+                  local thread_win = file:get_alternative_win(split)
+                  local original_buf = file:get_alternative_buf(split)
+                  -- move focus to the split containing the diff buffer
+                  -- restore the diff buffer so that window is not closed when deleting thread buffer
+                  vim.api.nvim_win_set_buf(thread_win, original_buf)
+                  -- delete the thread buffer
+                  pcall(vim.api.nvim_buf_delete, buffer.bufnr, { force = true })
+                  -- refresh signs and virtual text
+                  file:place_signs()
+                  -- diff buffers
+                  file:show_diff()
+                end
+              end
+            end -- if comment.kind == "PullRequestReviewComment"
+          end,
+        },
+      },
     }
   end
 end
@@ -1610,20 +1620,20 @@ function M.resolve_thread()
   local thread_id = _thread.threadId
   local thread_line = _thread.bufferStartLine
   local query = graphql("resolve_review_thread_mutation", thread_id)
-  gh.run {
-    args = { "api", "graphql", "-f", string.format("query=%s", query) },
-    cb = function(output, stderr)
-      if stderr and not utils.is_blank(stderr) then
-        utils.error(stderr)
-      elseif output then
-        local resp = vim.json.decode(output)
-        local thread = resp.data.resolveReviewThread.thread
-        if thread.isResolved then
-          update_review_thread_header(buffer.bufnr, thread, thread_id, thread_line)
-          --vim.cmd(string.format("%d,%dfoldclose", thread_line, thread_line))
-        end
-      end
-    end,
+  gh.api.graphql {
+    f = { query = query },
+    opts = {
+      cb = gh.create_callback {
+        success = function(output)
+          local resp = vim.json.decode(output)
+          local thread = resp.data.resolveReviewThread.thread
+          if thread.isResolved then
+            update_review_thread_header(buffer.bufnr, thread, thread_id, thread_line)
+            --vim.cmd(string.format("%d,%dfoldclose", thread_line, thread_line))
+          end
+        end,
+      },
+    },
   }
 end
 
@@ -1640,19 +1650,19 @@ function M.unresolve_thread()
   local thread_id = _thread.threadId
   local thread_line = _thread.bufferStartLine
   local query = graphql("unresolve_review_thread_mutation", thread_id)
-  gh.run {
-    args = { "api", "graphql", "-f", string.format("query=%s", query) },
-    cb = function(output, stderr)
-      if stderr and not utils.is_blank(stderr) then
-        utils.error(stderr)
-      elseif output then
-        local resp = vim.json.decode(output)
-        local thread = resp.data.unresolveReviewThread.thread
-        if not thread.isResolved then
-          update_review_thread_header(buffer.bufnr, thread, thread_id, thread_line)
-        end
-      end
-    end,
+  gh.api.graphql {
+    f = { query = query },
+    opts = {
+      cb = gh.create_callback {
+        success = function(output)
+          local resp = vim.json.decode(output)
+          local thread = resp.data.unresolveReviewThread.thread
+          if not thread.isResolved then
+            update_review_thread_header(buffer.bufnr, thread, thread_id, thread_line)
+          end
+        end,
+      },
+    },
   }
 end
 
@@ -2415,37 +2425,37 @@ function M.reaction_action(reaction)
 
   -- add/delete reaction
   local query = graphql(action .. "_reaction_mutation", id, reaction)
-  gh.run {
-    args = { "api", "graphql", "-f", string.format("query=%s", query) },
-    cb = function(output, stderr)
-      if stderr and not utils.is_blank(stderr) then
-        utils.error(stderr)
-      elseif output then
-        local resp = vim.json.decode(output)
-        if action == "add" then
-          reaction_groups = resp.data.addReaction.subject.reactionGroups
-        elseif action == "remove" then
-          reaction_groups = resp.data.removeReaction.subject.reactionGroups
-        end
+  gh.api.graphql {
+    f = { query = query },
+    opts = {
+      cb = gh.create_callback {
+        success = function(output)
+          local resp = vim.json.decode(output)
+          if action == "add" then
+            reaction_groups = resp.data.addReaction.subject.reactionGroups
+          elseif action == "remove" then
+            reaction_groups = resp.data.removeReaction.subject.reactionGroups
+          end
 
-        buffer:update_reactions_at_cursor(reaction_groups, reaction_line)
-        if action == "remove" and utils.count_reactions(reaction_groups) == 0 then
-          -- delete lines
-          vim.api.nvim_buf_set_lines(buffer.bufnr, reaction_line - 1, reaction_line + 1, false, {})
-          vim.api.nvim_buf_clear_namespace(
-            buffer.bufnr,
-            constants.OCTO_REACTIONS_VT_NS,
-            reaction_line - 1,
-            reaction_line + 1
-          )
-        elseif action == "add" and insert_line then
-          -- add lines
-          vim.api.nvim_buf_set_lines(buffer.bufnr, reaction_line - 1, reaction_line - 1, false, { "", "" })
-        end
-        writers.write_reactions(buffer.bufnr, reaction_groups, reaction_line)
-        buffer:update_metadata()
-      end
-    end,
+          buffer:update_reactions_at_cursor(reaction_groups, reaction_line)
+          if action == "remove" and utils.count_reactions(reaction_groups) == 0 then
+            -- delete lines
+            vim.api.nvim_buf_set_lines(buffer.bufnr, reaction_line - 1, reaction_line + 1, false, {})
+            vim.api.nvim_buf_clear_namespace(
+              buffer.bufnr,
+              constants.OCTO_REACTIONS_VT_NS,
+              reaction_line - 1,
+              reaction_line + 1
+            )
+          elseif action == "add" and insert_line then
+            -- add lines
+            vim.api.nvim_buf_set_lines(buffer.bufnr, reaction_line - 1, reaction_line - 1, false, { "", "" })
+          end
+          writers.write_reactions(buffer.bufnr, reaction_groups, reaction_line)
+          buffer:update_metadata()
+        end,
+      },
+    },
   }
 end
 
@@ -2460,38 +2470,38 @@ function M.set_project_v2_card()
     local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
     -- add new card
     local add_query = graphql("add_project_v2_item_mutation", node.id, project_id)
-    gh.run {
-      args = { "api", "graphql", "--paginate", "-f", string.format("query=%s", add_query) },
-      cb = function(add_output, add_stderr)
-        if add_stderr and not utils.is_blank(add_stderr) then
-          utils.error(add_stderr)
-        elseif add_output then
-          local resp = vim.json.decode(add_output)
-          local update_query = graphql(
-            "update_project_v2_item_mutation",
-            project_id,
-            resp.data.addProjectV2ItemById.item.id,
-            field_id,
-            value
-          )
-          gh.run {
-            args = { "api", "graphql", "--paginate", "-f", string.format("query=%s", update_query) },
-            cb = function(update_output, update_stderr)
-              if update_stderr and not utils.is_blank(update_stderr) then
-                utils.error(update_stderr)
-              elseif update_output then
-                -- TODO do update here
-                -- refresh issue/pr details
-                local hostname = get_hostname_from_buffer()
-                require("octo").load(buffer.repo, buffer.kind, buffer.number, hostname, function(obj)
-                  writers.write_details(buffer.bufnr, obj, true)
-                  node.projectCards = obj.projectCards
-                end)
-              end
-            end,
-          }
-        end
-      end,
+    gh.api.graphql {
+      f = { query = add_query },
+      opts = {
+        cb = gh.create_callback {
+          success = function(add_output)
+            local resp = vim.json.decode(add_output)
+            local update_query = graphql(
+              "update_project_v2_item_mutation",
+              project_id,
+              resp.data.addProjectV2ItemById.item.id,
+              field_id,
+              value
+            )
+            gh.api.graphql {
+              f = { query = update_query },
+              opts = {
+                cb = gh.create_callback {
+                  success = function()
+                    -- TODO do update here
+                    -- refresh issue/pr details
+                    local hostname = get_hostname_from_buffer()
+                    require("octo").load(buffer.repo, buffer.kind, buffer.number, hostname, function(obj)
+                      writers.write_details(buffer.bufnr, obj, true)
+                      node.projectCards = obj.projectCards
+                    end)
+                  end,
+                },
+              },
+            }
+          end,
+        },
+      },
     }
   end)
 end
@@ -2507,20 +2517,20 @@ function M.remove_project_v2_card()
     local node = buffer:isIssue() and buffer:issue() or buffer:pullRequest()
     -- delete card
     local query = graphql("delete_project_v2_item_mutation", project_id, item_id)
-    gh.run {
-      args = { "api", "graphql", "--paginate", "-f", string.format("query=%s", query) },
-      cb = function(output, stderr)
-        if stderr and not utils.is_blank(stderr) then
-          utils.error(stderr)
-        elseif output then
-          -- refresh issue/pr details
-          local hostname = get_hostname_from_buffer()
-          require("octo").load(buffer.repo, buffer.kind, buffer.number, hostname, function(obj)
-            node.projectCards = obj.projectCards
-            writers.write_details(buffer.bufnr, obj, true)
-          end)
-        end
-      end,
+    gh.api.graphql {
+      f = { query = query },
+      opts = {
+        cb = gh.create_callback {
+          success = function()
+            -- refresh issue/pr details
+            local hostname = get_hostname_from_buffer()
+            require("octo").load(buffer.repo, buffer.kind, buffer.number, hostname, function(obj)
+              node.projectCards = obj.projectCards
+              writers.write_details(buffer.bufnr, obj, true)
+            end)
+          end,
+        },
+      },
     }
   end)
 end
@@ -2755,19 +2765,19 @@ function M.remove_assignee(login)
 
   local function cb(user_id)
     local query = graphql("remove_assignees_mutation", iid, user_id)
-    gh.run {
-      args = { "api", "graphql", "--paginate", "-f", string.format("query=%s", query) },
-      cb = function(output, stderr)
-        if stderr and not utils.is_blank(stderr) then
-          utils.error(stderr)
-        elseif output then
-          -- refresh issue/pr details
-          local hostname = get_hostname_from_buffer()
-          require("octo").load(buffer.repo, buffer.kind, buffer.number, hostname, function(obj)
-            writers.write_details(buffer.bufnr, obj, true)
-          end)
-        end
-      end,
+    gh.api.graphql {
+      f = { query = query },
+      opts = {
+        cb = gh.create_callback {
+          success = function()
+            -- refresh issue/pr details
+            local hostname = get_hostname_from_buffer()
+            require("octo").load(buffer.repo, buffer.kind, buffer.number, hostname, function(obj)
+              writers.write_details(buffer.bufnr, obj, true)
+            end)
+          end,
+        },
+      },
     }
   end
   if login then

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -467,30 +467,30 @@ function OctoBuffer:do_add_issue_comment(comment_metadata)
   local obj = self:isIssue() and self:issue() or self:pullRequest()
   local id = obj.id
   local add_query = graphql("add_issue_comment_mutation", id, comment_metadata.body)
-  gh.run {
-    args = { "api", "graphql", "-f", string.format("query=%s", add_query) },
-    cb = function(output, stderr)
-      if stderr and not utils.is_blank(stderr) then
-        utils.print_err(stderr)
-      elseif output then
-        ---@type octo.mutations.AddIssueComment
-        local resp = vim.json.decode(output)
-        local respBody = resp.data.addComment.commentEdge.node.body
-        local respId = resp.data.addComment.commentEdge.node.id
-        if utils.trim(comment_metadata.body) == utils.trim(respBody) then
-          local comments = self.commentsMetadata
-          for i, c in ipairs(comments) do
-            if tonumber(c.id) == -1 then
-              comments[i].id = respId
-              comments[i].savedBody = respBody
-              comments[i].dirty = false
-              break
+  gh.api.graphql {
+    f = { query = add_query },
+    opts = {
+      cb = gh.create_callback {
+        success = function(output)
+          ---@type octo.mutations.AddIssueComment
+          local resp = vim.json.decode(output)
+          local respBody = resp.data.addComment.commentEdge.node.body
+          local respId = resp.data.addComment.commentEdge.node.id
+          if utils.trim(comment_metadata.body) == utils.trim(respBody) then
+            local comments = self.commentsMetadata
+            for i, c in ipairs(comments) do
+              if tonumber(c.id) == -1 then
+                comments[i].id = respId
+                comments[i].savedBody = respBody
+                comments[i].dirty = false
+                break
+              end
             end
+            self:render_signs()
           end
-          self:render_signs()
-        end
-      end
-    end,
+        end,
+      },
+    },
   }
 end
 
@@ -504,70 +504,70 @@ function OctoBuffer:do_add_thread_comment(comment_metadata)
     comment_metadata.body,
     comment_metadata.reviewId
   )
-  gh.run {
-    args = { "api", "graphql", "-f", string.format("query=%s", query) },
-    cb = function(output, stderr)
-      if stderr and not utils.is_blank(stderr) then
-        utils.print_err(stderr)
-      elseif output then
-        ---@type octo.mutations.AddPullRequestReviewComment
-        local resp = vim.json.decode(output)
-        local resp_comment = resp.data.addPullRequestReviewComment.comment
-        local comment_end ---@type integer
-        if utils.trim(comment_metadata.body) == utils.trim(resp_comment.body) then
-          local comments = self.commentsMetadata
-          for i, c in ipairs(comments) do
-            if tonumber(c.id) == -1 then
-              comments[i].id = resp_comment.id
-              comments[i].savedBody = resp_comment.body
-              comments[i].dirty = false
-              comment_end = comments[i].endLine
-              break
-            end
-          end
-
-          local threads = resp_comment.pullRequest.reviewThreads.nodes
-          local review = require("octo.reviews").get_current_review()
-          if review then
-            review:update_threads(threads)
-          end
-
-          self:render_signs()
-
-          -- update thread map
-          local thread_id ---@type string
-          for _, thread in ipairs(threads) do
-            for _, c in ipairs(thread.comments.nodes) do
-              if c.id == resp_comment.id then
-                thread_id = thread.id
+  gh.api.graphql {
+    f = { query = query },
+    opts = {
+      cb = gh.create_callback {
+        success = function(output)
+          ---@type octo.mutations.AddPullRequestReviewComment
+          local resp = vim.json.decode(output)
+          local resp_comment = resp.data.addPullRequestReviewComment.comment
+          local comment_end ---@type integer
+          if utils.trim(comment_metadata.body) == utils.trim(resp_comment.body) then
+            local comments = self.commentsMetadata
+            for i, c in ipairs(comments) do
+              if tonumber(c.id) == -1 then
+                comments[i].id = resp_comment.id
+                comments[i].savedBody = resp_comment.body
+                comments[i].dirty = false
+                comment_end = comments[i].endLine
                 break
               end
             end
-          end
-          local mark_id ---@type integer
-          for markId, threadMetadata in pairs(self.threadsMetadata) do
-            if threadMetadata.threadId == thread_id then
-              mark_id = markId
+
+            local threads = resp_comment.pullRequest.reviewThreads.nodes
+            local review = require("octo.reviews").get_current_review()
+            if review then
+              review:update_threads(threads)
             end
+
+            self:render_signs()
+
+            -- update thread map
+            local thread_id ---@type string
+            for _, thread in ipairs(threads) do
+              for _, c in ipairs(thread.comments.nodes) do
+                if c.id == resp_comment.id then
+                  thread_id = thread.id
+                  break
+                end
+              end
+            end
+            local mark_id ---@type integer
+            for markId, threadMetadata in pairs(self.threadsMetadata) do
+              if threadMetadata.threadId == thread_id then
+                mark_id = markId
+              end
+            end
+            local extmark = vim.api.nvim_buf_get_extmark_by_id(
+              self.bufnr,
+              constants.OCTO_THREAD_NS,
+              tonumber(mark_id) --[[@as integer]],
+              { details = true }
+            )
+            local thread_start = extmark[1]
+            -- update extmark
+            vim.api.nvim_buf_del_extmark(self.bufnr, constants.OCTO_THREAD_NS, tonumber(mark_id) --[[@as integer]])
+            local thread_mark_id = vim.api.nvim_buf_set_extmark(self.bufnr, constants.OCTO_THREAD_NS, thread_start, 0, {
+              end_line = comment_end + 2,
+              end_col = 0,
+            })
+            self.threadsMetadata[tostring(thread_mark_id)] = self.threadsMetadata[tostring(mark_id)]
+            self.threadsMetadata[tostring(mark_id)] = nil
           end
-          local extmark = vim.api.nvim_buf_get_extmark_by_id(
-            self.bufnr,
-            constants.OCTO_THREAD_NS,
-            tonumber(mark_id) --[[@as integer]],
-            { details = true }
-          )
-          local thread_start = extmark[1]
-          -- update extmark
-          vim.api.nvim_buf_del_extmark(self.bufnr, constants.OCTO_THREAD_NS, tonumber(mark_id) --[[@as integer]])
-          local thread_mark_id = vim.api.nvim_buf_set_extmark(self.bufnr, constants.OCTO_THREAD_NS, thread_start, 0, {
-            end_line = comment_end + 2,
-            end_col = 0,
-          })
-          self.threadsMetadata[tostring(thread_mark_id)] = self.threadsMetadata[tostring(mark_id)]
-          self.threadsMetadata[tostring(mark_id)] = nil
-        end
-      end
-    end,
+        end,
+      },
+    },
   }
 end
 
@@ -736,38 +736,38 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
         comment_metadata.path,
         position
       )
-      gh.run {
-        args = { "api", "graphql", "-f", string.format("query=%s", query) },
-        cb = function(output, stderr)
-          if stderr and not utils.is_blank(stderr) then
-            utils.print_err(stderr)
-          elseif output then
-            ---@type octo.mutations.AddPullRequestReviewCommitThread
-            local r = vim.json.decode(output)
-            local resp = r.data.addPullRequestReviewComment
-            if not utils.is_blank(resp.comment) then
-              if utils.trim(comment_metadata.body) == utils.trim(resp.comment.body) then
-                local comments = self.commentsMetadata
-                for i, c in ipairs(comments) do
-                  if tonumber(c.id) == -1 then
-                    comments[i].id = resp.comment.id
-                    comments[i].savedBody = resp.comment.body
-                    comments[i].dirty = false
-                    break
+      gh.api.graphql {
+        f = { query = query },
+        opts = {
+          cb = gh.create_callback {
+            success = function(output)
+              ---@type octo.mutations.AddPullRequestReviewCommitThread
+              local r = vim.json.decode(output)
+              local resp = r.data.addPullRequestReviewComment
+              if not utils.is_blank(resp.comment) then
+                if utils.trim(comment_metadata.body) == utils.trim(resp.comment.body) then
+                  local comments = self.commentsMetadata
+                  for i, c in ipairs(comments) do
+                    if tonumber(c.id) == -1 then
+                      comments[i].id = resp.comment.id
+                      comments[i].savedBody = resp.comment.body
+                      comments[i].dirty = false
+                      break
+                    end
                   end
+                  if review then
+                    local threads = resp.comment.pullRequest.reviewThreads.nodes
+                    review:update_threads(threads)
+                  end
+                  self:render_signs()
                 end
-                if review then
-                  local threads = resp.comment.pullRequest.reviewThreads.nodes
-                  review:update_threads(threads)
-                end
-                self:render_signs()
+              else
+                utils.error "Failed to create thread"
+                return
               end
-            else
-              utils.error "Failed to create thread"
-              return
-            end
-          end
-        end,
+            end,
+          },
+        },
       }
     end
   end
@@ -833,45 +833,45 @@ function OctoBuffer:do_update_comment(comment_metadata)
   elseif comment_metadata.kind == "DiscussionComment" then
     update_query = graphql("update_discussion_comment_mutation", comment_metadata.id, comment_metadata.body)
   end
-  gh.run {
-    args = { "api", "graphql", "-f", string.format("query=%s", update_query) },
-    cb = function(output, stderr)
-      if stderr and not utils.is_blank(stderr) then
-        utils.print_err(stderr)
-      elseif output then
-        ---@type octo.mutations.UpdateIssueComment|octo.mutations.UpdateDiscussionComment|octo.mutations.UpdatePullRequestReviewComment|octo.mutations.UpdatePullRequestReview
-        local resp = vim.json.decode(output)
+  gh.api.graphql {
+    f = { query = update_query },
+    opts = {
+      cb = gh.create_callback {
+        success = function(output)
+          ---@type octo.mutations.UpdateIssueComment|octo.mutations.UpdateDiscussionComment|octo.mutations.UpdatePullRequestReviewComment|octo.mutations.UpdatePullRequestReview
+          local resp = vim.json.decode(output)
 
-        local resp_comment ---@type { body: string }?
-        if comment_metadata.kind == "IssueComment" then
-          resp_comment = resp.data.updateIssueComment.issueComment
-        elseif comment_metadata.kind == "DiscussionComment" then
-          resp_comment = resp.data.updateDiscussionComment.comment
-        elseif comment_metadata.kind == "PullRequestReviewComment" then
-          resp_comment = resp.data.updatePullRequestReviewComment.pullRequestReviewComment
-          local threads =
-            resp.data.updatePullRequestReviewComment.pullRequestReviewComment.pullRequest.reviewThreads.nodes
-          local review = require("octo.reviews").get_current_review()
-          if review then
-            review:update_threads(threads)
-          end
-        elseif comment_metadata.kind == "PullRequestReview" then
-          resp_comment = resp.data.updatePullRequestReview.pullRequestReview
-        end
-
-        if resp_comment and utils.trim(comment_metadata.body) == utils.trim(resp_comment.body) then
-          local comments = self.commentsMetadata
-          for i, c in ipairs(comments) do
-            if c.id == comment_metadata.id then
-              comments[i].savedBody = comment_metadata.body
-              comments[i].dirty = false
-              break
+          local resp_comment ---@type { body: string }?
+          if comment_metadata.kind == "IssueComment" then
+            resp_comment = resp.data.updateIssueComment.issueComment
+          elseif comment_metadata.kind == "DiscussionComment" then
+            resp_comment = resp.data.updateDiscussionComment.comment
+          elseif comment_metadata.kind == "PullRequestReviewComment" then
+            resp_comment = resp.data.updatePullRequestReviewComment.pullRequestReviewComment
+            local threads =
+              resp.data.updatePullRequestReviewComment.pullRequestReviewComment.pullRequest.reviewThreads.nodes
+            local review = require("octo.reviews").get_current_review()
+            if review then
+              review:update_threads(threads)
             end
+          elseif comment_metadata.kind == "PullRequestReview" then
+            resp_comment = resp.data.updatePullRequestReview.pullRequestReview
           end
-          self:render_signs()
-        end
-      end
-    end,
+
+          if resp_comment and utils.trim(comment_metadata.body) == utils.trim(resp_comment.body) then
+            local comments = self.commentsMetadata
+            for i, c in ipairs(comments) do
+              if c.id == comment_metadata.id then
+                comments[i].savedBody = comment_metadata.body
+                comments[i].dirty = false
+                break
+              end
+            end
+            self:render_signs()
+          end
+        end,
+      },
+    },
   }
 end
 

--- a/lua/octo/pickers/fzf-lua/previewers.lua
+++ b/lua/octo/pickers/fzf-lua/previewers.lua
@@ -70,32 +70,34 @@ function M.issue(formatted_issues)
     elseif entry.kind == "pull_request" then
       query = graphql("pull_request_query", owner, name, number, _G.octo_pv2_fragment)
     end
-    gh.run {
-      args = { "api", "graphql", "-f", string.format("query=%s", query) },
-      cb = function(output, stderr)
-        if stderr and not utils.is_blank(stderr) then
-          utils.print_err(stderr)
-        elseif output and self.preview_bufnr == tmpbuf and vim.api.nvim_buf_is_valid(tmpbuf) then
-          local result = vim.json.decode(output)
-          local obj
-          if entry.kind == "issue" then
-            obj = result.data.repository.issue
-          elseif entry.kind == "pull_request" then
-            obj = result.data.repository.pullRequest
-          end
+    gh.api.graphql {
+      f = { query = query },
+      opts = {
+        cb = gh.create_callback {
+          success = function(output)
+            if self.preview_bufnr == tmpbuf and vim.api.nvim_buf_is_valid(tmpbuf) then
+              local result = vim.json.decode(output)
+              local obj
+              if entry.kind == "issue" then
+                obj = result.data.repository.issue
+              elseif entry.kind == "pull_request" then
+                obj = result.data.repository.pullRequest
+              end
 
-          local state = utils.get_displayed_state(entry.kind == "issue", obj.state, obj.stateReason)
+              local state = utils.get_displayed_state(entry.kind == "issue", obj.state, obj.stateReason)
 
-          writers.write_title(tmpbuf, obj.title, 1)
-          writers.write_details(tmpbuf, obj, false, true) -- include_status = true for preview
-          writers.write_body(tmpbuf, obj)
-          writers.write_state(tmpbuf, state:upper(), number)
-          local reactions_line = vim.api.nvim_buf_line_count(tmpbuf) - 1
-          writers.write_block(tmpbuf, { "", "" }, reactions_line)
-          writers.write_reactions(tmpbuf, obj.reactionGroups, reactions_line)
-          vim.bo[tmpbuf].filetype = "octo"
-        end
-      end,
+              writers.write_title(tmpbuf, obj.title, 1)
+              writers.write_details(tmpbuf, obj, false, true) -- include_status = true for preview
+              writers.write_body(tmpbuf, obj)
+              writers.write_state(tmpbuf, state:upper(), number)
+              local reactions_line = vim.api.nvim_buf_line_count(tmpbuf) - 1
+              writers.write_block(tmpbuf, { "", "" }, reactions_line)
+              writers.write_reactions(tmpbuf, obj.reactionGroups, reactions_line)
+              vim.bo[tmpbuf].filetype = "octo"
+            end
+          end,
+        },
+      },
     }
 
     self:set_preview_buf(tmpbuf)
@@ -130,32 +132,34 @@ function M.search()
     elseif kind == "pull_request" then
       query = graphql("pull_request_query", owner, name, number, _G.octo_pv2_fragment)
     end
-    gh.run {
-      args = { "api", "graphql", "-f", string.format("query=%s", query) },
-      cb = function(output, stderr)
-        if stderr and not utils.is_blank(stderr) then
-          utils.print_err(stderr)
-        elseif output and self.preview_bufnr == tmpbuf and vim.api.nvim_buf_is_valid(tmpbuf) then
-          local result = vim.json.decode(output)
-          local obj
-          if kind == "issue" then
-            obj = result.data.repository.issue
-          elseif kind == "pull_request" then
-            obj = result.data.repository.pullRequest
-          end
+    gh.api.graphql {
+      f = { query = query },
+      opts = {
+        cb = gh.create_callback {
+          success = function(output)
+            if self.preview_bufnr == tmpbuf and vim.api.nvim_buf_is_valid(tmpbuf) then
+              local result = vim.json.decode(output)
+              local obj
+              if kind == "issue" then
+                obj = result.data.repository.issue
+              elseif kind == "pull_request" then
+                obj = result.data.repository.pullRequest
+              end
 
-          local state = utils.get_displayed_state(kind == "issue", obj.state, obj.stateReason)
+              local state = utils.get_displayed_state(kind == "issue", obj.state, obj.stateReason)
 
-          writers.write_title(tmpbuf, obj.title, 1)
-          writers.write_details(tmpbuf, obj, false, true) -- include_status = true for preview
-          writers.write_body(tmpbuf, obj)
-          writers.write_state(tmpbuf, state:upper(), number)
-          local reactions_line = vim.api.nvim_buf_line_count(tmpbuf) - 1
-          writers.write_block(tmpbuf, { "", "" }, reactions_line)
-          writers.write_reactions(tmpbuf, obj.reactionGroups, reactions_line)
-          vim.bo[tmpbuf].filetype = "octo"
-        end
-      end,
+              writers.write_title(tmpbuf, obj.title, 1)
+              writers.write_details(tmpbuf, obj, false, true) -- include_status = true for preview
+              writers.write_body(tmpbuf, obj)
+              writers.write_state(tmpbuf, state:upper(), number)
+              local reactions_line = vim.api.nvim_buf_line_count(tmpbuf) - 1
+              writers.write_block(tmpbuf, { "", "" }, reactions_line)
+              writers.write_reactions(tmpbuf, obj.reactionGroups, reactions_line)
+              vim.bo[tmpbuf].filetype = "octo"
+            end
+          end,
+        },
+      },
     }
 
     self:set_preview_buf(tmpbuf)

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -42,16 +42,16 @@ end
 ---@param callback fun(obj: octo.mutations.StartReview): nil
 function Review:create(callback)
   local query = graphql("start_review_mutation", self.pull_request.id)
-  gh.run {
-    args = { "api", "graphql", "-f", string.format("query=%s", query) },
-    cb = function(output, stderr)
-      if stderr and not utils.is_blank(stderr) then
-        utils.error(stderr)
-      elseif output then
-        local resp = vim.json.decode(output)
-        callback(resp)
-      end
-    end,
+  gh.api.graphql {
+    f = { query = query },
+    opts = {
+      cb = gh.create_callback {
+        success = function(output)
+          local resp = vim.json.decode(output)
+          callback(resp)
+        end,
+      },
+    },
   }
 end
 
@@ -282,19 +282,19 @@ function Review:discard(opts)
 
           if choice == 1 then
             local delete_query = graphql("delete_pull_request_review_mutation", self.id --[[@as string]])
-            gh.run {
-              args = { "api", "graphql", "-f", string.format("query=%s", delete_query) },
-              cb = function(output_inner, stderr_inner)
-                if stderr_inner and not utils.is_blank(stderr_inner) then
-                  utils.error(stderr_inner)
-                elseif output_inner then
-                  self.id = default_id
-                  self.threads = {}
-                  self.files = {}
-                  utils.info "Pending review discarded"
-                  vim.cmd [[tabclose]]
-                end
-              end,
+            gh.api.graphql {
+              f = { query = delete_query },
+              opts = {
+                cb = gh.create_callback {
+                  success = function()
+                    self.id = default_id
+                    self.threads = {}
+                    self.files = {}
+                    utils.info "Pending review discarded"
+                    vim.cmd [[tabclose]]
+                  end,
+                },
+              },
             }
           end
         end
@@ -363,17 +363,17 @@ function Review:submit(event)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, default_id, false)
   local body = utils.escape_char(utils.trim(table.concat(lines, "\n")))
   local query = graphql("submit_pull_request_review_mutation", review_id, event, body, { escape = false })
-  gh.run {
-    args = { "api", "graphql", "-f", string.format("query=%s", query) },
-    cb = function(output, stderr)
-      if stderr and not utils.is_blank(stderr) then
-        utils.error(stderr)
-      elseif output then
-        utils.info "Review was submitted successfully!"
-        pcall(vim.api.nvim_win_close, winid, 0)
-        self.layout:close()
-      end
-    end,
+  gh.api.graphql {
+    f = { query = query },
+    opts = {
+      cb = gh.create_callback {
+        success = function()
+          utils.info "Review was submitted successfully!"
+          pcall(vim.api.nvim_win_close, winid, 0)
+          self.layout:close()
+        end,
+      },
+    },
   }
 end
 

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -1711,28 +1711,30 @@ function M.get_pull_request_for_current_branch(cb)
         local number = pr.number
         local id = pr.id
         local query = graphql("pull_request_query", base_owner, base_name, number, _G.octo_pv2_fragment)
-        gh.run {
-          args = { "api", "graphql", "--paginate", "--jq", ".", "-f", string.format("query=%s", query) },
-          cb = function(output, stderr)
-            if stderr and not M.is_blank(stderr) then
-              M.print_err(stderr)
-            elseif output then
-              local resp = M.aggregate_pages(output, "data.repository.pullRequest.timelineItems.nodes")
-              ---@type octo.PullRequest
-              local obj = resp.data.repository.pullRequest
-              local PullRequest = require "octo.model.pull-request"
+        gh.api.graphql {
+          f = { query = query },
+          paginate = true,
+          jq = ".",
+          opts = {
+            cb = gh.create_callback {
+              success = function(output)
+                local resp = M.aggregate_pages(output, "data.repository.pullRequest.timelineItems.nodes")
+                ---@type octo.PullRequest
+                local obj = resp.data.repository.pullRequest
+                local PullRequest = require "octo.model.pull-request"
 
-              local opts = {
-                repo = base_owner .. "/" .. base_name,
-                head_repo = obj.headRepository.nameWithOwner,
-                number = number,
-                id = id,
-                head_ref_name = obj.headRefName,
-              }
+                local opts = {
+                  repo = base_owner .. "/" .. base_name,
+                  head_repo = obj.headRepository.nameWithOwner,
+                  number = number,
+                  id = id,
+                  head_ref_name = obj.headRefName,
+                }
 
-              PullRequest.create_with_merge_base(opts, obj, cb)
-            end
-          end,
+                PullRequest.create_with_merge_base(opts, obj, cb)
+              end,
+            },
+          },
         }
       end
     end,


### PR DESCRIPTION
Replaces all `gh.run { args = { "api", "graphql", ... } }` call sites with `gh.api.graphql { ... }` + `gh.create_callback`.

Part of the Option A migration discussed in #876.

## Sites migrated

- `commands.lua` — `delete_*_comment`, `resolve/unresolve_review_thread`, `add/remove_reaction`, `add/update/delete_project_v2_card`, `remove_assignees`
- `model/octo-buffer.lua` — `add_issue_comment`, `add_pull_request_review_comment`, `add_pull_request_review_commit_thread`, `update_*_comment`
- `reviews/init.lua` — `start_review`, `delete_pull_request_review`, `submit_pull_request_review`
- `pickers/fzf-lua/previewers.lua` — issue/PR and search previewers
- `utils.lua` — paginated `pull_request_query` (`paginate = true, jq = "."`)

Intentional `gh.run` REST calls (diff fetch, `pr view --json`, REST reply endpoint) are left untouched.