### PR TITLE
fix(gh): pass comment/issue body as raw-field to avoid @ file interpretation

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -1839,7 +1839,10 @@ function M.save_issue(opts)
   gh.api.graphql {
     query = mutations.create_issue,
     jq = ".data.createIssue.issue",
-    F = { input = { repositoryId = utils.get_repo_id(opts.repo), title = title, body = body } },
+    -- Use f (raw-field) for title and body to avoid gh CLI interpreting a leading @ (mention)
+    -- as a file path (see https://github.com/cli/cli/issues/5979 - -F interprets @, -f treats as literal)
+    f = { input = { title = title, body = body } },
+    F = { input = { repositoryId = utils.get_repo_id(opts.repo) } },
     opts = {
       cb = gh.create_callback {
         success = function(output)

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -609,8 +609,14 @@ function OctoBuffer:do_add_new_thread(comment_metadata)
       input["line"] = comment_metadata.snippetEndLine
     end
 
+    -- Use f (raw-field) for body to avoid gh CLI interpreting a leading @ (mention)
+    -- as a file path (see https://github.com/cli/cli/issues/5979 - -F interprets @, -f treats as literal)
+    local input_f = { body = input.body }
+    input.body = nil
+
     gh.api.graphql {
       query = mutations.add_pull_request_review_thread,
+      f = { input = input_f },
       F = { input = input },
       opts = {
         cb = gh.create_callback {


### PR DESCRIPTION
## Problem

Creating an inline review-comment thread, or a new issue, whose body starts with an `@`-mention fails:

```
error parsing "input[body]" value: open <comment text>: no such file or directory
```

### Root cause

`OctoBuffer:do_add_new_thread` (`lua/octo/model/octo-buffer.lua`) and `create_issue` (`lua/octo/commands.lua`) send the body via the typed `-F`/`--field` flag. `gh` interprets a leading `@` in a `--field` value as "read the value from this file" ([cli/cli#5979](https://github.com/cli/cli/issues/5979)), so it strips the `@` and tries to open the rest of the comment as a filename.

Reproduce:

```
$ gh api graphql -f query='query{x}' -F 'input[body]=@user please fix this'
error parsing "input[body]" value: open user please fix this: no such file or directory
```

This is the same class of bug already fixed for updating an existing issue/PR title & body in `OctoBuffer:save()` (which uses `-f` for body/title with a comment citing cli/cli#5979). Two creation paths were missed.

## Fix

Move `body` (and the issue `title`) to `-f`/`--raw-field`, which treats the value as a literal string, while keeping non-string fields (`line`, ids, `repositoryId`) on `-F` for correct GraphQL type conversion. All `input[...]` params still merge into a single `input` object, so behavior is otherwise unchanged.

## Verification

- `luac -p` passes on both files; `stylua --check` clean.
- Simulated the built args — body lands on `-f input[body]=@...`, `line` stays on `-F input[line]=42`:

```
-f input[body]=@sherly19 could you upgrade to 9.0.2
-F input[line]=42
-F input[pullRequestReviewId]=R_x
...
```

- Confirmed `gh api graphql -f 'input[body]=@user ...'` no longer errors on the `@` (reaches GraphQL instead of the file-open error).