### PR TITLE
fix(gh): remove duplicate timeline fragment definitions in mutations

### DIFF
--- a/lua/octo/gh/mutations.lua
+++ b/lua/octo/gh/mutations.lua
@@ -662,7 +662,7 @@ mutation($input: CreateIssueInput!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
+]] .. fragments.issue .. fragments.pull_request .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
 
   M.close_issue = [[
 mutation($issueId: ID!, $stateReason: IssueCloseReason) {
@@ -699,7 +699,7 @@ mutation($issueId: ID!, $stateReason: IssueCloseReason) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.label_connection .. fragments.label .. fragments.reaction_groups .. fragments.assignee_connection .. fragments.issue_comment .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
+]] .. fragments.issue .. fragments.pull_request .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
 
   -- https://docs.github.com/en/free-pro-team@latest/graphql/reference/mutations#updateissue
   M.update_issue_state = [[
@@ -737,7 +737,7 @@ mutation($id: ID!, $state: IssueState!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
+]] .. fragments.issue .. fragments.pull_request .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
 
   -- https://docs.github.com/en/graphql/reference/mutations#reopenissue
   M.reopen_issue = [[
@@ -777,7 +777,7 @@ mutation($issueId: ID!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
+]] .. fragments.issue .. fragments.pull_request .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_timeline_items_connection .. fragments.issue_information .. fragments.get_issue_timeline_definitions()
 
   ---@class octo.mutations.UpdatePullRequest
   ---@field data {
@@ -903,7 +903,7 @@ mutation($pullRequestId: ID!, $state: PullRequestUpdateState!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.merged_event .. fragments.review_requested_event .. fragments.renamed_title_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.get_pr_timeline_definitions()
+]] .. fragments.issue .. fragments.pull_request .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.get_pr_timeline_definitions()
 
   M.create_discussion = [[
 mutation($repo_id: ID!, $category_id: ID!, $title: String!, $body: String!) {
@@ -1185,7 +1185,7 @@ mutation($input: CreatePullRequestInput!) {
     }
   }
 }
-]] .. fragments.cross_referenced_event .. fragments.issue .. fragments.pull_request .. fragments.connected_event .. fragments.convert_to_draft_event .. fragments.milestoned_event .. fragments.demilestoned_event .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.issue_comment .. fragments.pull_request_review .. fragments.pull_request_commit .. fragments.review_request_removed_event .. fragments.review_requested_event .. fragments.merged_event .. fragments.review_dismissed_event .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.get_pr_timeline_definitions()
+]] .. fragments.issue .. fragments.pull_request .. fragments.reaction_groups .. fragments.label_connection .. fragments.label .. fragments.assignee_connection .. fragments.pull_request_timeline_items_connection .. fragments.review_thread_information .. fragments.review_thread_comment .. fragments.get_pr_timeline_definitions()
 
   M.mark_answer = [[
 mutation($id: ID!) {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

The timeline registry refactor in #1491 added `fragments.get_pr_timeline_definitions()` / `fragments.get_issue_timeline_definitions()` which emit the full GraphQL fragment definitions for every registered timeline-item fragment. `lua/octo/gh/queries.lua` was updated to use those helpers exclusively, but `lua/octo/gh/mutations.lua` was missed — its 6 issue/PR mutations still concatenate the individual timeline-item fragments *and* call the registry helper, so each of those fragments ends up defined twice in the same query.

`gh` 2.92+ enforces unique fragment names and rejects these mutations with errors like:

```
Fragment name "CrossReferencedEventFragment" must be unique
Fragment name "ConnectedEventFragment" must be unique
Fragment name "ConvertToDraftEventFragment" must be unique
Fragment name "MilestonedEventFragment" must be unique
Fragment name "DemilestonedEventFragment" must be unique
Fragment name "IssueCommentFragment" must be unique
Fragment name "PullRequestReviewFragment" must be unique
Fragment name "PullRequestCommitFragment" must be unique
Fragment name "ReviewRequestRemovedEventFragment" must be unique
Fragment name "ReviewRequestedEventFragment" must be unique
Fragment name "MergedEventFragment" must be unique
Fragment name "ReviewDismissedEventFragment" must be unique
```

This breaks `:Octo pr create`, `:Octo pr edit`, `:Octo issue close`, `:Octo issue reopen`, `:Octo issue edit`, and `:Octo issue create` on current `gh`.

### Does this pull request fix one issue?

Fixes #1519

### Describe how you did it

Aligned the 6 affected mutation concatenations in `lua/octo/gh/mutations.lua` with the pattern already used by the corresponding queries in `lua/octo/gh/queries.lua`: removed the explicit per-event fragments that are now emitted by the registry helper, keeping only the non-timeline fragments (`issue`, `pull_request`, `reaction_groups`, `label_connection`, `label`, `assignee_connection`, `issue_timeline_items_connection` / `pull_request_timeline_items_connection`, `issue_information` / `review_thread_*`) plus the `get_*_timeline_definitions()` call.

Affected mutations:

- `update_issue`
- `close_issue`
- `update_issue_state`
- `reopen_issue`
- `update_pull_request`
- `create_pr`

No fragment that was previously available to these queries is dropped — every removed name is registered in the corresponding `_issue_timeline_registry` / `_pr_timeline_registry` in `lua/octo/gh/fragments.lua` and therefore re-emitted by the registry helper.

### Describe how to verify it

With `gh` 2.92.0+ on a clean checkout of `master`, the following commands fail before this PR and succeed after it:

- `:Octo pr create`
- `:Octo pr edit`
- `:Octo issue create`
- `:Octo issue edit`
- `:Octo issue close`
- `:Octo issue reopen`

You can also confirm by grepping `lua/octo/gh/mutations.lua` for any of the previously duplicated fragment names (`cross_referenced_event`, `connected_event`, `convert_to_draft_event`, `milestoned_event`, `demilestoned_event`, `issue_comment`, `pull_request_review`, `pull_request_commit`, `review_request_removed_event`, `review_requested_event`, `merged_event`, `review_dismissed_event`, `renamed_title_event`) — they should no longer appear.

### Special notes for reviews

Pure regression fix; behaviorally a no-op when paired with a `gh` that didn't enforce unique fragment names. Scope is intentionally limited to `lua/octo/gh/mutations.lua` so the diff is easy to review against #1491.

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt (not applicable — internal GraphQL query string only)
