### PR TITLE
fix: ignore stale reload callbacks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,15 @@ jobs:
         with:
           neovim: true
           version: ${{ matrix.nvim_version }}
+      - name: Install vusted
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lua5.1 liblua5.1-0-dev luarocks
+          luarocks --lua-version=5.1 install --local vusted
+      - name: Run vusted tests
+        run: |
+          eval "$(luarocks --lua-version=5.1 path --local)"
+          VUSTED_USE_LOCAL=1 vusted lua/tests/vusted/load_buffer_stale_spec.lua
       - name: Restore plenary.nvim from cache
         uses: actions/cache@v6
         with:

--- a/lua/octo/init.lua
+++ b/lua/octo/init.lua
@@ -98,7 +98,8 @@ end
 function M.load_buffer(opts)
   opts = opts or {}
   local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
-  local cursor_pos = vim.api.nvim_win_get_cursor(0)
+  local winid = vim.api.nvim_get_current_win()
+  local cursor_pos = vim.api.nvim_win_get_cursor(winid)
   local bufname = vim.fn.bufname(bufnr)
   local buffer_info = uri.parse(bufname)
   if buffer_info == nil then
@@ -107,19 +108,43 @@ function M.load_buffer(opts)
   end
   local repo, kind, id, hostname = buffer_info.repo, buffer_info.kind, buffer_info.id, buffer_info.hostname
 
+  local function is_stale_target()
+    if not vim.api.nvim_buf_is_valid(bufnr) or not vim.api.nvim_buf_is_loaded(bufnr) then
+      return true
+    end
+
+    local current = uri.parse(vim.fn.bufname(bufnr))
+    if current == nil then
+      return true
+    end
+
+    return current.repo ~= repo
+      or current.kind ~= kind
+      or tostring(current.id) ~= tostring(id)
+      or current.hostname ~= hostname
+  end
+
   M.load(repo, kind, id, hostname, function(obj)
+    if is_stale_target() then
+      return
+    end
+
+    local should_restore_cursor = vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == bufnr
+
     vim.api.nvim_buf_call(bufnr, function()
       M.create_buffer(kind, obj, repo, false, hostname)
 
-      -- get size of newly created buffer
-      local lines = vim.api.nvim_buf_line_count(bufnr)
+      if should_restore_cursor then
+        -- get size of newly created buffer
+        local lines = vim.api.nvim_buf_line_count(bufnr)
 
-      -- One to the left
-      local new_cursor_pos = {
-        math.min(cursor_pos[1], lines),
-        math.max(0, cursor_pos[2] - 1),
-      }
-      vim.api.nvim_win_set_cursor(0, new_cursor_pos)
+        -- One to the left
+        local new_cursor_pos = {
+          math.min(cursor_pos[1], lines),
+          math.max(0, cursor_pos[2] - 1),
+        }
+        pcall(vim.api.nvim_win_set_cursor, winid, new_cursor_pos)
+      end
 
       if opts.verbose then
         utils.info(string.format("Loaded %s/%s/%d", repo, kind, id))

--- a/lua/tests/vusted/load_buffer_stale_spec.lua
+++ b/lua/tests/vusted/load_buffer_stale_spec.lua
@@ -1,0 +1,135 @@
+---@diagnostic disable
+vim.opt.runtimepath:append(vim.fn.getcwd())
+vim.opt.swapfile = false
+
+local octo = require "octo"
+
+describe("octo.load_buffer stale callbacks", function()
+  local original_load
+  local original_create_buffer
+  local original_win_set_cursor
+  local callbacks
+  local create_calls
+  local cursor_calls
+  local buffers
+
+  local function create_octo_buffer(name)
+    local bufnr = vim.api.nvim_create_buf(true, false)
+    table.insert(buffers, bufnr)
+    vim.bo[bufnr].swapfile = false
+    vim.api.nvim_buf_set_name(bufnr, name or "octo://pwntester/octo.nvim/issue/42")
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "one", "two", "three" })
+    vim.api.nvim_set_current_buf(bufnr)
+    return bufnr
+  end
+
+  local function callback()
+    assert(#callbacks == 1, "expected one captured load callback, got " .. #callbacks)
+    return callbacks[1]
+  end
+
+  before_each(function()
+    original_load = octo.load
+    original_create_buffer = octo.create_buffer
+    original_win_set_cursor = vim.api.nvim_win_set_cursor
+    callbacks = {}
+    create_calls = {}
+    cursor_calls = {}
+    buffers = {}
+
+    octo.load = function(repo, kind, id, hostname, cb)
+      table.insert(callbacks, {
+        repo = repo,
+        kind = kind,
+        id = tostring(id),
+        hostname = hostname,
+        cb = cb,
+      })
+    end
+
+    octo.create_buffer = function(kind, obj, repo, create, hostname)
+      table.insert(create_calls, {
+        bufnr = vim.api.nvim_get_current_buf(),
+        kind = kind,
+        obj = obj,
+        repo = repo,
+        create = create,
+        hostname = hostname,
+      })
+    end
+  end)
+
+  after_each(function()
+    octo.load = original_load
+    octo.create_buffer = original_create_buffer
+    vim.api.nvim_win_set_cursor = original_win_set_cursor
+
+    for _, bufnr in ipairs(buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+  end)
+
+  it("ignores deleted target buffers", function()
+    local bufnr = create_octo_buffer()
+
+    octo.load_buffer { bufnr = bufnr }
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+
+    local ok, err = pcall(callback().cb, { id = "node-id", number = 42 })
+
+    assert(ok, err)
+    assert(#create_calls == 0, "expected no render calls, got " .. #create_calls)
+  end)
+
+  it("ignores buffers renamed to a different octo target", function()
+    local bufnr = create_octo_buffer()
+
+    octo.load_buffer { bufnr = bufnr }
+    vim.api.nvim_buf_set_name(bufnr, "octo://pwntester/octo.nvim/issue/43")
+
+    local ok, err = pcall(callback().cb, { id = "node-id", number = 42 })
+
+    assert(ok, err)
+    assert(#create_calls == 0, "expected no render calls, got " .. #create_calls)
+  end)
+
+  it("reloads a valid target buffer", function()
+    local bufnr = create_octo_buffer()
+    vim.api.nvim_win_set_cursor(0, { 2, 1 })
+
+    octo.load_buffer { bufnr = bufnr }
+    callback().cb { id = "node-id", number = 42 }
+
+    assert(#create_calls == 1, "expected one render call, got " .. #create_calls)
+    assert(create_calls[1].bufnr == bufnr, "expected render in target buffer")
+    assert(create_calls[1].kind == "issue", "expected issue kind")
+    assert(create_calls[1].repo == "pwntester/octo.nvim", "expected repo to be preserved")
+
+    local cursor = vim.api.nvim_win_get_cursor(0)
+    assert(cursor[1] == 2, "expected cursor row 2, got " .. cursor[1])
+    assert(cursor[2] == 0, "expected cursor column 0, got " .. cursor[2])
+  end)
+
+  it("does not restore cursor when original window no longer shows target buffer", function()
+    local bufnr = create_octo_buffer()
+    vim.api.nvim_win_set_cursor(0, { 3, 2 })
+
+    octo.load_buffer { bufnr = bufnr }
+
+    local other = create_octo_buffer "octo://pwntester/octo.nvim/issue/99"
+    vim.api.nvim_set_current_buf(other)
+
+    vim.api.nvim_win_set_cursor = function(winid, pos)
+      table.insert(cursor_calls, { winid = winid, pos = pos })
+      return original_win_set_cursor(winid, pos)
+    end
+
+    callback().cb { id = "node-id", number = 42 }
+
+    assert(#create_calls == 1, "expected one render call, got " .. #create_calls)
+    assert(create_calls[1].bufnr == bufnr, "expected render in target buffer")
+    assert(#cursor_calls == 0, "expected no cursor restore calls, got " .. #cursor_calls)
+  end)
+end)


### PR DESCRIPTION
### Describe what this PR does / why we need it

This PR fixes a stale async reload callback race in `octo.load_buffer()`.

If an Octo buffer is closed, unloaded, renamed, or replaced while an async reload is still in flight, the old callback can later try to render into the stale buffer and crash with an invalid buffer error. The callback now silently returns when the original target is no longer valid or no longer matches the captured Octo URI target.

This also adds a vusted regression test so the behavior is checked inside real headless Neovim without adding Plenary coverage for this case.

### Does this pull request fix one issue?

Fixes #1528

### Describe how you did it

- Capture the original buffer, window, cursor position, and parsed Octo target before starting `M.load()`.
- Before rendering the async callback result, verify that the buffer is still valid, loaded, parseable, and still points at the same repo/kind/id/hostname.
- Skip cursor restore unless the original window is still valid and still displaying the target buffer.
- Add a vusted spec that monkeypatches `octo.load()` and `octo.create_buffer()` to exercise deleted, renamed, valid, and window-changed reload callbacks with real Neovim buffer APIs.
- Add a vusted CI step to the existing test workflow while keeping the current Plenary test step unchanged.

### Describe how to verify it

Verified locally:

```sh
mise exec -- vusted lua/tests/vusted/load_buffer_stale_spec.lua
```

Result:

```text
4 success
```

Also verified workflow YAML parsing locally.

Note: the existing Plenary suite is still run by CI through the existing workflow setup. My local Plenary run did not complete cleanly because the local runtime could not load `plenary/busted`, so CI remains the source of truth for the existing Plenary job.

### Special notes for reviews

This intentionally leaves existing Plenary tests alone, but does not add a new Plenary test for this regression. The project is tracking migration away from Plenary, and this bug depends on real Neovim buffer/window behavior, so the new coverage uses vusted instead.

Stale callbacks are silent by design; this is an expected async race, not a user-facing error.

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt (not applicable)
