### PR TITLE
feat: add config to hide virtual-text on review panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ require"octo".setup {
   reviews = {
     auto_show_threads = true, -- automatically show comment threads on cursor move
     focus = "right", -- focus right buffer on diff open
+    show_virtual_text = true, -- show virtual text with comment count and date
   },
   runs = {
     icons = {
@@ -777,6 +778,7 @@ If no command is passed, the argument to `Octo` is treated as a URL from where a
 - Hold the cursor on a line with a comment to show a thread buffer with all the thread comments
   - To modify, delete, react or reply to a comment, move to the window containing the thread buffer
   - Perform any operations as if you were in a regular issue buffer
+- Virtual text showing comment count and date can be controlled via the `show_virtual_text` option under `reviews` config
 - Review pending comments with `Octo review comments`
   - Use <CR> to jump to the selected pending comment
 - If you want to review a specific commit, use `Octo review commit` to pick a commit. The file panel will get filtered to show only files changed by that commit. Any comments placed on these files will be applied at that specific commit level and will be added to the pending review.

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -75,6 +75,7 @@ local M = {}
 ---@class OctoConfigReviews
 ---@field auto_show_threads boolean
 ---@field focus OctoSplit
+---@field show_virtual_text boolean
 
 ---@class OctoConfigDiscussions
 ---@field order_by OctoConfigOrderBy
@@ -290,6 +291,7 @@ function M.get_default_values()
     reviews = {
       auto_show_threads = true, -- automatically show comment threads on cursor move
       focus = "right", -- focus right buffer on diff open
+      show_virtual_text = true, -- show virtual text with comment count and date
     },
     runs = {
       icons = {

--- a/lua/octo/reviews/file-entry.lua
+++ b/lua/octo/reviews/file-entry.lua
@@ -407,6 +407,10 @@ end
 
 ---Update thread signs in diff buffers.
 function FileEntry:place_signs()
+  self:_place_signs_with_virtual_text(config.values.reviews.show_virtual_text)
+end
+
+function FileEntry:_place_signs_with_virtual_text(show_virtual_text)
   local current_review = require("octo.reviews").get_current_review()
   if not current_review then
     return
@@ -472,19 +476,26 @@ function FileEntry:place_signs()
           end
 
           -- place the virtual text only on first line
-          local last_date = comment.lastEditedAt ~= vim.NIL and comment.lastEditedAt or comment.createdAt
-          local comments_count = #thread.comments.nodes
-          local comments_word = comments_count == 1 and "comment" or "comments"
-          local vt_msg = string.format("    %d %s (%s)", comments_count, comments_word, utils.format_date(last_date))
-          --vim.api.nvim_buf_set_virtual_text(split.bufnr, -1, startLine - 1, { { vt_msg, "Comment" } }, {})
-          local opts = {
-            virt_text = { { vt_msg, "Comment" } },
-            virt_text_pos = "right_align",
-            -- adding the extmark below can fail if we are in the `COMMIT` review level and the commit contains thread comments
-            -- that is why we set strict to `false` here to ignore this possible error
-            strict = false,
-          }
-          vim.api.nvim_buf_set_extmark(split.bufnr, constants.OCTO_REVIEW_COMMENTS_NS, startLine - 1, -1, opts)
+          if show_virtual_text then
+            local last_date = comment.lastEditedAt ~= vim.NIL and comment.lastEditedAt or comment.createdAt
+            local comments_count = #thread.comments.nodes
+            local comments_word = comments_count == 1 and "comment" or "comments"
+            local vt_msg = string.format("    %d %s (%s)", comments_count, comments_word, utils.format_date(last_date))
+            local opts = {
+              virt_text = { { vt_msg, "Comment" } },
+              virt_text_pos = "right_align",
+              -- adding the extmark below can fail if we are in the `COMMIT` review level and the commit contains thread comments
+              -- that is why we set strict to `false` here to ignore this possible error
+              strict = false,
+            }
+            vim.api.nvim_buf_set_extmark(split.bufnr, constants.OCTO_REVIEW_COMMENTS_NS, startLine - 1, -1, opts)
+          else
+            -- still place the sign without virtual text
+            local opts = {
+              strict = false,
+            }
+            vim.api.nvim_buf_set_extmark(split.bufnr, constants.OCTO_REVIEW_COMMENTS_NS, startLine - 1, -1, opts)
+          end
           -- break out to prevent duplicate extmarks for the current comment thread
           break
         end


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
The virtual-text in the review panel might hide the text in the buffer.

### Does this pull request fix one issue?
Fixes #445

### Describe how you did it
- Add `show_virtual_text` config option (default: true)
- Refactor `place_signs` to conditionally render virtual text based on config
- Update README with new configuration option and usage details


### Describe how to verify it
Add the following configuration:
```lua
require"octo".setup {
...
reviews = {
    show_virtual_text = false, -- show virtual text with comment count and date on review diff
  },
...
}
```

And open a review on a PR with pre-existing comments. Verify that no virtual-text is visible.

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
