### PR TITLE
feat: add process abstraction with vim.system and migrate git commands

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2,6 +2,7 @@
 local constants = require "octo.constants"
 local context = require "octo.context"
 local navigation = require "octo.navigation"
+local git = require "octo.git"
 local gh = require "octo.gh"
 local headers = require "octo.gh.headers"
 local graphql = require "octo.gh.graphql"
@@ -1898,8 +1899,7 @@ function M.create_pr(is_draft)
   end
 
   -- get current local branch
-  local cmd = "git rev-parse --abbrev-ref HEAD"
-  local local_branch = string.gsub(vim.fn.system(cmd), "%s+", "")
+  local local_branch = git.rev_parse({ abbrev_ref = "HEAD" }):trim()
 
   -- get remote branches
   if
@@ -1935,20 +1935,15 @@ function M.create_pr(is_draft)
         end,
       }
       utils.info(string.format("Pushing '%s' to '%s:%s' ...", local_branch, remote, remote_branch))
-      local ok, Job = pcall(require, "plenary.job")
-      if ok then
-        local job = Job:new {
-          command = "git",
-          args = { "push", remote, local_branch .. ":" .. remote_branch },
-          cwd = vim.fn.getcwd(),
-        }
-        job:sync()
-        --local stdout = table.concat(job:result(), "\n")
-        local stderr = table.concat(job:stderr_result(), "\n")
+      local push_result = git.push {
+        remote,
+        string.format("%s:%s", local_branch, remote_branch),
+      }
+      if not push_result or push_result.code ~= 0 then
+        local stderr = push_result and push_result.stderr or ""
         if not utils.is_blank(stderr) then
           utils.error(stderr)
         end
-      else
         utils.error "Aborting PR creation"
         return
       end
@@ -1986,7 +1981,8 @@ function M.save_pr(opts)
   local use_branch_name_as_title = conf.pull_requests.use_branch_name_as_title or false
   -- title and body
   local title, body
-  local last_commit = string.gsub(vim.fn.system "git log -1 --pretty=%B", "%s+$", "")
+  local log_result = git.log { "-1", pretty = "%B" }
+  local last_commit = (log_result and log_result:trim()) or ""
   local last_commit_lines = vim.split(last_commit, "\n")
   if #last_commit_lines >= 1 then
     title = last_commit_lines[1]

--- a/lua/octo/git.lua
+++ b/lua/octo/git.lua
@@ -2,6 +2,7 @@
 ---@field abbrev_ref? string | boolean
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGitStatusOpts
 ---@field short? boolean
@@ -10,6 +11,7 @@
 ---@field untracked_files? string
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGitCheckoutOpts
 ---@field b? string
@@ -18,6 +20,7 @@
 ---@field detach? boolean
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGitFetchOpts
 ---@field all? boolean
@@ -25,12 +28,14 @@
 ---@field tags? boolean
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGitPullOpts
 ---@field rebase? boolean
 ---@field ff_only? boolean
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGitPushOpts
 ---@field set_upstream? boolean
@@ -38,6 +43,7 @@
 ---@field tags? boolean
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGitBranchOpts
 ---@field all? boolean
@@ -46,20 +52,24 @@
 ---@field move? boolean
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGitRemoteOpts
 ---@field verbose? boolean
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGitConfigOpts
 ---@field get_regexp? string
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGitShowOpts
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGitMergeOpts
 ---@field squash? boolean
@@ -67,6 +77,7 @@
 ---@field abort? boolean
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGitLogOpts
 ---@field oneline? boolean
@@ -76,6 +87,7 @@
 ---@field pretty? string
 ---@field [integer]? string
 ---@field opts? OctoRuntimeOpts
+---@field args? table
 
 ---@class OctoGit
 ---@field rev_parse fun(opts?: OctoGitRevParseOpts): OctoProcessResult

--- a/lua/octo/git.lua
+++ b/lua/octo/git.lua
@@ -1,0 +1,98 @@
+---@class OctoGitRevParseOpts
+---@field abbrev_ref? string | boolean
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGitStatusOpts
+---@field short? boolean
+---@field branch? boolean
+---@field porcelain? boolean
+---@field untracked_files? string
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGitCheckoutOpts
+---@field b? string
+---@field B? string
+---@field track? boolean
+---@field detach? boolean
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGitFetchOpts
+---@field all? boolean
+---@field prune? boolean
+---@field tags? boolean
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGitPullOpts
+---@field rebase? boolean
+---@field ff_only? boolean
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGitPushOpts
+---@field set_upstream? boolean
+---@field force_with_lease? boolean
+---@field tags? boolean
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGitBranchOpts
+---@field all? boolean
+---@field remotes? boolean
+---@field delete? boolean
+---@field move? boolean
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGitRemoteOpts
+---@field verbose? boolean
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGitConfigOpts
+---@field get_regexp? string
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGitShowOpts
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGitMergeOpts
+---@field squash? boolean
+---@field no_ff? boolean
+---@field abort? boolean
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGitLogOpts
+---@field oneline? boolean
+---@field decorate? boolean
+---@field graph? boolean
+---@field max_count? number
+---@field pretty? string
+---@field [integer]? string
+---@field opts? OctoRuntimeOpts
+
+---@class OctoGit
+---@field rev_parse fun(opts?: OctoGitRevParseOpts): OctoProcessResult
+---@field status fun(opts?: OctoGitStatusOpts): OctoProcessResult
+---@field checkout fun(opts?: OctoGitCheckoutOpts): OctoProcessResult
+---@field fetch fun(opts?: OctoGitFetchOpts): OctoProcessResult
+---@field pull fun(opts?: OctoGitPullOpts): OctoProcessResult
+---@field push fun(opts?: OctoGitPushOpts): OctoProcessResult
+---@field branch fun(opts?: OctoGitBranchOpts): OctoProcessResult
+---@field remote fun(opts?: OctoGitRemoteOpts): OctoProcessResult
+---@field config fun(opts?: OctoGitConfigOpts): OctoProcessResult
+---@field show fun(opts?: OctoGitShowOpts): OctoProcessResult
+---@field merge fun(opts?: OctoGitMergeOpts): OctoProcessResult
+---@field log fun(opts?: OctoGitLogOpts): OctoProcessResult
+---@field [string] any
+
+---@type OctoGit
+local git = require("octo.process").factory "git"
+
+return git

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -1,5 +1,6 @@
 local gh = require "octo.gh"
 local queries = require "octo.gh.queries"
+local git = require "octo.git"
 local utils = require "octo.utils"
 
 local vim = vim
@@ -123,8 +124,7 @@ function M.go_to_file()
   end
   local result = open_file_if_found(utils.path_join { vim.fn.getcwd(), path }, line)
   if not result then
-    local cmd = "git rev-parse --show-toplevel"
-    local git_root = vim.fn.system(cmd):gsub("\n", "")
+    local git_root = git.rev_parse({ show_toplevel = true }):trim()
     result = open_file_if_found(utils.path_join { git_root, path }, line)
   end
   if not result then

--- a/lua/octo/process.lua
+++ b/lua/octo/process.lua
@@ -8,6 +8,7 @@ local M = {}
 ---@field data string The primary output (stdout or stderr)
 ---@field json fun(): table Helper to decode JSON
 ---@field trim fun(): string Helper to trim primary output
+---@field ok fun(): boolean Helper to check exit code
 
 ---@class OctoRuntimeOpts
 ---@field stdin? string
@@ -22,8 +23,9 @@ local M = {}
 ---@field command string[]
 ---@field opts vim.SystemOpts
 ---@field timeout? number
+---@field ok fun(): boolean
 
----@alias OctoProcessResult OctoResult|OctoDryRunResult|nil
+---@alias OctoProcessResult OctoResult|OctoDryRunResult
 
 ---@param text string
 ---@return table
@@ -51,6 +53,10 @@ local function wrap_res(obj)
     return vim.trim(result.data)
   end
 
+  result.ok = function()
+    return result.code == 0
+  end
+
   return result
 end
 
@@ -71,6 +77,10 @@ local function emit_complete_lines(carry, chunk, emit)
   return buffered
 end
 
+---@param bin string
+---@param args string[]
+---@param transformer_opts OctoRuntimeOpts
+---@return OctoResult|OctoDryRunResult|nil
 function M.run(bin, args, transformer_opts)
   transformer_opts = transformer_opts or {}
 
@@ -90,6 +100,9 @@ function M.run(bin, args, transformer_opts)
       command = cmd,
       opts = sys_opts,
       timeout = transformer_opts.timeout,
+      ok = function()
+        return true
+      end,
     }
   end
 
@@ -135,6 +148,7 @@ function M.run(bin, args, transformer_opts)
       end
     end
 
+    ---@diagnostic disable-next-line: no-unknown
     if transformer_opts.stream_cb then
       obj.stdout = table.concat(stdout_chunks)
       obj.stderr = table.concat(stderr_chunks)
@@ -153,13 +167,15 @@ function M.run(bin, args, transformer_opts)
   end)
 
   if co then
+    ---@diagnostic disable-next-line: await-in-sync
     return coroutine.yield()
   end
 
+  ---@diagnostic disable-next-line: return-type-mismatch
   return nil
 end
 
----@param tbl table
+---@param tbl table<string|integer, any>
 ---@param target string[]
 local function append_formatted(tbl, target)
   for k, v in pairs(tbl) do
@@ -189,10 +205,14 @@ end
 ---Handles: { flag = true } -> --flag, { f = "val" } -> -f val, { list = {1, 2} } -> --list 1 --list 2
 ---Reserved keys stripped from CLI output: opts, _stdin, args
 ---When args is present, a `--` separator is inserted before its contents
+---@param path string[]
+---@param opts table<string|integer, any>
+---@return string[], OctoRuntimeOpts
 function M.default_transformer(path, opts)
   opts = vim.deepcopy(opts or {})
 
   local args = vim.deepcopy(path)
+  ---@type table
   local runtime_opts = type(opts.opts) == "table" and opts.opts or {}
 
   if opts._stdin ~= nil and runtime_opts.stdin == nil then
@@ -202,11 +222,13 @@ function M.default_transformer(path, opts)
   opts._stdin = nil
   opts.opts = nil
 
+  ---@type table?
   local extra_args = opts.args
   opts.args = nil
 
   -- Strip any literal "--" from args since we auto-insert it below
   if extra_args ~= nil then
+    ---@type table
     local cleaned = {}
     local pos = 1
     for i = 1, math.huge do
@@ -226,6 +248,7 @@ function M.default_transformer(path, opts)
     extra_args = cleaned
   end
 
+  ---@type OctoRuntimeOpts
   local t_opts = {
     stdin = runtime_opts.stdin,
     env = runtime_opts.env,
@@ -247,18 +270,24 @@ function M.default_transformer(path, opts)
 end
 
 ---The Proxy Factory
+---@param bin string
+---@param transformer? fun(path: string[], opts: table): string[], OctoRuntimeOpts
+---@return table
 function M.factory(bin, transformer)
   transformer = transformer or M.default_transformer
 
   local function make_proxy(path)
     return setmetatable({}, {
       __index = function(_, key)
+        ---@diagnostic disable-next-line: no-unknown
         local segment = key:gsub("_", "-")
         return make_proxy(vim.list_extend(vim.deepcopy(path), { segment }))
       end,
       __call = function(_, opts)
         opts = opts or {}
+        ---@type string[], OctoRuntimeOpts
         local args, t_opts = transformer(path, opts)
+        ---@type OctoResult|OctoDryRunResult
         return M.run(bin, args, t_opts)
       end,
     })

--- a/lua/octo/process.lua
+++ b/lua/octo/process.lua
@@ -238,12 +238,15 @@ function M.default_transformer(path, opts)
         break
       end
       if extra_args[i] ~= "--" then
+        ---@diagnostic disable-next-line: no-unknown
         cleaned[pos] = extra_args[i]
         pos = pos + 1
       end
     end
+    ---@diagnostic disable-next-line: no-unknown
     for k, v in pairs(extra_args) do
       if type(k) == "string" then
+        ---@diagnostic disable-next-line: no-unknown
         cleaned[k] = v
       end
     end

--- a/lua/octo/process.lua
+++ b/lua/octo/process.lua
@@ -1,0 +1,227 @@
+-- lua/octo/process.lua
+local M = {}
+
+---@class OctoResult
+---@field code number The exit code
+---@field stdout string Combined stdout
+---@field stderr string Combined stderr
+---@field data string The primary output (stdout or stderr)
+---@field json fun(): table Helper to decode JSON
+---@field trim fun(): string Helper to trim primary output
+
+---@class OctoRuntimeOpts
+---@field stdin? string
+---@field env? table<string, string|integer>
+---@field timeout? number
+---@field cwd? string
+---@field stream_cb? fun(stdout: string?, stderr: string?)
+---@field cb? fun(stdout: string, stderr: string, code: number, result: OctoResult)
+---@field dry_run? boolean
+
+---@class OctoDryRunResult
+---@field command string[]
+---@field opts vim.SystemOpts
+---@field timeout? number
+
+---@alias OctoProcessResult OctoResult|OctoDryRunResult|nil
+
+---@param text string
+---@return table
+local function json_decode_or_empty(text)
+  local ok, decoded = pcall(vim.json.decode, text)
+  return ok and decoded or {}
+end
+
+---@param obj vim.SystemCompleted
+---@return OctoResult
+local function wrap_res(obj)
+  local result = {
+    code = obj.code,
+    stdout = obj.stdout or "",
+    stderr = obj.stderr or "",
+  }
+
+  result.data = (result.code == 0 and result.stdout ~= "") and result.stdout or result.stderr
+
+  result.json = function()
+    return json_decode_or_empty(result.stdout)
+  end
+
+  result.trim = function()
+    return vim.trim(result.data)
+  end
+
+  return result
+end
+
+---@param carry string
+---@param chunk string
+---@param emit fun(line: string): nil
+---@return string
+local function emit_complete_lines(carry, chunk, emit)
+  local buffered = carry .. chunk
+  while true do
+    local idx = buffered:find("\n", 1, true)
+    if not idx then
+      break
+    end
+    emit(buffered:sub(1, idx - 1))
+    buffered = buffered:sub(idx + 1)
+  end
+  return buffered
+end
+
+function M.run(bin, args, transformer_opts)
+  transformer_opts = transformer_opts or {}
+
+  local cmd = { bin, unpack(args) }
+  local co = coroutine.running()
+  local has_async_callbacks = transformer_opts.cb ~= nil or transformer_opts.stream_cb ~= nil
+
+  local sys_opts = {
+    text = true,
+    stdin = transformer_opts.stdin,
+    env = transformer_opts.env,
+    cwd = transformer_opts.cwd,
+  }
+
+  if transformer_opts.dry_run then
+    return {
+      command = cmd,
+      opts = sys_opts,
+      timeout = transformer_opts.timeout,
+    }
+  end
+
+  if not co and not has_async_callbacks then
+    local obj = vim.system(cmd, sys_opts):wait(transformer_opts.timeout)
+    return wrap_res(obj)
+  end
+
+  local stdout_chunks = {}
+  local stderr_chunks = {}
+  local stdout_carry = ""
+  local stderr_carry = ""
+
+  if transformer_opts.stream_cb then
+    sys_opts.stdout = function(_, data)
+      if not data then
+        return
+      end
+      table.insert(stdout_chunks, data)
+      stdout_carry = emit_complete_lines(stdout_carry, data, function(line)
+        transformer_opts.stream_cb(line, nil)
+      end)
+    end
+
+    sys_opts.stderr = function(_, data)
+      if not data then
+        return
+      end
+      table.insert(stderr_chunks, data)
+      stderr_carry = emit_complete_lines(stderr_carry, data, function(line)
+        transformer_opts.stream_cb(nil, line)
+      end)
+    end
+  end
+
+  vim.system(cmd, sys_opts, function(obj)
+    if transformer_opts.stream_cb then
+      if stdout_carry ~= "" then
+        transformer_opts.stream_cb(stdout_carry, nil)
+      end
+      if stderr_carry ~= "" then
+        transformer_opts.stream_cb(nil, stderr_carry)
+      end
+    end
+
+    if transformer_opts.stream_cb then
+      obj.stdout = table.concat(stdout_chunks)
+      obj.stderr = table.concat(stderr_chunks)
+    end
+
+    local wrapped = wrap_res(obj)
+    if transformer_opts.cb then
+      transformer_opts.cb(wrapped.stdout, wrapped.stderr, wrapped.code, wrapped)
+    end
+
+    if co then
+      vim.schedule(function()
+        coroutine.resume(co, wrapped)
+      end)
+    end
+  end)
+
+  if co then
+    return coroutine.yield()
+  end
+
+  return nil
+end
+
+---The "Standard" Transformer logic
+---Handles: { flag = true } -> --flag, { f = "val" } -> -f val, { list = {1, 2} } -> --list 1 --list 2
+function M.default_transformer(path, opts)
+  opts = vim.deepcopy(opts or {})
+
+  local args = vim.deepcopy(path)
+  local runtime_opts = type(opts.opts) == "table" and opts.opts or {}
+
+  if opts._stdin ~= nil and runtime_opts.stdin == nil then
+    runtime_opts.stdin = opts._stdin
+  end
+
+  opts._stdin = nil
+  opts.opts = nil
+
+  local t_opts = {
+    stdin = runtime_opts.stdin,
+    env = runtime_opts.env,
+    timeout = runtime_opts.timeout,
+    cwd = runtime_opts.cwd,
+    stream_cb = runtime_opts.stream_cb,
+    cb = runtime_opts.cb,
+    dry_run = runtime_opts.dry_run,
+  }
+
+  for k, v in pairs(opts) do
+    if type(k) == "string" then
+      local flag = (#k == 1 and "-" or "--") .. k:gsub("_", "-")
+      if type(v) == "table" then
+        for _, item in ipairs(v) do
+          vim.list_extend(args, { flag, tostring(item) })
+        end
+      else
+        table.insert(args, flag)
+        if v ~= true then
+          table.insert(args, tostring(v))
+        end
+      end
+    elseif type(k) == "number" then
+      table.insert(args, tostring(v))
+    end
+  end
+  return args, t_opts
+end
+
+---The Proxy Factory
+function M.factory(bin, transformer)
+  transformer = transformer or M.default_transformer
+
+  local function make_proxy(path)
+    return setmetatable({}, {
+      __index = function(_, key)
+        local segment = key:gsub("_", "-")
+        return make_proxy(vim.list_extend(vim.deepcopy(path), { segment }))
+      end,
+      __call = function(_, opts)
+        opts = opts or {}
+        local args, t_opts = transformer(path, opts)
+        return M.run(bin, args, t_opts)
+      end,
+    })
+  end
+  return make_proxy {}
+end
+
+return M

--- a/lua/octo/process.lua
+++ b/lua/octo/process.lua
@@ -159,8 +159,36 @@ function M.run(bin, args, transformer_opts)
   return nil
 end
 
+---@param tbl table
+---@param target string[]
+local function append_formatted(tbl, target)
+  for k, v in pairs(tbl) do
+    if type(k) == "string" then
+      local flag = (#k == 1 and "-" or "--") .. k:gsub("_", "-")
+      if type(v) == "table" then
+        for _, item in ipairs(v) do
+          vim.list_extend(target, { flag, tostring(item) })
+        end
+      else
+        table.insert(target, flag)
+        if v ~= true then
+          table.insert(target, tostring(v))
+        end
+      end
+    end
+  end
+  for i = 1, math.huge do
+    if tbl[i] == nil then
+      break
+    end
+    table.insert(target, tostring(tbl[i]))
+  end
+end
+
 ---The "Standard" Transformer logic
 ---Handles: { flag = true } -> --flag, { f = "val" } -> -f val, { list = {1, 2} } -> --list 1 --list 2
+---Reserved keys stripped from CLI output: opts, _stdin, args
+---When args is present, a `--` separator is inserted before its contents
 function M.default_transformer(path, opts)
   opts = vim.deepcopy(opts or {})
 
@@ -174,6 +202,30 @@ function M.default_transformer(path, opts)
   opts._stdin = nil
   opts.opts = nil
 
+  local extra_args = opts.args
+  opts.args = nil
+
+  -- Strip any literal "--" from args since we auto-insert it below
+  if extra_args ~= nil then
+    local cleaned = {}
+    local pos = 1
+    for i = 1, math.huge do
+      if extra_args[i] == nil then
+        break
+      end
+      if extra_args[i] ~= "--" then
+        cleaned[pos] = extra_args[i]
+        pos = pos + 1
+      end
+    end
+    for k, v in pairs(extra_args) do
+      if type(k) == "string" then
+        cleaned[k] = v
+      end
+    end
+    extra_args = cleaned
+  end
+
   local t_opts = {
     stdin = runtime_opts.stdin,
     env = runtime_opts.env,
@@ -184,23 +236,13 @@ function M.default_transformer(path, opts)
     dry_run = runtime_opts.dry_run,
   }
 
-  for k, v in pairs(opts) do
-    if type(k) == "string" then
-      local flag = (#k == 1 and "-" or "--") .. k:gsub("_", "-")
-      if type(v) == "table" then
-        for _, item in ipairs(v) do
-          vim.list_extend(args, { flag, tostring(item) })
-        end
-      else
-        table.insert(args, flag)
-        if v ~= true then
-          table.insert(args, tostring(v))
-        end
-      end
-    elseif type(k) == "number" then
-      table.insert(args, tostring(v))
-    end
+  append_formatted(opts, args)
+
+  if extra_args ~= nil and next(extra_args) ~= nil then
+    table.insert(args, "--")
+    append_formatted(extra_args, args)
   end
+
   return args, t_opts
 end
 

--- a/lua/octo/process.lua
+++ b/lua/octo/process.lua
@@ -182,6 +182,7 @@ local function append_formatted(tbl, target)
     if type(k) == "string" then
       local flag = (#k == 1 and "-" or "--") .. k:gsub("_", "-")
       if type(v) == "table" then
+        ---@diagnostic disable-next-line: no-unknown
         for _, item in ipairs(v) do
           vim.list_extend(target, { flag, tostring(item) })
         end
@@ -211,6 +212,7 @@ end
 function M.default_transformer(path, opts)
   opts = vim.deepcopy(opts or {})
 
+  ---@type string[]
   local args = vim.deepcopy(path)
   ---@type table
   local runtime_opts = type(opts.opts) == "table" and opts.opts or {}
@@ -259,10 +261,12 @@ function M.default_transformer(path, opts)
     dry_run = runtime_opts.dry_run,
   }
 
+  ---@diagnostic disable-next-line: no-unknown
   append_formatted(opts, args)
 
   if extra_args ~= nil and next(extra_args) ~= nil then
     table.insert(args, "--")
+    ---@diagnostic disable-next-line: no-unknown
     append_formatted(extra_args, args)
   end
 

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -379,6 +379,7 @@ end
 ---@param commit string
 ---@param cb fun(exists: boolean)
 function M.commit_exists(commit, cb)
+  ---@type OctoProcessResult
   local result = git.cat_file { "-t", commit }
   if result and result:trim() == "commit" then
     cb(true)

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -4,6 +4,7 @@ local gh = require "octo.gh"
 local graphql = require "octo.gh.graphql"
 local queries = require "octo.gh.queries"
 local _, Job = pcall(require, "plenary.job")
+local git = require "octo.git"
 local release = require "octo.release"
 local notify = require "octo.notify"
 local uri = require "octo.uri"
@@ -267,18 +268,20 @@ end
 function M.parse_git_remote()
   local conf = config.values
   local aliases = conf.ssh_aliases
-  ---@diagnostic disable-next-line: missing-fields
-  local job = Job:new { command = "git", args = { "remote", "-v" }, cwd = vim.fn.getcwd() }
-  job:sync()
-  local stderr = table.concat(job:stderr_result(), "\n")
-  if not M.is_blank(stderr) then
+  local result = git.remote {
+    "-v",
+    opts = {
+      cwd = vim.fn.getcwd(),
+    },
+  }
+
+  if not result or result.code ~= 0 or not M.is_blank(result.stderr) then
     return {}
   end
+
   ---@type table<string, OctoRepo>
   local remotes = {}
-  for _, line in
-    ipairs(job:result() --[[@as string[] ]])
-  do
+  for _, line in ipairs(vim.split(result.stdout, "\n", { trimempty = true })) do
     local name, url = line:match "^(%S+)%s+(%S+)"
     if name then
       local remote = M.parse_remote_url(url, aliases)
@@ -376,22 +379,12 @@ end
 ---@param commit string
 ---@param cb fun(exists: boolean)
 function M.commit_exists(commit, cb)
-  if not Job then
-    return
+  local result = git.cat_file { "-t", commit }
+  if result and result:trim() == "commit" then
+    cb(true)
+  else
+    cb(false)
   end
-  ---@diagnostic disable-next-line: missing-fields
-  Job:new({
-    enable_recording = true,
-    command = "git",
-    args = { "cat-file", "-t", commit },
-    on_exit = vim.schedule_wrap(function(j_self, _, _)
-      if "commit" == M.trim(table.concat(j_self:result(), "\n")) then
-        cb(true)
-      else
-        cb(false)
-      end
-    end),
-  }):start()
 end
 
 ---Add a milestone to an issue or PR
@@ -488,8 +481,8 @@ function M.get_milestone_progress(milestone)
 end
 
 local function branch_switch_message()
-  local output = vim.fn.system "git branch --show-current"
-  M.info("Switched to " .. vim.fn.trim(output))
+  local output = git.branch({ show_current = true }):trim()
+  M.info("Switched to " .. output)
 end
 
 function M.develop_issue(issue_repo, issue_number, branch_repo)
@@ -514,23 +507,16 @@ end
 ---@param commit string
 ---@param cb fun(lines: string[])
 function M.get_file_at_commit(path, commit, cb)
-  if not Job then
-    return
-  end
-  ---@diagnostic disable-next-line: missing-fields
-  local job = Job:new {
-    enable_recording = true,
-    command = "git",
-    args = { "show", string.format("%s:%s", commit, path) },
+  local result = git.show {
+    string.format("%s:%s", commit, path),
   }
-  ---@type string[]?
-  local result = job:sync()
-  if not result then
+
+  if not result or result.code ~= 0 then
     M.error "Failed to get file contents"
     return
   end
-  local output = table.concat(result, "\n")
-  cb(vim.split(output, "\n"))
+
+  cb(vim.split(result.stdout, "\n"))
 end
 
 function M.in_pr_repo()
@@ -563,13 +549,12 @@ end
 --- @param pr PullRequest
 --- @return boolean
 function M.in_pr_branch_locally_tracked(pr)
-  local cmd = "git rev-parse --abbrev-ref --symbolic-full-name @{u}"
-  local cmd_out = vim.fn.system(cmd)
-  if vim.v.shell_error ~= 0 then
+  local res = git.rev_parse { abbrev_ref = true, symbolic_full_name = "@{u}" }
+  if res.code ~= 0 then
     return false
   end
 
-  local local_branch_with_local_remote = vim.split(string.gsub(cmd_out, "%s+", ""), "/")
+  local local_branch_with_local_remote = vim.split(res:trim(), "/")
   local local_remote = local_branch_with_local_remote[1]
   local local_branch = table.concat(local_branch_with_local_remote, "/", 2)
 
@@ -596,9 +581,9 @@ end
 -- maps to a PR HEAD, when 'gh pr checkout' is used.
 ---@param pr PullRequest
 function M.get_upstream_branch_from_config(pr)
-  local branch_cmd = "git rev-parse --abbrev-ref HEAD"
-  local branch = vim.fn.system(branch_cmd)
-  if vim.v.shell_error ~= 0 then
+  local res = git.rev_parse { abbrev_ref = "HEAD" }
+  local branch = res:trim()
+  if res.code ~= 0 then
     return ""
   end
 
@@ -606,22 +591,18 @@ function M.get_upstream_branch_from_config(pr)
     return ""
   end
 
-  -- trim white space off branch
-  branch = string.gsub(branch, "%s+", "")
-
-  local merge_config_cmd = string.format('git config --get-regexp "^branch\\.%s\\.merge"', branch)
-
-  local merge_config = vim.fn.system(merge_config_cmd)
-  if vim.v.shell_error ~= 0 then
+  local merge_config = git.config { get_regexp = string.format("^branch\\.%s\\.merge", branch) }
+  if not merge_config or merge_config.code ~= 0 then
     return ""
   end
 
-  if #merge_config == 0 then
+  local merge_config_out = merge_config:trim()
+  if #merge_config_out == 0 then
     return ""
   end
 
   -- split merge_config to key, value with space delimiter
-  local merge_config_kv = vim.split(merge_config, "%s+")
+  local merge_config_kv = vim.split(merge_config_out, "%s+")
   -- use > 2 since there maybe some garbage white space at the end of the map.
   if #merge_config_kv < 2 then
     return ""
@@ -952,10 +933,11 @@ end
 
 -- Checks if the current cwd is in a git repo
 function M.cwd_is_git()
-  local cmd = "git rev-parse --is-inside-work-tree"
-  local out = vim.fn.system(cmd)
-  out = out:gsub("%s+", "")
-  return out == "true"
+  local out = git.rev_parse { is_inside_work_tree = true }
+  if not out or out.code ~= 0 then
+    return false
+  end
+  return out:trim() == "true"
 end
 
 ---Gets repo info

--- a/lua/tests/plenary/process_spec.lua
+++ b/lua/tests/plenary/process_spec.lua
@@ -35,6 +35,69 @@ describe("process.default_transformer", function()
 
     eq("payload", t_opts.stdin)
   end)
+
+  it("strips args key and auto-inserts -- before its content", function()
+    local args, _ = process.default_transformer({ "log" }, {
+      oneline = true,
+      args = { "--all" },
+    })
+
+    assert.is_true(has_value(args, "log"))
+    assert.is_true(has_value(args, "--oneline"))
+    assert.is_true(has_value(args, "--"))
+    assert.is_true(has_value(args, "--all"))
+    assert.is_false(has_value(args, "--args"))
+  end)
+
+  it("formats string keys in args table as flags after --", function()
+    local args, _ = process.default_transformer({ "clone" }, {
+      [1] = "owner/repo",
+      args = { depth = 1, branch = "main" },
+    })
+
+    assert.is_true(has_value(args, "clone"))
+    assert.is_true(has_value(args, "owner/repo"))
+    local dash_i, depth_i
+    for i, v in ipairs(args) do
+      if v == "--" then
+        dash_i = i
+      end
+      if v == "--depth" then
+        depth_i = i
+      end
+    end
+    assert.is_not_nil(dash_i)
+    assert.is_not_nil(depth_i)
+    assert.is_true(dash_i < depth_i, "-- must come before --depth")
+  end)
+
+  it("strips literal -- from args positional values to avoid double separator", function()
+    local args, _ = process.default_transformer({ "log" }, {
+      oneline = true,
+      args = { "HEAD", "--", "src/" },
+    })
+
+    local dashes = {}
+    for _, v in ipairs(args) do
+      if v == "--" then
+        table.insert(dashes, #dashes + 1)
+      end
+    end
+    assert.is_true(has_value(args, "--oneline"))
+    assert.is_true(has_value(args, "HEAD"))
+    assert.is_true(has_value(args, "src/"))
+    eq(1, #dashes, "expected exactly one -- separator")
+  end)
+
+  it("does not insert -- for empty args table", function()
+    local args, _ = process.default_transformer({ "status" }, {
+      short = true,
+      args = {},
+    })
+
+    assert.is_true(has_value(args, "--short"))
+    assert.is_false(has_value(args, "--"))
+  end)
 end)
 
 describe("process.run", function()

--- a/lua/tests/plenary/process_spec.lua
+++ b/lua/tests/plenary/process_spec.lua
@@ -1,0 +1,110 @@
+---@diagnostic disable
+local process = require "octo.process"
+local eq = assert.are.same
+
+local function has_value(t, value)
+  return vim.tbl_contains(t, value)
+end
+
+describe("process.default_transformer", function()
+  it("extracts runtime opts from opts namespace", function()
+    local args, t_opts = process.default_transformer({ "status" }, {
+      short = true,
+      [1] = "--porcelain",
+      opts = {
+        cwd = "/tmp",
+        timeout = 100,
+        dry_run = true,
+      },
+    })
+
+    assert.is_true(has_value(args, "status"))
+    assert.is_true(has_value(args, "--short"))
+    assert.is_true(has_value(args, "--porcelain"))
+    assert.is_false(has_value(args, "--opts"))
+
+    eq("/tmp", t_opts.cwd)
+    eq(100, t_opts.timeout)
+    eq(true, t_opts.dry_run)
+  end)
+
+  it("keeps backwards compatibility for _stdin", function()
+    local _, t_opts = process.default_transformer({}, {
+      _stdin = "payload",
+    })
+
+    eq("payload", t_opts.stdin)
+  end)
+end)
+
+describe("process.run", function()
+  it("returns sync result outside coroutine", function()
+    local result = process.run("sh", { "-c", "printf '{\"ok\":true}'" }, {})
+    eq(0, result.code)
+    eq('{"ok":true}', result.stdout)
+    eq("", result.stderr)
+    eq(true, result.json().ok)
+    eq('{"ok":true}', result.trim())
+  end)
+
+  it("returns result in coroutine flow", function()
+    local got
+    coroutine.wrap(function()
+      got = process.run("sh", { "-c", "printf 'co'" }, {})
+    end)()
+
+    vim.wait(2000, function()
+      return got ~= nil
+    end)
+
+    assert.is_not_nil(got)
+    eq(0, got.code)
+    eq("co", got.stdout)
+  end)
+
+  it("streams complete lines and flushes trailing data", function()
+    local streamed = {}
+    local completed = false
+    local callback_result
+
+    process.run("sh", { "-c", "printf 'a'; printf 'b\\ncd\\nef'" }, {
+      stream_cb = function(stdout, _)
+        if stdout ~= nil then
+          table.insert(streamed, stdout)
+        end
+      end,
+      cb = function(stdout, stderr, code, result)
+        callback_result = { stdout = stdout, stderr = stderr, code = code, result = result }
+        completed = true
+      end,
+    })
+
+    vim.wait(2000, function()
+      return completed
+    end)
+
+    eq({ "ab", "cd", "ef" }, streamed)
+    eq(0, callback_result.code)
+    eq("ab\ncd\nef", callback_result.stdout)
+    eq("", callback_result.stderr)
+    eq("ab\ncd\nef", callback_result.result.stdout)
+  end)
+end)
+
+describe("process.factory", function()
+  it("supports dry_run via opts namespace", function()
+    local git = process.factory "git"
+    local out = git.status {
+      short = true,
+      opts = {
+        cwd = "/tmp",
+        dry_run = true,
+      },
+    }
+
+    eq("git", out.command[1])
+    assert.is_true(has_value(out.command, "status"))
+    assert.is_true(has_value(out.command, "--short"))
+    eq("/tmp", out.opts.cwd)
+  end)
+end)


### PR DESCRIPTION
Introduce `process.lua` as a lightweight `vim.system`-based execution backend to replace `plenary.job`, and migrate all runtime git command invocations onto it as a first consumer.

`process.lua` exposes a `run()` function that resolves runtime controls (`env`, `cwd`, `timeout`, `stdin`, `cb`, `stream_cb`, `dry_run`) via a reserved `opts` namespace, keeping them from colliding with CLI flags. It supports sync (blocking), coroutine-aware, and async+callback execution with line-buffered streaming for consumers that need page/line granularity.

A typed `OctoGit` wrapper in `git.lua` provides per-command option classes (`rev_parse`, `status`, `checkout`, `fetch`, `pull`, `push`, `branch`, `remote`, `config`, `show`, `merge`, `log`) with dynamic `[string] any` fallback for custom usage.

## Async via coroutine.wrap

Coroutines eliminate nested callbacks when running commands. Handle the result inside the coroutine for a natural synchronous-style flow:

```lua
coroutine.wrap(function()
  local res = git.log{
    opts = { cwd = repo_dir },
    max_count = 5,
    format = "%h %s",
  }

  for _, line in ipairs(vim.split(res:trim(), "\n")) do
    print(line)
  end
end)()
```

## The `args` key: forwarding content after `--`

The `args` reserved key forwards flags and positional arguments after an auto-inserted `--` separator. This is used for pathspecs (git) or flags forwarded to underlying tools (gh):

```lua
-- Pathspecs after --
git.log { oneline = true, args = { "--all" } }
-- → git log --oneline -- --all

git.checkout { args = { "file.txt" } }
-- → git checkout -- file.txt

-- gh flag forwarding
gh.repo.clone { "owner/repo", args = { depth = 1, branch = "main" } }
-- → gh repo clone owner/repo -- --depth 1 --branch main

-- Mixed flags (pre --) and args (post --)
git.checkout { b = "new-branch", args = { "file.txt" } }
-- → git checkout -b new-branch -- file.txt
```

Inside `args`, string keys become flags and numeric keys become positional strings — same formatting as the main opts table. A literal `"--"` inside args is stripped to avoid double separators.

## Migrations

- **commands.lua**: `Job:new` git push → `git.push`, `vim.fn.system` git log → `git.log`
- **utils.lua**: `parse_git_remote` → `git.remote`, `get_file_at_commit` → `git.show`, `get_upstream_branch_from_config` → `git.config`, `cwd_is_git` → `git.rev_parse{is_inside_work_tree=true}`, `commit_exists` → `git.cat_file` sync
- **navigation.lua**: `vim.fn.system("git rev-parse --show-toplevel")` → `git.rev_parse{show_toplevel=true}:trim()`

## Testing

Added `lua/tests/plenary/process_spec.lua` covering opts extraction, legacy `_stdin` compatibility, sync/coroutine execution, streaming assembly with trailing flush, dry-run output, and `args` forwarding with separator auto-insertion.

## Follow-up: gh migration

`lua/octo/gh/init.lua` still uses `plenary.job` — migrating its execution backend onto `process.lua` is deferred to a follow-up PR, mapping `RunOpts` to the `opts` namespace while keeping gh-specific arg logic (f/F flags, headers, hostname, pagination) local to the module. Additional sites using `vim.fn.system`, `io.popen`, and `os.execute` for gh/browser calls will also be addressed in subsequent PRs.