### PR TITLE
feat!: add file panel icon callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ From any octo buffer, press `<CR>` in normal mode to see common actions.
   - [fzf-lua](https://github.com/ibhagwan/fzf-lua)
   - [snacks.nvim](https://github.com/folke/snacks.nvim)
   - default picker uses `vim.ui.select`
-- Install [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)
+- Install [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) for file panel icons, or configure `file_panel.get_icon`
 
 After installation, run `:checkhealth octo` to verify your setup.
 
@@ -176,7 +176,7 @@ For a basic installation using [`lazy.nvim`](https://lazy.folke.io/), try:
     "nvim-telescope/telescope.nvim",
     -- OR "ibhagwan/fzf-lua",
     -- OR "folke/snacks.nvim",
-    "nvim-tree/nvim-web-devicons",
+    "nvim-tree/nvim-web-devicons", -- optional if file_panel.get_icon is configured
   },
 }
 ```
@@ -331,7 +331,8 @@ require"octo".setup {
   },
   file_panel = {
     size = 10, -- changed files panel rows
-    use_icons = true, -- use web-devicons in file panel (if false, nvim-web-devicons does not need to be installed)
+    use_icons = true, -- show icons in file panel
+    get_icon = nil, -- callback to provide file panel icons and highlights: function(name, ext) return icon, hl end
   },
   colors = { -- used for highlight groups (see Colors section below)
     white = "#ffffff",
@@ -573,6 +574,22 @@ require"octo".setup {
 }
 ```
 <!-- END_CONFIG -->
+
+### File panel icon callback
+
+Set `file_panel.get_icon` to use a custom file icon provider. The callback receives
+the file name and extension and should return an icon and optional highlight group.
+
+```lua
+require("octo").setup({
+  file_panel = {
+    use_icons = true,
+    get_icon = function(name, _ext)
+      return require("mini.icons").get("file", name)
+    end,
+  },
+})
+```
 
 ## 🤖 Commands
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ From any octo buffer, press `<CR>` in normal mode to see common actions.
   - [fzf-lua](https://github.com/ibhagwan/fzf-lua)
   - [snacks.nvim](https://github.com/folke/snacks.nvim)
   - default picker uses `vim.ui.select`
-- Install [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) for file panel icons, or configure `file_panel.get_icon`
+- Install [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) for file panel icons, or configure `file_panel.icons`
 
 After installation, run `:checkhealth octo` to verify your setup.
 
@@ -176,7 +176,7 @@ For a basic installation using [`lazy.nvim`](https://lazy.folke.io/), try:
     "nvim-telescope/telescope.nvim",
     -- OR "ibhagwan/fzf-lua",
     -- OR "folke/snacks.nvim",
-    "nvim-tree/nvim-web-devicons", -- optional if file_panel.get_icon is configured
+    "nvim-tree/nvim-web-devicons", -- optional if file_panel.icons is a function
   },
 }
 ```
@@ -331,8 +331,7 @@ require"octo".setup {
   },
   file_panel = {
     size = 10, -- changed files panel rows
-    use_icons = true, -- show icons in file panel
-    get_icon = nil, -- callback to provide file panel icons and highlights: function(name, ext) return icon, hl end
+    icons = true, -- true = nvim-web-devicons, false = disabled, function = custom provider
   },
   colors = { -- used for highlight groups (see Colors section below)
     white = "#ffffff",
@@ -575,16 +574,18 @@ require"octo".setup {
 ```
 <!-- END_CONFIG -->
 
-### File panel icon callback
+### File panel icons
 
-Set `file_panel.get_icon` to use a custom file icon provider. The callback receives
-the file name and extension and should return an icon and optional highlight group.
+Configure file panel icons with `file_panel.icons`:
+
+- `true`: use `nvim-web-devicons`
+- `false`: disable icons
+- `function(name, ext)`: return `icon, hl`
 
 ```lua
 require("octo").setup({
   file_panel = {
-    use_icons = true,
-    get_icon = function(name, _ext)
+    icons = function(name, _ext)
       return require("mini.icons").get("file", name)
     end,
   },

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -24,7 +24,7 @@ Run `:checkhealth octo` to verify your installation. The report covers:
 
 - `octo.nvim`      setup() was called
 - `Neovim version` minimum and recommended version requirements
-- `Dependencies`   gh CLI binary, plenary.nvim, picker plugin, nvim-web-devicons
+- `Dependencies`   gh CLI binary, plenary.nvim, picker plugin, file panel icon provider
 - `Authentication` active GitHub account, token source, and token scopes
 
 If any check fails, follow the advice shown in the report.

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -63,6 +63,7 @@ local M = {}
 ---@class OctoConfigFilePanel
 ---@field size number
 ---@field use_icons boolean
+---@field get_icon? fun(name: string, ext: string): string?, string?
 
 ---@class OctoConfigUi
 ---@field use_signcolumn boolean
@@ -311,7 +312,8 @@ function M.get_default_values()
     },
     file_panel = {
       size = 10, -- changed files panel rows
-      use_icons = true, -- use web-devicons in file panel (if false, nvim-web-devicons does not need to be installed)
+      use_icons = true, -- show icons in file panel
+      get_icon = nil, -- callback to provide file panel icons and highlights: function(name, ext) return icon, hl end
     },
     colors = { -- used for highlight groups (see Colors section below)
       white = "#ffffff",
@@ -795,6 +797,7 @@ function M.validate_config()
     if validate_type(config.file_panel, "file_panel", "table") then
       validate_type(config.file_panel.size, "file_panel.size", "number")
       validate_type(config.file_panel.use_icons, "file_panel.use_icons", "boolean")
+      validate_type(config.file_panel.get_icon, "file_panel.get_icon", { "nil", "function" })
     end
     validate_aliases()
     validate_pickers()

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -62,8 +62,7 @@ local M = {}
 
 ---@class OctoConfigFilePanel
 ---@field size number
----@field use_icons boolean
----@field get_icon? fun(name: string, ext: string): string?, string?
+---@field icons boolean|fun(name: string, ext: string): string?, string?
 
 ---@class OctoConfigUi
 ---@field use_signcolumn boolean
@@ -312,8 +311,7 @@ function M.get_default_values()
     },
     file_panel = {
       size = 10, -- changed files panel rows
-      use_icons = true, -- show icons in file panel
-      get_icon = nil, -- callback to provide file panel icons and highlights: function(name, ext) return icon, hl end
+      icons = true, -- true = nvim-web-devicons, false = disabled, function = custom provider
     },
     colors = { -- used for highlight groups (see Colors section below)
       white = "#ffffff",
@@ -796,8 +794,16 @@ function M.validate_config()
     validate_notifications()
     if validate_type(config.file_panel, "file_panel", "table") then
       validate_type(config.file_panel.size, "file_panel.size", "number")
-      validate_type(config.file_panel.use_icons, "file_panel.use_icons", "boolean")
-      validate_type(config.file_panel.get_icon, "file_panel.get_icon", { "nil", "function" })
+      validate_type(config.file_panel.icons, "file_panel.icons", { "boolean", "function" })
+      if config.file_panel.use_icons ~= nil then
+        err("file_panel.use_icons", "`file_panel.use_icons` is no longer supported; use `file_panel.icons = false`")
+      end
+      if config.file_panel.get_icon ~= nil then
+        err(
+          "file_panel.get_icon",
+          "`file_panel.get_icon` is no longer supported; use `file_panel.icons = function(name, ext) ... end`"
+        )
+      end
     end
     validate_aliases()
     validate_pickers()

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -795,10 +795,10 @@ function M.validate_config()
     if validate_type(config.file_panel, "file_panel", "table") then
       validate_type(config.file_panel.size, "file_panel.size", "number")
       validate_type(config.file_panel.icons, "file_panel.icons", { "boolean", "function" })
-      if config.file_panel.use_icons ~= nil then
+      if rawget(config.file_panel, "use_icons") ~= nil then
         err("file_panel.use_icons", "`file_panel.use_icons` is no longer supported; use `file_panel.icons = false`")
       end
-      if config.file_panel.get_icon ~= nil then
+      if rawget(config.file_panel, "get_icon") ~= nil then
         err(
           "file_panel.get_icon",
           "`file_panel.get_icon` is no longer supported; use `file_panel.icons = function(name, ext) ... end`"

--- a/lua/octo/health.lua
+++ b/lua/octo/health.lua
@@ -128,19 +128,23 @@ local function check_picker()
   end
 end
 
---- Check that nvim-web-devicons is installed when file_panel.use_icons is enabled.
+--- Check that nvim-web-devicons is installed when file_panel.use_icons is enabled
+--- and no custom icon callback is configured.
 local function check_devicons()
   local config = require "octo.config"
   if not config.values.file_panel.use_icons then
     return
   end
+  if config.values.file_panel.get_icon then
+    vim.health.info "`file_panel.get_icon` configured; skipping `nvim-web-devicons` check"
+    return
+  end
   if pcall(require, "nvim-web-devicons") then
     vim.health.ok "`nvim-web-devicons` installed"
   else
-    vim.health.warn(
-      "`nvim-web-devicons` not found.",
-      { "Install nvim-tree/nvim-web-devicons, or set `file_panel.use_icons = false` in your octo.nvim config." }
-    )
+    vim.health.warn("`nvim-web-devicons` not found.", {
+      "Install nvim-tree/nvim-web-devicons, configure `file_panel.get_icon`, or set `file_panel.use_icons = false` in your octo.nvim config.",
+    })
   end
 end
 

--- a/lua/octo/health.lua
+++ b/lua/octo/health.lua
@@ -128,22 +128,22 @@ local function check_picker()
   end
 end
 
---- Check that nvim-web-devicons is installed when file_panel.use_icons is enabled
---- and no custom icon callback is configured.
+--- Check that nvim-web-devicons is installed when file_panel.icons uses the default provider.
 local function check_devicons()
   local config = require "octo.config"
-  if not config.values.file_panel.use_icons then
+  local icons = config.values.file_panel.icons
+  if icons == false then
     return
   end
-  if config.values.file_panel.get_icon then
-    vim.health.info "`file_panel.get_icon` configured; skipping `nvim-web-devicons` check"
+  if type(icons) == "function" then
+    vim.health.info "`file_panel.icons` custom provider configured"
     return
   end
   if pcall(require, "nvim-web-devicons") then
     vim.health.ok "`nvim-web-devicons` installed"
   else
     vim.health.warn("`nvim-web-devicons` not found.", {
-      "Install nvim-tree/nvim-web-devicons, configure `file_panel.get_icon`, or set `file_panel.use_icons = false` in your octo.nvim config.",
+      "Install nvim-tree/nvim-web-devicons, set `file_panel.icons` to a function, or set `file_panel.icons = false`.",
     })
   end
 end

--- a/lua/octo/reviews/renderer.lua
+++ b/lua/octo/reviews/renderer.lua
@@ -98,11 +98,15 @@ function M.get_file_icon(name, ext, render_data, line_idx, offset)
     return " "
   end
 
-  if not web_devicons then
-    web_devicons = require "nvim-web-devicons"
+  local get_icon = config.values.file_panel.get_icon
+  if not get_icon then
+    if not web_devicons then
+      web_devicons = require "nvim-web-devicons"
+    end
+    get_icon = web_devicons.get_icon
   end
 
-  local icon, hl = web_devicons.get_icon(name, ext)
+  local icon, hl = get_icon(name, ext)
 
   if icon then
     if hl then

--- a/lua/octo/reviews/renderer.lua
+++ b/lua/octo/reviews/renderer.lua
@@ -93,13 +93,13 @@ end
 ---@param line_idx integer
 ---@param offset integer
 function M.get_file_icon(name, ext, render_data, line_idx, offset)
-  local use_icons = config.values.file_panel.use_icons
-  if not use_icons then
+  local icons = config.values.file_panel.icons
+  if icons == false then
     return " "
   end
 
-  local get_icon = config.values.file_panel.get_icon
-  if not get_icon then
+  local get_icon = icons
+  if type(get_icon) ~= "function" then
     if not web_devicons then
       web_devicons = require "nvim-web-devicons"
     end

--- a/lua/tests/plenary/config_spec.lua
+++ b/lua/tests/plenary/config_spec.lua
@@ -4,7 +4,7 @@ local eq = assert.are.same
 local user_config = {
   default_remote = { "remote1", "remote2" },
   default_merge_method = "rebase",
-  file_panel = { use_icons = false },
+  file_panel = { icons = false },
   ssh_aliases = {
     ["remote"] = "host",
   },
@@ -31,7 +31,7 @@ describe("Config module:", function()
       eq(merged_config.default_remote[2], "remote2")
       eq(merged_config.default_merge_method, "rebase")
       eq(merged_config.file_panel.size, 10, "file_panel.size should be 10")
-      eq(merged_config.file_panel.use_icons, false, "file_panel.use_icons should be false")
+      eq(merged_config.file_panel.icons, false, "file_panel.icons should be false")
       eq(merged_config.ssh_aliases["remote"], "host")
       eq(merged_config.colors.white, "#AAAAAA")
       eq(merged_config.colors.black, "#000000")
@@ -42,6 +42,43 @@ describe("Config module:", function()
       eq(merged_config.mappings.issue.close_issue.desc, "Close issue")
       eq(merged_config.mappings.pull_request.merge_pr.lhs, "<localleader>pm")
       eq(merged_config.mappings.pull_request.merge_pr.desc, "merge commit PR")
+    end)
+  end)
+
+  describe("validation", function()
+    before_each(function()
+      this.values = this.get_default_values()
+    end)
+
+    it("accepts boolean and function file panel icons values", function()
+      this.values.file_panel.icons = true
+      eq({}, this.validate_config())
+
+      this.values.file_panel.icons = false
+      eq({}, this.validate_config())
+
+      this.values.file_panel.icons = function()
+        return "x"
+      end
+      eq({}, this.validate_config())
+    end)
+
+    it("rejects invalid file panel icons values", function()
+      this.values.file_panel.icons = "invalid"
+
+      assert.True(vim.tbl_count(this.validate_config()) ~= 0)
+    end)
+
+    it("rejects legacy file panel icon options", function()
+      this.values.file_panel.use_icons = false
+      this.values.file_panel.get_icon = function()
+        return "x"
+      end
+
+      local errors = this.validate_config()
+
+      assert.truthy(errors["file_panel.use_icons"])
+      assert.truthy(errors["file_panel.get_icon"])
     end)
   end)
 end)

--- a/lua/tests/plenary/config_spec.lua
+++ b/lua/tests/plenary/config_spec.lua
@@ -64,16 +64,16 @@ describe("Config module:", function()
     end)
 
     it("rejects invalid file panel icons values", function()
-      this.values.file_panel.icons = "invalid"
+      rawset(this.values.file_panel, "icons", "invalid")
 
       assert.True(vim.tbl_count(this.validate_config()) ~= 0)
     end)
 
     it("rejects legacy file panel icon options", function()
-      this.values.file_panel.use_icons = false
-      this.values.file_panel.get_icon = function()
+      rawset(this.values.file_panel, "use_icons", false)
+      rawset(this.values.file_panel, "get_icon", function()
         return "x"
-      end
+      end)
 
       local errors = this.validate_config()
 

--- a/lua/tests/plenary/renderer_spec.lua
+++ b/lua/tests/plenary/renderer_spec.lua
@@ -1,0 +1,76 @@
+local config = require "octo.config"
+local renderer = require "octo.reviews.renderer"
+local eq = assert.are.same
+
+describe("reviews renderer", function()
+  before_each(function()
+    config.values = config.get_default_values()
+  end)
+
+  local function render_data()
+    return {
+      hl = {},
+      add_hl = function(self, group, line_idx, first, last)
+        table.insert(self.hl, {
+          group = group,
+          line_idx = line_idx,
+          first = first,
+          last = last,
+        })
+      end,
+    }
+  end
+
+  it("returns blank spacing when file panel icons are disabled", function()
+    config.values.file_panel.icons = false
+
+    local data = render_data()
+
+    eq(" ", renderer.get_file_icon("README.md", "md", data, 3, 2))
+    eq({}, data.hl)
+  end)
+
+  it("uses a custom file panel icon provider", function()
+    config.values.file_panel.icons = function(name, ext)
+      eq("README.md", name)
+      eq("md", ext)
+      return "R", "OctoCustomIcon"
+    end
+
+    local data = render_data()
+
+    eq("R ", renderer.get_file_icon("README.md", "md", data, 3, 2))
+    eq({
+      {
+        group = "OctoCustomIcon",
+        line_idx = 3,
+        first = 2,
+        last = 4,
+      },
+    }, data.hl)
+  end)
+
+  it("uses nvim-web-devicons when file panel icons are enabled", function()
+    package.loaded["nvim-web-devicons"] = {
+      get_icon = function(name, ext)
+        eq("init.lua", name)
+        eq("lua", ext)
+        return "L", "DevIconLua"
+      end,
+    }
+
+    local data = render_data()
+
+    eq("L ", renderer.get_file_icon("init.lua", "lua", data, 5, 1))
+    eq({
+      {
+        group = "DevIconLua",
+        line_idx = 5,
+        first = 1,
+        last = 3,
+      },
+    }, data.hl)
+
+    package.loaded["nvim-web-devicons"] = nil
+  end)
+end)


### PR DESCRIPTION
### Describe what this PR does / why we need it

Adds a `file_panel.get_icon(name, ext)` callback so users can provide file panel icons from custom providers like `mini.icons` without Octo owning provider-specific integration.

### Does this pull request fix one issue?

Fixes #1511

### Describe how you did it

- Added `file_panel.get_icon` to config defaults, type annotations, and validation.
- Updated the review file panel renderer to call the callback when present, with the existing `nvim-web-devicons` path preserved as the default fallback.
- Updated health/docs so `nvim-web-devicons` is not treated as required when a custom icon callback is configured.
- Avoided adding new Plenary-based tests; verification uses direct headless Neovim checks instead.

### Describe how to verify it

- `stylua --check lua/octo/config.lua lua/octo/reviews/renderer.lua lua/octo/health.lua`
- Headless Neovim checks for callback path, fallback path, and `file_panel.get_icon` validation.
- Full lint/test/typecheck workflows are not currently visible on this PR; verified with stylua and direct headless Neovim checks.

### Special notes for reviews

The callback owns provider-specific lookup. Example:

```lua
file_panel = {
  get_icon = function(name, _ext)
    return require("mini.icons").get("file", name)
  end,
}
```

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
