### PR TITLE
fix: replace hardcoded diff highlight colors with configurable groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,6 +839,8 @@ Also, you can use [`cmp-emoji`](https://github.com/hrsh7th/cmp-emoji) or [`blink
 | _OctoStateClosedFloat_            | OctoRedFloat       |
 | _OctoStateMergedFloat_            | OctoPurpleFloat    |
 | _OctoStateDraftFloat_             | OctoGreyFloat      |
+| _OctoReviewDiffDeleteText_        | OctoRed            |
+| _OctoReviewDiffAddText_           | OctoGreen          |
 
 The term `GitHub color` refers to the colors used in the WebUI.
 The (addition) `viewer` means the user of the plugin or more precisely the user authenticated via the `gh` CLI tool used to retrieve the data from GitHub.

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -558,6 +558,8 @@ HIGHLIGHT GROUPS                                *octo-highlights*
   `OctoStateChangesRequested`   `OctoStateClosed`
   `OctoStateCommented`          `Normal`
   `OctoStateDismissed`          `OctoStateClosed`
+  `OctoReviewDiffDeleteText`    GitHub color
+  `OctoReviewDiffAddText`       GitHub color
 
 The term "GitHub color" refers to the colors used in the WebUI.
 

--- a/lua/octo/reviews/layout.lua
+++ b/lua/octo/reviews/layout.lua
@@ -82,12 +82,12 @@ end
 function Layout:init_layout()
   self.left_winid = vim.api.nvim_get_current_win()
   vim.api.nvim_win_set_hl_ns(self.left_winid, constants.OCTO_REVIEW_LEFT_HIGHLIGHT_NS)
-  vim.api.nvim_set_hl(constants.OCTO_REVIEW_LEFT_HIGHLIGHT_NS, "DiffText", { background = "#5d425a" })
+  vim.api.nvim_set_hl(constants.OCTO_REVIEW_LEFT_HIGHLIGHT_NS, "DiffText", { link = "OctoReviewDiffDeleteText" })
   vim.api.nvim_set_hl(constants.OCTO_REVIEW_LEFT_HIGHLIGHT_NS, "DiffChange", { link = "DiffDelete" })
   vim.cmd "belowright vsp"
   self.right_winid = vim.api.nvim_get_current_win()
   vim.api.nvim_win_set_hl_ns(self.right_winid, constants.OCTO_REVIEW_RIGHT_HIGHLIGHT_NS)
-  vim.api.nvim_set_hl(constants.OCTO_REVIEW_RIGHT_HIGHLIGHT_NS, "DiffText", { background = "#39556f" })
+  vim.api.nvim_set_hl(constants.OCTO_REVIEW_RIGHT_HIGHLIGHT_NS, "DiffText", { link = "OctoReviewDiffAddText" })
   vim.api.nvim_set_hl(constants.OCTO_REVIEW_RIGHT_HIGHLIGHT_NS, "DiffChange", { link = "DiffAdd" })
   self.file_panel:open()
 end

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -56,6 +56,8 @@ local function get_hl_groups()
     Strikethrough = { fg = colors.grey, strikethrough = true },
     Underline = { fg = colors.white, underline = true },
     Bubble = { fg = colors.white, bg = colors.grey },
+    ReviewDiffDeleteText = { fg = colors.white, bg = colors.dark_red },
+    ReviewDiffAddText = { fg = colors.white, bg = colors.dark_green },
   }
 end
 


### PR DESCRIPTION
## 📋  Summary

This PR attempts to solve this issue: https://github.com/pwntester/octo.nvim/issues/1472

Currently, the highlight groups for `DiffText` in review mode are hardcoded, which makes users unable to customize them. This causes an issue on light theme users like myself, since the hardcoded colors were meant to look good only on dark themes.

We can solve this by introducing two new highlight groups:
- `OctoReviewDiffDeleteText`
- `OctoReviewDiffAddText`

Users can configure these highlight groups to customise the review diff appearance.

_Disclaimer: I've used Claude Code to help me solve the issue._

## 📷 Screenshots

| Case | Screenshot |
| - | - |
| Before | <img width="1883" height="173" alt="Screenshot 2026-04-27 at 10 08 27" src="https://github.com/user-attachments/assets/dffa63bc-bd2a-4253-a687-22fa4ce15ea0" />|
| After (default colors in light theme) | <img width="1890" height="175" alt="Screenshot 2026-04-27 at 09 32 31" src="https://github.com/user-attachments/assets/4dfda995-75b2-45b4-868f-251023c66a3f" />|
| After (custom colors in light theme) | <img width="1883" height="178" alt="Screenshot 2026-04-27 at 09 41 13" src="https://github.com/user-attachments/assets/fd96fd82-e0b9-432b-b75a-14f0e563dff0" />|
| After (default colors in dark theme) | <img width="1887" height="169" alt="Screenshot 2026-04-27 at 09 32 19" src="https://github.com/user-attachments/assets/3a688f53-93c1-42cc-a951-db24c2045673" />|


