### PR TITLE
ci(tests): add nightly Neovim to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,45 +12,27 @@ on:
 
 jobs:
   x64-ubuntu:
-    name: X64-ubuntu
-    runs-on: ${{ matrix.os }}
+    name: X64-ubuntu (${{ matrix.nvim_version }})
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-22.04
-            manager: sudo apt-get
-            packages: -y fd-find
+        nvim_version: [stable, nightly]
     steps:
       - uses: actions/checkout@v6
-      - run: date +%F > todays-date
-      - name: Restore neovim from cache
-        uses: actions/cache@v5
+      - uses: rhysd/action-setup-vim@v1
         with:
-          path: _neovim
-          key: ${{ runner.os }}-latest-${{ hashFiles('todays-date') }}
+          neovim: true
+          version: ${{ matrix.nvim_version }}
       - name: Restore plenary.nvim from cache
         uses: actions/cache@v5
         with:
           path: ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
-          key: ${{ runner.os }}-plenary-${{ hashFiles('todays-date') }}
-      - name: Prepare
-        env:
-          GH_TOKEN: ${{ github.token }}
+          key: ${{ runner.os }}-plenary-${{ matrix.nvim_version }}
+      - name: Install plenary.nvim
         run: |
-          ${{ matrix.manager }} update
-          ${{ matrix.manager }} install ${{ matrix.packages }}
-          latest_version=$(gh release list --limit 1 --repo neovim/neovim --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName')
-          url="https://github.com/neovim/neovim/releases/download/$latest_version/nvim-linux-x86_64.tar.gz"
-          test -d _neovim || {
-            mkdir -p _neovim
-            curl -sL $url | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
-          }
           mkdir -p ~/.local/share/nvim/site/pack/vendor/start
           test -d ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim || git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
           ln -s $(pwd) ~/.local/share/nvim/site/pack/vendor/start
       - name: Run tests
-        run: |
-          export PATH="${PWD}/_neovim/bin:${PATH}"
-          export VIM="${PWD}/_neovim/share/nvim/runtime"
-          nvim --headless -c "PlenaryBustedDirectory lua/tests/plenary/ {minimal_init = 'lua/tests/minimal_init.vim'}"
+        run: nvim --headless -c "PlenaryBustedDirectory lua/tests/plenary/ {minimal_init = 'lua/tests/minimal_init.vim'}"


### PR DESCRIPTION
Extends the test matrix to include Neovim nightly alongside stable, following the same pattern used by telescope.nvim, gitsigns.nvim, and lualine.nvim.

- Replaces the bespoke Neovim download script with `rhysd/action-setup-vim@v1`
- `fail-fast: false` ensures a nightly failure does not cancel or block the stable result
- Job names now include the Neovim version for easy identification in the Actions UI