### PR TITLE
fix(timeline): guard nil actors in GHES timeline events

### DIFF
--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -2322,6 +2322,11 @@ end
 ---@param bufnr integer
 ---@param item octo.fragments.HeadRefDeletedEvent
 function M.write_head_ref_deleted_event(bufnr, item)
+  -- Handle case where actor is nil (can happen on GHES when fragment is excluded)
+  if utils.is_blank(item.actor) then
+    return
+  end
+
   TextChunkBuilder:new()
     :timeline_marker("head_ref")
     :actor(item.actor)
@@ -2362,6 +2367,11 @@ end
 ---@param bufnr integer
 ---@param item octo.fragments.HeadRefRestoredEvent
 function M.write_head_ref_restored_event(bufnr, item)
+  -- Handle case where actor is nil (can happen on GHES when fragment is excluded)
+  if utils.is_blank(item.actor) then
+    return
+  end
+
   TextChunkBuilder:new()
     :timeline_marker("head_ref")
     :actor(item.actor)
@@ -2581,6 +2591,11 @@ end
 ---@param bufnr integer
 ---@param item octo.fragments.DeployedEvent
 function M.write_deployed_event(bufnr, item)
+  -- Handle case where actor is nil (can happen on GHES when fragment is excluded)
+  if utils.is_blank(item.actor) then
+    return
+  end
+
   local bubble_info = utils.deployed_state_map[item.deployment.state]
   TextChunkBuilder:new()
     :timeline_marker("deployed")
@@ -2848,6 +2863,11 @@ end
 ---@param bufnr integer
 ---@param item octo.fragments.ConvertToDraftEvent
 function M.write_convert_to_draft_event(bufnr, item)
+  -- Handle case where actor is nil (can happen on GHES when fragment is excluded)
+  if utils.is_blank(item.actor) then
+    return
+  end
+
   TextChunkBuilder:new()
     :timeline_marker("draft")
     :actor(item.actor)
@@ -2873,6 +2893,11 @@ end
 ---@param bufnr integer
 ---@param item octo.fragments.BaseRefChangedEvent
 function M.write_base_ref_changed_event(bufnr, item)
+  -- Handle case where actor is nil (can happen on GHES when fragment is excluded)
+  if utils.is_blank(item.actor) then
+    return
+  end
+
   TextChunkBuilder:new()
     :timeline_marker("base_ref_changed")
     :actor(item.actor)

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -2274,6 +2274,11 @@ end
 ---@param bufnr integer
 ---@param item octo.fragments.AutoSquashEnabledEvent
 function M.write_auto_squash_enabled_event(bufnr, item)
+  -- Handle case where actor is nil (can happen on GHES when fragment is excluded)
+  if utils.is_blank(item.actor) then
+    return
+  end
+
   TextChunkBuilder:new()
     :timeline_marker("auto_squash")
     :actor(item.actor)
@@ -2285,6 +2290,11 @@ end
 ---@param bufnr integer
 ---@param item octo.fragments.AutoMergeEnabledEvent
 function M.write_auto_merge_enabled_event(bufnr, item)
+  -- Handle case where actor is nil (can happen on GHES when fragment is excluded)
+  if utils.is_blank(item.actor) then
+    return
+  end
+
   TextChunkBuilder:new()
     :timeline_marker("auto_squash")
     :actor(item.actor)
@@ -2296,6 +2306,11 @@ end
 ---@param bufnr integer
 ---@param item octo.fragments.AutoMergeDisabledEvent
 function M.write_auto_merge_disabled_event(bufnr, item)
+  -- Handle case where actor is nil (can happen on GHES when fragment is excluded)
+  if utils.is_blank(item.actor) then
+    return
+  end
+
   TextChunkBuilder:new()
     :timeline_marker("auto_squash")
     :actor(item.actor)
@@ -2361,6 +2376,12 @@ end
 ---@param items octo.fragments.HeadRefForcePushedEvent[]
 function M.write_head_ref_force_pushed_events(bufnr, items)
   local total_events = #items
+
+  -- Handle case where actor is nil (can happen on GHES when fragment is excluded)
+  if utils.is_blank(items[1].actor) then
+    return
+  end
+
   local builder = TextChunkBuilder:new()
     :timeline_marker("force_push")
     :actor(items[1].actor)
@@ -3588,6 +3609,7 @@ function M.write_timeline_items(bufnr, obj)
       and (
         not item
         or item.__typename ~= "HeadRefForcePushedEvent"
+        or not item.actor
         or item.actor.login ~= unrendered_force_push_events[1].actor.login
       )
     then


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fixes an issues when trying to view the details of a PR on a GHES instance, whereby an `attempt to index local 'actor' (a nil value)` error is thrown if the timeline contains a force push event/

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #1524 

### Describe how you did it

Added additional checks and guards for the presence of `item.actor` where previously the assumption was that the property would exist and be valid.

### Describe how to verify it

Create a pr on a GHES instance, and performa force push to the PR branch. Run `:Octo pr` to view that PR's details. Without the code changes in this PR, an error will be thrown. With these changes, the PR detaisl are viewed as expected, without error.

### Special notes for reviews

Requires GHES access

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
