### PR TITLE
feat(pr-checks): copy check URL

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2199,6 +2199,20 @@ function M.pr_checks(buffer)
       end,
     })
 
+    vim.api.nvim_buf_set_keymap(wbufnr, "n", mappings.copy_url.lhs, "", {
+      noremap = true,
+      silent = true,
+      callback = function()
+        local line_number = vim.api.nvim_win_get_cursor(0)[1]
+        local url = data[line_number].link
+        if not url or url == "" then
+          utils.error "No URL for this check"
+          return
+        end
+        utils.copy_url(url)
+      end,
+    })
+
     vim.api.nvim_buf_set_keymap(wbufnr, "n", mappings.rerun.lhs, "", {
       noremap = true,
       silent = true,


### PR DESCRIPTION
feat(pr-checks): copy check URL

Add a copy-url action in the PR checks popup so you can grab the current check's URL with the configured keybinding.

```text
In PR checks
- press <C-y> (or your mapped key) to copy the current check URL
```

Uses the existing mappings.runs.copy_url configuration used by workflow run views.