### PR TITLE
feat(config): add user-configurable conceallevel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ require"octo".setup {
     projects_v2 = false,
   },
   ui = {
+    conceallevel = 2, -- conceallevel for octo buffers
     use_signcolumn = false, -- show "modified" marks on the sign column
     use_statuscolumn = true, -- show "modified" marks on the status column
     use_foldtext = true,

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -65,6 +65,7 @@ local M = {}
 ---@field icons boolean|fun(name: string, ext: string): string?, string?
 
 ---@class OctoConfigUi
+---@field conceallevel integer
 ---@field use_signcolumn boolean
 ---@field use_statuscolumn boolean
 ---@field use_foldtext boolean
@@ -268,6 +269,7 @@ function M.get_default_values()
       projects_v2 = false,
     },
     ui = {
+      conceallevel = 2, -- conceallevel for octo buffers
       use_signcolumn = false, -- show "modified" marks on the sign column
       use_statuscolumn = true, -- show "modified" marks on the status column
       use_foldtext = true,

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -223,7 +223,7 @@ function OctoBuffer:configure()
     vim.cmd [[setlocal filetype=octo]]
     vim.cmd [[setlocal buftype=acwrite]]
     vim.cmd [[setlocal omnifunc=v:lua.octo_omnifunc]]
-    vim.cmd [[setlocal conceallevel=2]]
+    vim.wo[0][0].conceallevel = config.values.ui.conceallevel
     vim.cmd [[setlocal nonumber norelativenumber nocursorline wrap]]
 
     if config.values.ui.use_signcolumn then


### PR DESCRIPTION
### Describe what this PR does / why we need it

exposes conceallevel as a user-configurable option during setup.

i initially tried setting it in after/ftplugin/octo.lua like a good citizen, but i quickly realized that octo was ignoring my configuration. if it intends to control that value, might as well let the user change it during setup.

### Does this pull request fix one issue?

NONE

### Describe how you did it

```lua
vim.wo[0][0].conceallevel = config.values.ui.conceallevel
```

### Describe how to verify it

```lua
require("octo").setup({ ui = { conceallevel = 0 } })
```

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt