### PR TITLE
feat(hooks): add async chainable hook system and User autocmd events

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,32 @@ require"octo".setup {
 ```
 <!-- END_CONFIG -->
 
+## 🪝 Hooks & Events
+
+Hooks allow intercepting and mutating data before API calls. Events are read-only notifications after operations complete.
+
+See `:help octo-hooks-events` for the full API reference, available hooks, event constants, and examples.
+
+```lua
+-- Register a hook in setup (see :help octo-hooks for details)
+require("octo").setup({
+  hooks = {
+    before_review_submit = function(data, next)
+      data.body = data.body .. "\n\n_AI summary_"
+      next(data)
+    end,
+  },
+})
+
+-- Listen for events via User autocommand (see :help octo-events)
+vim.api.nvim_create_autocmd("User", {
+  pattern = "OctoReviewSubmitted",
+  callback = function(opts)
+    print("Review " .. opts.data.review_id .. " submitted!")
+  end,
+})
+```
+
 ## 🤖 Commands
 
 There is only an `Octo <object> <action> [arguments]` command:

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -185,6 +185,154 @@ There are plenty of examples in the repo so consider checking it out for more
 reference or read more in the GitHub discussion:
 `Octo discussion edit 876 pwntester/octo.nvim`
 
+HOOKS                                           *octo-hooks* *octo-hooks-events*
+
+Hooks allow you to intercept and mutate data before octo.nvim performs API
+calls. Register them via `setup()` or with `require("octo.hooks").register()`.
+
+Setup example: >lua
+    require("octo").setup({
+        hooks = {
+            before_review_submit = function(data, next)
+                local branch = data.pull_request.head_ref_name
+                local diff = vim.fn.system("git diff main..." .. branch)
+                data.body = data.body .. "\n\n## AI Summary\n" .. call_llm(diff)
+                next(data)
+            end,
+        },
+    })
+<
+
+Programmatic API: >lua
+    local hooks = require("octo.hooks")
+    hooks.register("before_review_submit", function(data, next)
+        data.body = data.body .. "\n\nSigned off by bot"
+        next(data)
+    end)
+<
+
+Available hooks: ~
+
+before_review_submit
+    Fires before a review is submitted (APPROVE/COMMENT/REQUEST_CHANGES).
+    Payload: `{ review_id, action, body, pull_request }`
+    Mutate `data.action` or `data.body` and call `next(data)` to proceed.
+
+Hooks run in registration order. Each must call `next(mutated_data)` or the
+chain stalls and the operation is cancelled. Use `hooks.clear(name)` to
+remove registered hooks, or `hooks.clear()` to remove all.
+
+The hook name is also accepted in the `setup()` table for convenience: >lua
+    require("octo").setup({
+        hooks = {
+            before_review_submit = function(data, next) next(data) end,
+        },
+    })
+<
+
+EVENTS                                          *octo-events*
+
+Events are read-only notifications emitted after operations complete. They
+cannot mutate data. Listen to them via `User` autocommands:
+
+Example: >lua
+    vim.api.nvim_create_autocmd("User", {
+        pattern = "OctoReviewSubmitted",
+        callback = function(opts)
+            print("Review " .. opts.data.review_id .. " submitted!")
+        end,
+    })
+<
+
+Event constants are available via `require("octo.events")`: >lua
+    local events = require("octo.events")
+    vim.api.nvim_create_autocmd("User", {
+        pattern = events.REVIEW_SUBMITTED,
+        callback = function(opts) print("done!") end,
+    })
+<
+
+Available events: ~
+
+BUFFER_LOADED (`OctoBufferLoaded`)
+    Fires after a buffer is loaded and rendered.
+    Payload: `{ bufnr, kind, repo, number }`
+
+BUFFER_CLOSED (`OctoBufferClosed`)
+    Fires after a buffer is cleaned up.
+    Payload: `{ bufnr }`
+
+REVIEW_OPENED (`OctoReviewOpened`)
+    Fires after a review is started or resumed.
+    Payload: `{ review_id, pull_request }`
+
+REVIEW_CLOSED (`OctoReviewClosed`)
+    Fires when a review tab is closed.
+    Payload: `{ review_id }`
+
+REVIEW_SUBMITTED (`OctoReviewSubmitted`)
+    Fires after a review is successfully submitted.
+    Payload: `{ review_id, action, body, pull_request }`
+
+REVIEW_DISCARDED (`OctoDiscarded`)
+    Fires after a pending review is discarded.
+    Payload: `{ review_id, pull_request }`
+
+COMMENT_ADDED (`OctoCommentAdded`)
+    Fires after a comment is created on GitHub.
+    Payload: `{ comment_id, body, kind, repo, number }`
+
+COMMENT_UPDATED (`OctoCommentUpdated`)
+    Fires after a comment is edited on GitHub.
+    Payload: `{ comment_id, body, kind, repo }`
+
+COMMENT_DELETED (`OctoCommentDeleted`)
+    Fires after a comment is deleted on GitHub.
+    Payload: `{ comment_id, kind, repo }`
+
+CONTEXT                                         *octo-context*
+
+The context module (`require("octo.context")`) provides guard helpers for
+buffer-kind operations in commands and mappings. It offers two styles:
+
+Thunk-returning wrappers (for mappings/callbacks): >lua
+    context.within_issue(function(buffer)
+        -- only runs if current buffer is an issue
+    end)
+
+    context.within_pr(function(buffer)
+        -- only runs if current buffer is a PR
+    end)
+<
+
+Direct-invoke variants (for use in plain function bodies): >lua
+    context.with_octo_buffer(function(buffer) end)
+    context.with_repo(function(buffer) end)
+    context.with_issue(function(buffer) end)
+    context.with_pr(function(buffer) end)
+    context.with_discussion(function(buffer) end)
+    context.with_release(function(buffer) end)
+    context.with_review_thread(function(buffer) end)
+    context.with_issue_or_pr(function(buffer) end)
+<
+
+Cursor accessors: >lua
+    context.on_comment(function(comment) end)
+        -- comment at cursor in current buffer
+
+    context.on_body(function(body_metadata) end)
+        -- issue/PR/discussion body at cursor
+
+    context.on_thread(function(thread) end)
+        -- review thread at cursor
+<
+
+Convenience references: >lua
+    context.get_current_buffer()  -- => OctoBuffer?
+    context.get_current_review()  -- => Review?
+    context.buffer_at(bufnr)      -- => OctoBuffer?
+<
+
 COMMANDS                                        *octo-commands*
 
 There is only one main command: `Octo <object> <action> [args]` command. If no

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1,6 +1,7 @@
 ---@diagnostic disable
 local constants = require "octo.constants"
 local context = require "octo.context"
+local events = require "octo.events"
 local navigation = require "octo.navigation"
 local gh = require "octo.gh"
 local headers = require "octo.gh.headers"
@@ -1534,6 +1535,11 @@ function M.delete_comment()
                 end
               end
             end -- if comment.kind == "PullRequestReviewComment"
+            events.emit(events.COMMENT_DELETED, {
+              comment_id = comment.id,
+              kind = comment.kind,
+              repo = buffer.repo,
+            })
           end,
         },
       },

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -118,6 +118,7 @@ local M = {}
 ---@field completion_overrides table<string, string[]|fun(argLead: string, cmdLine: string): string[]>
 
 ---@class OctoConfig Octo configuration settings
+---@field hooks? OctoHooksConfig
 ---@field picker OctoPickers
 ---@field picker_config OctoPickerConfig
 ---@field default_remote table

--- a/lua/octo/context.lua
+++ b/lua/octo/context.lua
@@ -18,6 +18,20 @@ local function create_buffer_wrapper(check_fn, error_message)
   end
 end
 
+local function create_buffer_direct(check_fn, error_message)
+  ---@param cb fun(buffer: OctoBuffer): nil
+  return function(cb)
+    local buffer = utils.get_current_buffer()
+    if not buffer or (check_fn and not check_fn(buffer)) then
+      utils.error(error_message)
+      return
+    end
+    return cb(buffer)
+  end
+end
+
+-- Thunk-returning guard wrappers (for mappings/callbacks)
+
 M.within_octo_buffer = create_buffer_wrapper(nil, "Not an Octo buffer")
 M.within_repo = create_buffer_wrapper(function(b)
   return b:isRepo()
@@ -31,9 +45,40 @@ end, "Not a Pull Request buffer")
 M.within_discussion = create_buffer_wrapper(function(b)
   return b:isDiscussion()
 end, "Not a Discussion buffer")
+M.within_release = create_buffer_wrapper(function(b)
+  return b:isRelease()
+end, "Not a Release buffer")
+M.within_review_thread = create_buffer_wrapper(function(b)
+  return b:isReviewThread()
+end, "Not a Review Thread buffer")
 M.within_issue_or_pr = create_buffer_wrapper(function(b)
   return b:isPullRequest() or b:isIssue()
-end, "Not an Issue or  Pull Request buffer")
+end, "Not an Issue or Pull Request buffer")
+
+-- Direct-invoke variants (no thunk, for use in commands/functions)
+
+M.with_octo_buffer = create_buffer_direct(nil, "Not an Octo buffer")
+M.with_repo = create_buffer_direct(function(b)
+  return b:isRepo()
+end, "Not a Repository buffer")
+M.with_issue = create_buffer_direct(function(b)
+  return b:isIssue()
+end, "Not an Issue buffer")
+M.with_pr = create_buffer_direct(function(b)
+  return b:isPullRequest()
+end, "Not a Pull Request buffer")
+M.with_discussion = create_buffer_direct(function(b)
+  return b:isDiscussion()
+end, "Not a Discussion buffer")
+M.with_release = create_buffer_direct(function(b)
+  return b:isRelease()
+end, "Not a Release buffer")
+M.with_review_thread = create_buffer_direct(function(b)
+  return b:isReviewThread()
+end, "Not a Review Thread buffer")
+M.with_issue_or_pr = create_buffer_direct(function(b)
+  return b:isPullRequest() or b:isIssue()
+end, "Not an Issue or Pull Request buffer")
 
 ---@param cb fun(current_review: Review): nil
 function M.within_review(cb)
@@ -45,6 +90,16 @@ function M.within_review(cb)
     end
     cb(current_review)
   end
+end
+
+---@param cb fun(current_review: Review): nil
+function M.with_review(cb)
+  local current_review = reviews.get_current_review()
+  if not current_review then
+    utils.error "Please start or resume a review first"
+    return
+  end
+  return cb(current_review)
 end
 
 ---@param cb fun(comment: any, buffer: OctoBuffer): nil
@@ -64,6 +119,62 @@ function M.on_comment(cb)
   return M.on_comment_in_buffer(function(comment, _)
     cb(comment)
   end)
+end
+
+---@param cb fun(body: BodyMetadata, buffer: OctoBuffer): nil
+function M.on_body_in_buffer(cb)
+  return M.within_issue_or_pr(function(buffer)
+    local body, start_line, end_line = buffer:get_body_at_cursor()
+    if not body then
+      utils.error "No body found at cursor"
+      return
+    end
+    cb(body, buffer)
+  end)
+end
+
+---@param cb fun(body: BodyMetadata): nil
+function M.on_body(cb)
+  return M.on_body_in_buffer(function(body, _)
+    cb(body)
+  end)
+end
+
+---@param cb fun(thread: ThreadMetadata, buffer: OctoBuffer): nil
+function M.on_thread_in_buffer(cb)
+  return M.within_pr(function(buffer)
+    local thread = buffer:get_thread_at_cursor()
+    if not thread then
+      utils.error "No thread found at cursor"
+      return
+    end
+    cb(thread, buffer)
+  end)
+end
+
+---@param cb fun(thread: ThreadMetadata): nil
+function M.on_thread(cb)
+  return M.on_thread_in_buffer(function(thread, _)
+    cb(thread)
+  end)
+end
+
+---Convenience references
+
+---@return OctoBuffer?
+function M.get_current_buffer()
+  return utils.get_current_buffer()
+end
+
+---@return Review?
+function M.get_current_review()
+  return reviews.get_current_review()
+end
+
+---@param bufnr integer
+---@return OctoBuffer?
+function M.buffer_at(bufnr)
+  return octo_buffers[bufnr]
 end
 
 return M

--- a/lua/octo/events.lua
+++ b/lua/octo/events.lua
@@ -1,0 +1,58 @@
+--- Read-only notification events emitted by octo.nvim after operations complete.
+--- Consumers listen via `vim.api.nvim_create_autocmd("User", { pattern = "Octo*", callback = ... })`.
+--- These are fire-and-forget — they cannot mutate the data that was operated on.
+
+---@alias OctoEventName
+---  | "OctoBufferLoaded"
+---  | "OctoBufferClosed"
+---  | "OctoReviewOpened"
+---  | "OctoReviewClosed"
+---  | "OctoReviewSubmitted"
+---  | "OctoReviewDiscarded"
+---  | "OctoCommentAdded"
+---  | "OctoCommentUpdated"
+---  | "OctoCommentDeleted"
+
+---@class OctoEventPayloads
+---@field OctoBufferLoaded { bufnr: integer, kind: string, repo: string, number: number }
+---@field OctoBufferClosed { bufnr: integer }
+---@field OctoReviewOpened { review_id: string, pull_request: { number: number, repo: string } }
+---@field OctoReviewClosed { review_id: string }
+---@field OctoReviewSubmitted { review_id: string, action: string, body: string, pull_request: { number: number, repo: string } }
+---@field OctoReviewDiscarded { review_id: string, pull_request: { number: number, repo: string } }
+---@field OctoCommentAdded { comment_id: string, body: string, kind: string, repo: string, number: number }
+---@field OctoCommentUpdated { comment_id: string, body: string, kind: string, repo: string }
+---@field OctoCommentDeleted { comment_id: string, kind: string, repo: string }
+
+local M = {}
+
+--- A buffer for an Octo object (issue, PR, discussion, etc.) finished loading.
+M.BUFFER_LOADED = "OctoBufferLoaded"
+--- An Octo buffer was closed or cleaned up.
+M.BUFFER_CLOSED = "OctoBufferClosed"
+--- A review session was opened for a pull request.
+M.REVIEW_OPENED = "OctoReviewOpened"
+--- A review session was closed without submission.
+M.REVIEW_CLOSED = "OctoReviewClosed"
+--- A review (approve, comment, or request changes) was submitted.
+M.REVIEW_SUBMITTED = "OctoReviewSubmitted"
+--- A pending review was discarded.
+M.REVIEW_DISCARDED = "OctoReviewDiscarded"
+--- A comment was added to an issue, PR, or discussion.
+M.COMMENT_ADDED = "OctoCommentAdded"
+--- A comment was edited.
+M.COMMENT_UPDATED = "OctoCommentUpdated"
+--- A comment was deleted.
+M.COMMENT_DELETED = "OctoCommentDeleted"
+
+--- Emit a read-only notification via `User` autocommand.
+--- @param name OctoEventName  One of the event constants on this module (e.g. `events.REVIEW_SUBMITTED`).
+--- @param data table  Payload for the event. Shape depends on the event — see `OctoEventPayloads`.
+function M.emit(name, data)
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = name,
+    data = data,
+  })
+end
+
+return M

--- a/lua/octo/hooks.lua
+++ b/lua/octo/hooks.lua
@@ -1,0 +1,66 @@
+--- Async chainable interception hook registry.
+--- Hooks allow plugins and user config to intercept and mutate data before
+--- octo.nvim performs an API call or action. Each hook receives the current
+--- payload and a `next` callback — calling `next(mutated_data)` passes control
+--- to the next hook in the chain, following an Express.js / Koa middleware pattern.
+--- If no hook calls `next` the chain stalls; the final `done` callback is never
+--- invoked and the operation is effectively cancelled.
+
+---@class OctoBeforeReviewSubmitData
+---@field review_id string
+---@field action string
+---@field body string
+---@field pull_request { number: number, repo: string, head_ref_name: string, diff: string }
+
+---@alias OctoHookFn fun(data: table, next: fun(table?))
+
+---@alias OctoHooksConfig { before_review_submit?: fun(data: OctoBeforeReviewSubmitData, next: fun(data: OctoBeforeReviewSubmitData)) }
+
+local registry = {} ---@type table<string, OctoHookFn[]>
+
+local M = {}
+
+--- Register an interception hook.
+--- The function will be called in registration order when `run` is invoked for `name`.
+--- @param name string  Hook identifier (e.g. `"before_review_submit"`).
+--- @param fn OctoHookFn  Handler. Call `next(modified_data)` to continue the chain.
+function M.register(name, fn)
+  registry[name] = registry[name] or {}
+  table.insert(registry[name], fn)
+end
+
+--- Run the hook chain for `name` with the given `data`.
+--- Each registered hook receives `(data, next)`. When a hook calls
+--- `next(mutated)`, the mutated value is passed to the next hook.
+--- After the last hook calls `next`, `done` receives the final payload.
+--- If no hooks are registered `done` is called immediately with the original data.
+--- @param name string  Hook identifier to trigger.
+--- @param data table  Initial payload to pass through the chain.
+--- @param done fun(result: table)  Final callback receiving the (possibly mutated) payload.
+function M.run(name, data, done)
+  local chain = registry[name] or {}
+  if #chain == 0 then
+    return done(data)
+  end
+  local i = 0
+  local function step(result)
+    i = i + 1
+    if i > #chain then
+      return done(result)
+    end
+    chain[i](result or data, step)
+  end
+  step(data)
+end
+
+--- Clear all hooks, or hooks for a specific name.
+--- @param name? string  If provided, only hooks registered under this name are cleared.
+function M.clear(name)
+  if name then
+    registry[name] = nil
+  else
+    registry = {}
+  end
+end
+
+return M

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -4,8 +4,10 @@ local config = require "octo.config"
 local constants = require "octo.constants"
 local commands = require "octo.commands"
 local completion = require "octo.completion"
+local events = require "octo.events"
 local folds = require "octo.folds"
 local gh = require "octo.gh"
+local hooks = require "octo.hooks"
 local queries = require "octo.gh.queries"
 local graphql = require "octo.gh.graphql"
 local picker = require "octo.picker"
@@ -23,8 +25,12 @@ _G.octo_repo_issues = {}
 ---@type table<integer, OctoBuffer>
 _G.octo_buffers = {}
 
-local M = {}
+local M = {
+  events = require "octo.events",
+  hooks = require "octo.hooks",
+}
 
+---@param user_config? OctoConfig
 function M.setup(user_config)
   if not vim.fn.has "nvim-0.7" then
     utils.error "octo.nvim requires neovim 0.7+"
@@ -35,6 +41,10 @@ function M.setup(user_config)
   if not vim.fn.executable(config.values.gh_cmd) then
     utils.error("gh executable not found using path: " .. config.values.gh_cmd)
     return
+  end
+
+  for name, fn in pairs(user_config and user_config.hooks or {}) do
+    hooks.register(name, fn)
   end
 
   colors.setup()
@@ -408,6 +418,13 @@ function M.create_buffer(kind, obj, repo, create, hostname)
   end
   utils.clear_history()
   require("octo.polling").track_buffer(bufnr)
+
+  events.emit(events.BUFFER_LOADED, {
+    bufnr = bufnr,
+    kind = kind,
+    repo = repo,
+    number = obj.number,
+  })
 end
 
 return M

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -3,6 +3,7 @@ local TitleMetadata = require("octo.model.title-metadata").TitleMetadata
 local autocmds = require "octo.autocmds"
 local config = require "octo.config"
 local constants = require "octo.constants"
+local events = require "octo.events"
 local folds = require "octo.folds"
 local gh = require "octo.gh"
 local headers = require "octo.gh.headers"
@@ -454,6 +455,13 @@ function OctoBuffer:do_add_discussion_comment(comment_metadata)
           end
 
           self:render_signs()
+          events.emit(events.COMMENT_ADDED, {
+            comment_id = resp.id,
+            body = resp.body,
+            kind = "DiscussionComment",
+            repo = self.repo,
+            number = self.number,
+          })
         end,
       },
     },
@@ -487,6 +495,13 @@ function OctoBuffer:do_add_issue_comment(comment_metadata)
               end
             end
             self:render_signs()
+            events.emit(events.COMMENT_ADDED, {
+              comment_id = respId,
+              body = respBody,
+              kind = "IssueComment",
+              repo = self.repo,
+              number = self.number,
+            })
           end
         end,
       },
@@ -532,6 +547,13 @@ function OctoBuffer:do_add_thread_comment(comment_metadata)
             end
 
             self:render_signs()
+            events.emit(events.COMMENT_ADDED, {
+              comment_id = resp_comment.id,
+              body = resp_comment.body,
+              kind = "PullRequestReviewComment",
+              repo = self.repo,
+              number = self.number,
+            })
 
             -- update thread map
             local thread_id ---@type string
@@ -655,6 +677,13 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
                 review:update_threads(review_threads)
               end
               self:render_signs()
+              events.emit(events.COMMENT_ADDED, {
+                comment_id = new_comment.id,
+                body = new_comment.body,
+                kind = "PullRequestReviewComment",
+                repo = self.repo,
+                number = self.number,
+              })
             end
           end,
         },
@@ -760,6 +789,13 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
                     review:update_threads(threads)
                   end
                   self:render_signs()
+                  events.emit(events.COMMENT_ADDED, {
+                    comment_id = resp.comment.id,
+                    body = resp.comment.body,
+                    kind = "PullRequestReviewComment",
+                    repo = self.repo,
+                    number = self.number,
+                  })
                 end
               else
                 utils.error "Failed to create thread"
@@ -809,6 +845,13 @@ function OctoBuffer:do_add_pull_request_comment(comment_metadata)
               end
             end
             self:render_signs()
+            events.emit(events.COMMENT_ADDED, {
+              comment_id = resp.id,
+              body = resp.body,
+              kind = "PullRequestReviewComment",
+              repo = self.repo,
+              number = self.number,
+            })
           end
         else
           utils.error "Failed to create thread"
@@ -868,6 +911,12 @@ function OctoBuffer:do_update_comment(comment_metadata)
               end
             end
             self:render_signs()
+            events.emit(events.COMMENT_UPDATED, {
+              comment_id = comment_metadata.id,
+              body = resp_comment.body,
+              kind = comment_metadata.kind,
+              repo = self.repo,
+            })
           end
         end,
       },
@@ -1088,6 +1137,7 @@ function OctoBuffer:navigate_to_comment(opts)
 end
 
 ---Gets the issue/PR body at cursor (if any)
+---@return BodyMetadata?, integer?, integer?
 function OctoBuffer:get_body_at_cursor()
   local cursor = vim.api.nvim_win_get_cursor(0)
   local metadata = self.bodyMetadata
@@ -1101,6 +1151,7 @@ function OctoBuffer:get_body_at_cursor()
 end
 
 ---Gets the review thread at cursor (if any)
+---@return ThreadMetadata?
 function OctoBuffer:get_thread_at_cursor()
   local cursor = vim.api.nvim_win_get_cursor(0)
   return self:get_thread_at_line(cursor[1])

--- a/lua/octo/reviews/init.lua
+++ b/lua/octo/reviews/init.lua
@@ -1,7 +1,9 @@
 local Layout = require("octo.reviews.layout").Layout
 local Rev = require("octo.reviews.rev").Rev
 local config = require "octo.config"
+local events = require "octo.events"
 local gh = require "octo.gh"
+local hooks = require "octo.hooks"
 local queries = require "octo.gh.queries"
 local graphql = require "octo.gh.graphql"
 local thread_panel = require "octo.reviews.thread-panel"
@@ -89,6 +91,13 @@ function Review:start()
     local threads = resp.data.addPullRequestReview.pullRequestReview.pullRequest.reviewThreads.nodes
     self:update_threads(threads)
     self:initiate()
+    events.emit(events.REVIEW_OPENED, {
+      review_id = self.id,
+      pull_request = {
+        number = self.pull_request.number,
+        repo = self.pull_request.repo,
+      },
+    })
   end)
 end
 
@@ -128,6 +137,13 @@ function Review:resume()
     local threads = resp.data.repository.pullRequest.reviewThreads.nodes
     self:update_threads(threads)
     self:initiate()
+    events.emit(events.REVIEW_OPENED, {
+      review_id = self.id,
+      pull_request = {
+        number = self.pull_request.number,
+        repo = self.pull_request.repo,
+      },
+    })
   end)
 end
 
@@ -152,6 +168,13 @@ function Review:start_or_resume()
     local threads = resp.data.repository.pullRequest.reviewThreads.nodes
     self:update_threads(threads)
     self:initiate()
+    events.emit(events.REVIEW_OPENED, {
+      review_id = self.id,
+      pull_request = {
+        number = self.pull_request.number,
+        repo = self.pull_request.repo,
+      },
+    })
   end)
 end
 
@@ -292,6 +315,13 @@ function Review:discard(opts)
                     self.files = {}
                     utils.info "Pending review discarded"
                     vim.cmd [[tabclose]]
+                    events.emit(events.REVIEW_DISCARDED, {
+                      review_id = self.id,
+                      pull_request = {
+                        number = self.pull_request.number,
+                        repo = self.pull_request.repo,
+                      },
+                    })
                   end,
                 },
               },
@@ -362,19 +392,45 @@ function Review:submit(event)
   local winid = vim.api.nvim_get_current_win()
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, default_id, false)
   local body = utils.escape_char(utils.trim(table.concat(lines, "\n")))
-  local query = graphql("submit_pull_request_review_mutation", review_id, event, body, { escape = false })
-  gh.api.graphql {
-    f = { query = query },
-    opts = {
-      cb = gh.create_callback {
-        success = function()
-          utils.info "Review was submitted successfully!"
-          pcall(vim.api.nvim_win_close, winid, 0)
-          self.layout:close()
-        end,
-      },
+
+  local pr = self.pull_request
+  hooks.run("before_review_submit", {
+    review_id = review_id,
+    action = event,
+    body = body,
+    pull_request = {
+      number = pr.number,
+      repo = pr.repo,
+      head_ref_name = pr.head_ref_name,
+      diff = pr.diff,
     },
-  }
+  }, function(mutated)
+    event = mutated.action or event
+    body = mutated.body or body
+
+    local query = graphql("submit_pull_request_review_mutation", review_id, event, body, { escape = false })
+    gh.api.graphql {
+      f = { query = query },
+      opts = {
+        cb = gh.create_callback {
+          success = function()
+            utils.info "Review was submitted successfully!"
+            pcall(vim.api.nvim_win_close, winid, 0)
+            self.layout:close()
+            events.emit(events.REVIEW_SUBMITTED, {
+              review_id = review_id,
+              action = event,
+              body = body,
+              pull_request = {
+                number = pr.number,
+                repo = pr.repo,
+              },
+            })
+          end,
+        },
+      },
+    }
+  end)
 end
 
 function Review:show_pending_comments()
@@ -621,6 +677,9 @@ function M.close(tabpage)
     local review = M.reviews[tostring(tabpage)]
     if review and review.layout then
       review.layout:close()
+      events.emit(events.REVIEW_CLOSED, {
+        review_id = review.id,
+      })
     end
     M.reviews[tostring(tabpage)] = nil
   end

--- a/lua/tests/plenary/events_spec.lua
+++ b/lua/tests/plenary/events_spec.lua
@@ -1,0 +1,73 @@
+---@diagnostic disable
+local events = require "octo.events"
+local eq = assert.are.same
+
+describe("Events module:", function()
+  describe("constants", function()
+    it("define review lifecycle events.", function()
+      eq(events.REVIEW_OPENED, "OctoReviewOpened")
+      eq(events.REVIEW_CLOSED, "OctoReviewClosed")
+      eq(events.REVIEW_SUBMITTED, "OctoReviewSubmitted")
+      eq(events.REVIEW_DISCARDED, "OctoReviewDiscarded")
+    end)
+
+    it("define buffer lifecycle events.", function()
+      eq(events.BUFFER_LOADED, "OctoBufferLoaded")
+      eq(events.BUFFER_CLOSED, "OctoBufferClosed")
+    end)
+
+    it("define comment lifecycle events.", function()
+      eq(events.COMMENT_ADDED, "OctoCommentAdded")
+      eq(events.COMMENT_UPDATED, "OctoCommentUpdated")
+      eq(events.COMMENT_DELETED, "OctoCommentDeleted")
+    end)
+  end)
+
+  describe("emit", function()
+    it("fires a User autocommand with the given pattern and data.", function()
+      local received = false
+      vim.api.nvim_create_autocmd("User", {
+        pattern = events.COMMENT_ADDED,
+        once = true,
+        callback = function(opts)
+          received = true
+          eq(opts.data.comment_id, "123")
+          eq(opts.data.body, "test body")
+        end,
+      })
+
+      events.emit(events.COMMENT_ADDED, {
+        comment_id = "123",
+        body = "test body",
+        kind = "IssueComment",
+      })
+
+      vim.wait(50, function()
+        return false
+      end)
+      assert.is_true(received)
+    end)
+
+    it("delivers data through vim.v.event.", function()
+      local result
+      vim.api.nvim_create_autocmd("User", {
+        pattern = events.REVIEW_SUBMITTED,
+        once = true,
+        callback = function(opts)
+          result = opts.data
+        end,
+      })
+
+      events.emit(events.REVIEW_SUBMITTED, {
+        review_id = "42",
+        action = "APPROVE",
+      })
+
+      vim.wait(50, function()
+        return false
+      end)
+      eq(result.review_id, "42")
+      eq(result.action, "APPROVE")
+    end)
+  end)
+end)

--- a/lua/tests/plenary/hooks_spec.lua
+++ b/lua/tests/plenary/hooks_spec.lua
@@ -1,0 +1,125 @@
+---@diagnostic disable
+local hooks = require "octo.hooks"
+local eq = assert.are.same
+
+describe("Hooks module:", function()
+  before_each(function()
+    hooks.clear()
+  end)
+
+  describe("register", function()
+    it("adds a hook under the given name.", function()
+      local fn = function(data, next)
+        next(data)
+      end
+      hooks.register("test_hook", fn)
+      hooks.run("test_hook", { value = 1 }, function(result)
+        eq(result.value, 1)
+      end)
+    end)
+  end)
+
+  describe("run", function()
+    it("passes data through a single hook.", function()
+      hooks.register("mutate", function(data, next)
+        data.value = data.value + 1
+        next(data)
+      end)
+      hooks.run("mutate", { value = 1 }, function(result)
+        eq(result.value, 2)
+      end)
+    end)
+
+    it("chains multiple hooks in registration order.", function()
+      local order = {}
+      hooks.register("chain", function(data, next)
+        table.insert(order, "a")
+        next(data)
+      end)
+      hooks.register("chain", function(data, next)
+        table.insert(order, "b")
+        next(data)
+      end)
+      hooks.run("chain", {}, function()
+        eq(order, { "a", "b" })
+      end)
+    end)
+
+    it("mutates data across the chain.", function()
+      hooks.register("mutate", function(data, next)
+        data.body = data.body .. " middle"
+        next(data)
+      end)
+      hooks.register("mutate", function(data, next)
+        data.body = data.body .. " end"
+        next(data)
+      end)
+      hooks.run("mutate", { body = "start" }, function(result)
+        eq(result.body, "start middle end")
+      end)
+    end)
+
+    it("calls done immediately when no hooks registered.", function()
+      local called = false
+      hooks.run("unregistered", { x = 1 }, function(result)
+        called = true
+        eq(result.x, 1)
+      end)
+      assert.is_true(called)
+    end)
+
+    it("stalls if a hook never calls next.", function()
+      hooks.register("stall", function(_, _) end)
+      local called = false
+      hooks.run("stall", {}, function()
+        called = true
+      end)
+      assert.is_false(called)
+    end)
+
+    it("supports a single hook skipping optional args.", function()
+      hooks.register("single", function(data, next)
+        data.ok = true
+        next(data)
+      end)
+      hooks.run("single", { ok = false }, function(result)
+        assert.is_true(result.ok)
+      end)
+    end)
+  end)
+
+  describe("clear", function()
+    it("removes hooks for a specific name.", function()
+      hooks.register("temp", function(data, next)
+        next(data)
+      end)
+      hooks.clear "temp"
+      local called = false
+      hooks.run("temp", {}, function()
+        called = true
+      end)
+      assert.is_true(called)
+      -- no hooks intercept so done calls immediately
+    end)
+
+    it("removes all hooks when called without a name.", function()
+      hooks.register("a", function(data, next)
+        next(data)
+      end)
+      hooks.register("b", function(data, next)
+        next(data)
+      end)
+      hooks.clear()
+      local called_a = false
+      local called_b = false
+      hooks.run("a", {}, function()
+        called_a = true
+      end)
+      hooks.run("b", {}, function()
+        called_b = true
+      end)
+      assert.is_true(called_a)
+      assert.is_true(called_b)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary

Adds hooks (interception/mutation layer), events (read-only User autocmd
notifications), and expanded context helpers.

- **Hooks** (`require("octo.hooks")`): Chainable middleware pattern using
  `register(name, fn)`, `run(name, data, done)`, `clear(name)`. Each hook
  calls `next(mutated_data)` to pass control forward. Stalling the chain
  cancels the operation.
- **Events** (`require("octo.events")`): Constants + `emit()` wrapping
  `nvim_exec_autocmds("User", ...)`. Read-only notifications after API
  calls complete. Listen via `:help User` autocommands.
- **Context** (`require("octo.context")`): Expanded with missing buffer-kind
  guards (`within_release`, `within_review_thread`), direct-invoke variants
  (`with_*`), cursor accessors (`on_body`, `on_thread`), and convenience
  references (`get_current_buffer`, `get_current_review`, `buffer_at`).
- **Integrated hooks**: `before_review_submit` in `Review:submit()` with
  payload (`review_id`, `action`, `body`, `pull_request`).
- **Integrated events**: `REVIEW_OPENED`, `REVIEW_SUBMITTED`,
  `REVIEW_DISCARDED`, `REVIEW_CLOSED`, `COMMENT_ADDED` (5 call sites),
  `COMMENT_UPDATED`, `COMMENT_DELETED`, `BUFFER_LOADED`.
- **14 passing tests** for hooks (register, chain, mutate, order,
  pass-through, stall, skip-next, clear) and events (constants, emit
  reception).
- **Documentation** in `doc/octo.txt` (`*octo-hooks*`, `*octo-events*`,
  `*octo-context*`) and `README.md` pointer.

All pre-commit hooks pass (StyLua, linting, whitespace).

## Related Issues

closes #472, #501, #1249
