### PR TITLE
fix(workflow_runs): replace '/' in step/job names with '_' when matching log paths

### DIFF
--- a/lua/octo/workflow_runs.lua
+++ b/lua/octo/workflow_runs.lua
@@ -313,9 +313,9 @@ local function get_logs(id, repo)
       return
     end
 
-    local sanitized_name = node.id:gsub("/", ""):gsub(":", ""):gsub(">", "")
+    local sanitized_name = node.id:gsub("/", "_"):gsub(":", ""):gsub(">", "")
     --Make more than 3 consecutive dots at the end of line into */. This avoids a bug with unreliable filename endings
-    local sanitized_job_id = node.job_id:gsub("/", ""):gsub(":", ""):gsub("%.+$", "*/")
+    local sanitized_job_id = node.job_id:gsub("/", "_"):gsub(":", ""):gsub("%.+$", "*/")
     local file_name = string.format("%s_%s.txt", node.number, sanitized_name)
     local path = vim.fs.joinpath(sanitized_job_id, file_name)
     local res = vim


### PR DESCRIPTION
### Describe what this PR does / why we need it

When viewing workflow run logs via `Octo runs` and pressing `o` on a step, octo currently fails to extract logs for any step or job whose name contains `/`. The user sees a stream of `Failed to extract logs for ...` errors and no log content.

Repro: any workflow that uses an action with a `/` in its name (e.g. `dorny/paths-filter@v3`) or any job whose display name contains `/` (e.g. `Test / Underwriting`).

### Root cause

GitHub's `/repos/{owner}/{repo}/actions/runs/{id}/logs` zip encodes `/` in step/job names as `_`. For example:

- step `Run dorny/paths-filter@v3` → archive entry `Check-GraphQL-Paths/2_Run dorny_paths-filter@v3.txt`
- job `Test / Underwriting` → archive folder `Test _ Underwriting/`

`get_logs` in `lua/octo/workflow_runs.lua` sanitizes names by *stripping* `/` rather than replacing it with `_`:

```lua
local sanitized_name = node.id:gsub(\"/\", \"\")...
local sanitized_job_id = node.job_id:gsub(\"/\", \"\")...
```

So octo asks `unzip -p` for `Check-GraphQL-Paths/2_Run dornypaths-filter@v3.txt`, which doesn't exist, and `unzip` returns `caution: filename not matched`.

### Does this pull request fix one issue?

Refs #973

### Describe how you did it

Change both `gsub(\"/\", \"\")` calls to `gsub(\"/\", \"_\")` so the sanitized names match what GitHub actually puts in the zip.

### Describe how to verify it

1. `Octo pr runs` on a PR whose workflow includes a step like `uses: dorny/paths-filter@v3` or a job whose display name contains `/` (matrix jobs commonly do).
2. Press `o` on a run.
3. Before this fix: status line shows multiple `Failed to extract logs for ...` errors and no logs are populated.
4. After this fix: logs populate normally.

I confirmed against a real run by listing the archive with `unzip -Z1` and observing entries like `Test _ Underwriting/1_Set up job.txt` and `Check-GraphQL-Paths/2_Run dorny_paths-filter@v3.txt`.

### Special notes for reviews

Two-character diff. The other sanitization steps (`:`, `>`, trailing dots) are unchanged.

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt — not applicable, internal helper behavior only