### PR TITLE
fix(fzf-lua): pop cb from opts in issues picker

### DIFF
--- a/lua/octo/pickers/fzf-lua/pickers/issues.lua
+++ b/lua/octo/pickers/fzf-lua/pickers/issues.lua
@@ -30,6 +30,7 @@ return function(opts)
 
   local window_title = utils.pop_key(opts, "window_title") or "Issues"
   local prompt_title = utils.pop_key(opts, "prompt_title")
+  local cb = utils.pop_key(opts, "cb")
 
   local formatted_issues = {} ---@type table<string, table> entry.ordinal -> entry
 
@@ -71,6 +72,17 @@ return function(opts)
     }
   end
 
+  local actions
+  if cb then
+    actions = {
+      ["default"] = function(selected)
+        cb(formatted_issues[selected[1]])
+      end,
+    }
+  else
+    actions = fzf_actions.common_open_actions(formatted_issues)
+  end
+
   fzf.fzf_exec(get_contents, {
     prompt = picker_utils.get_prompt(prompt_title),
     previewer = previewers.issue(formatted_issues),
@@ -83,6 +95,6 @@ return function(opts)
       title = window_title,
       title_pos = "center",
     },
-    actions = fzf_actions.common_open_actions(formatted_issues),
+    actions = actions,
   })
 end


### PR DESCRIPTION
### Describe what this PR does / why we need it

The fzf-lua issues picker did not pop \`opts.cb\` before passing \`opts\` as \`filter_by\` to the GraphQL query. \`:Octo parent add\` and \`:Octo child add\` set \`opts.cb\` to a function and then call \`picker.issues(opts)\`. With the function value left in \`opts\`, \`gh.insert_input\` later concatenates it into the args string and crashes with \`attempt to concatenate local 'value' (a function value)\`.

### Does this pull request fix one issue?

Fixes #1471

### Describe how you did it

\`utils.pop_key(opts, "cb")\` the same way the telescope provider (line 154) and default provider (line 125) do. When \`cb\` is provided, wire it up as the default fzf action so callers like \`parent.add\` actually invoke it on selection.

### Describe how to verify it

With \`picker = 'fzf-lua'\`, open an issue buffer and run \`:Octo parent add\`. Before: crash on the GraphQL call. After: the issues picker opens; selecting an issue invokes the \`add_subissue\` mutation.

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt