### PR TITLE
feat(merge-queue): render merged via the queue and enable GHES support

### DIFF
--- a/lua/octo/gh/fragments.lua
+++ b/lua/octo/gh/fragments.lua
@@ -1467,9 +1467,9 @@ fragment IssueTimelineItemsConnectionFragment on IssueTimelineItemsConnection {
     { "AutoSquashEnabledEventFragment", M.auto_squash_enabled_event, is_github_com },
     { "AutoMergeEnabledEventFragment", M.auto_merge_enabled_event, is_github_com },
     { "AutoMergeDisabledEventFragment", M.auto_merge_disabled_event, is_github_com },
-    -- Merge queue events (GHES 3.12+, gated to github.com for safety)
-    { "AddedToMergeQueueEventFragment", M.added_to_merge_queue_event, is_github_com },
-    { "RemovedFromMergeQueueEventFragment", M.removed_from_merge_queue_event, is_github_com },
+    -- Merge queue events (GHES 3.12+)
+    { "AddedToMergeQueueEventFragment", M.added_to_merge_queue_event },
+    { "RemovedFromMergeQueueEventFragment", M.removed_from_merge_queue_event },
     -- Projects V2
     { "AddedToProjectV2EventFragment", M.added_to_project_v2_event, projects_v2_enabled },
     { "RemovedFromProjectV2EventFragment", M.removed_from_project_v2_event, projects_v2_enabled },

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -158,7 +158,7 @@ query($endCursor: String) {
     pullRequest(number: %d) {
       id
       isDraft
-      {isInMergeQueue}
+      isInMergeQueue
       number
       state
       title
@@ -560,7 +560,7 @@ query(
         repository { nameWithOwner }
         headRefName
         isDraft
-        {isInMergeQueue}
+        isInMergeQueue
         state
       }
       pageInfo {
@@ -600,7 +600,7 @@ query($prompt: String!, $type: SearchType = ISSUE, $last: Int = 100) {
         url
         state
         isDraft
-        {isInMergeQueue}
+        isInMergeQueue
         repository { nameWithOwner }
       }
       ... on Discussion {

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -3110,14 +3110,20 @@ end
 
 ---@param bufnr integer
 ---@param item octo.fragments.MergedEvent
-function M.write_merged_event(bufnr, item)
-  TextChunkBuilder:new()
-    :timeline_marker("merged")
-    :actor(item.actor)
-    :heading(" merged commit ")
-    :text(item.commit.abbreviatedOid, "OctoDetailsLabel")
-    :heading(" into ")
+---@param via_queue? boolean
+function M.write_merged_event(bufnr, item, via_queue)
+  local builder = TextChunkBuilder:new():timeline_marker("merged"):actor(item.actor)
+
+  if via_queue then
+    builder:heading " merged via the queue into "
+  else
+    builder:heading " merged into "
+  end
+
+  builder
     :heading(item.mergeRefName)
+    :heading(" with commit ")
+    :text(item.commit.abbreviatedOid, "OctoDetailsLabel")
     :date(item.createdAt)
     :write_event(bufnr)
 end
@@ -3649,6 +3655,17 @@ function M.write_timeline_items(bufnr, obj)
   --- labeled/unlabeled events or subissues events are rendered
   table.insert(timeline_nodes, {})
 
+  --- Pre-scan: detect if this PR was merged via the merge queue.
+  --- The RemovedFromMergeQueueEvent (reason: "merged") appears after MergedEvent
+  --- in the timeline, so we need to know upfront to adjust MergedEvent rendering.
+  local merged_via_queue = false
+  for _, node in ipairs(timeline_nodes) do
+    if node.__typename == "RemovedFromMergeQueueEvent" and node.reason == "merged" then
+      merged_via_queue = true
+      break
+    end
+  end
+
   ---@param items any[]
   local function clear_items(items)
     for idx = #items, 1, -1 do
@@ -3729,6 +3746,20 @@ function M.write_timeline_items(bufnr, obj)
     subissue_removed_events = unrendered_subissue_removed_events,
   }
 
+  --- When merged via the queue, wrap the MergedEvent writer to pass via_queue flag.
+  --- The RemovedFromMergeQueueEvent (reason: "merged") is skipped by its writer,
+  --- so the MergedEvent carries the queue context instead.
+  local orig_merged_writer = nil
+  if merged_via_queue then
+    local entry = timeline_registry.get "MergedEvent"
+    if entry and entry.writer then
+      orig_merged_writer = entry.writer
+      entry.writer = function(bufnr_inner, item_inner)
+        orig_merged_writer(bufnr_inner, item_inner, true)
+      end
+    end
+  end
+
   for _, item in ipairs(timeline_nodes) do
     render_accumulated_events(item)
     if item.__typename == "IssueComment" then
@@ -3801,6 +3832,14 @@ function M.write_timeline_items(bufnr, obj)
 
   if prev_is_event then
     M.write_block(bufnr, { "" })
+  end
+
+  --- Restore the original MergedEvent writer after rendering.
+  if orig_merged_writer then
+    local entry = timeline_registry.get "MergedEvent"
+    if entry then
+      entry.writer = orig_merged_writer
+    end
   end
 end
 

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -3746,20 +3746,6 @@ function M.write_timeline_items(bufnr, obj)
     subissue_removed_events = unrendered_subissue_removed_events,
   }
 
-  --- When merged via the queue, wrap the MergedEvent writer to pass via_queue flag.
-  --- The RemovedFromMergeQueueEvent (reason: "merged") is skipped by its writer,
-  --- so the MergedEvent carries the queue context instead.
-  local orig_merged_writer = nil
-  if merged_via_queue then
-    local entry = timeline_registry.get "MergedEvent"
-    if entry and entry.writer then
-      orig_merged_writer = entry.writer
-      entry.writer = function(bufnr_inner, item_inner)
-        orig_merged_writer(bufnr_inner, item_inner, true)
-      end
-    end
-  end
-
   for _, item in ipairs(timeline_nodes) do
     render_accumulated_events(item)
     if item.__typename == "IssueComment" then
@@ -3806,7 +3792,11 @@ function M.write_timeline_items(bufnr, obj)
       local entry = timeline_registry.get(item.__typename)
       if entry then
         if entry.writer then
-          entry.writer(bufnr, item)
+          if item.__typename == "MergedEvent" and merged_via_queue then
+            M.write_merged_event(bufnr, item, true)
+          else
+            entry.writer(bufnr, item)
+          end
           if entry.sets_prev_event == nil or entry.sets_prev_event then
             prev_is_event = true
           end
@@ -3832,14 +3822,6 @@ function M.write_timeline_items(bufnr, obj)
 
   if prev_is_event then
     M.write_block(bufnr, { "" })
-  end
-
-  --- Restore the original MergedEvent writer after rendering.
-  if orig_merged_writer then
-    local entry = timeline_registry.get "MergedEvent"
-    if entry then
-      entry.writer = orig_merged_writer
-    end
   end
 end
 

--- a/scripts/example-timeline.lua
+++ b/scripts/example-timeline.lua
@@ -376,7 +376,34 @@ writers.write_timeline_items(bufnr, {
         createdAt = now,
         pullRequest = { headRefName = branch },
       },
+      ---@type octo.fragments.AddedToMergeQueueEvent
+      {
+        __typename = "AddedToMergeQueueEvent",
+        actor = { login = me },
+        createdAt = now,
+        enqueuer = { login = me },
+      },
       ---@type octo.fragments.MergedEvent
+      --- Rendered as "merged via the queue into main with commit X"
+      --- because a RemovedFromMergeQueueEvent (reason: "merged") follows
+      {
+        __typename = "MergedEvent",
+        actor = { login = other },
+        createdAt = now,
+        commit = { abbreviatedOid = "abc1234" },
+        mergeRefName = branch,
+      },
+      ---@type octo.fragments.RemovedFromMergeQueueEvent
+      --- Skipped by writer (reason: "merged"), but triggers via_queue on MergedEvent
+      {
+        __typename = "RemovedFromMergeQueueEvent",
+        actor = { login = "github-merge-queue" },
+        createdAt = now,
+        reason = "merged",
+        enqueuer = { login = "github-merge-queue[bot]" },
+      },
+      ---@type octo.fragments.MergedEvent
+      --- Regular (non-queue) merge — rendered as "merged into main with commit X"
       {
         __typename = "MergedEvent",
         actor = { login = other },


### PR DESCRIPTION
Merge queue merges now match GitHub's UI language. Non-queue merges also
updated to match current wording.

Closes #1365

Changes:
- Pre-scan timeline for `RemovedFromMergeQueueEvent` (reason: merged) to detect queue merges and render "merged via the queue into Y with commit X"
- Fix non-queue merge wording from "merged commit X into Y" to match GitHub: "merged into Y with commit X"
- Save/restore `MergedEvent` writer to prevent registry mutation leaking across PR views
- Remove `is_github_com` gate from merge queue fragments (GHES 3.12+ supports them)
- Remove gsub placeholder injection for `isInMergeQueue`, hardcode directly in query strings

To test, compare the GitHub UI with `:Octo pr edit <number> <repo>` for:
- Queue merge: `2624 pymc-labs/pymc-marketing`
- Direct merge: `1531 pwntester/octo.nvim`
- Local examples: `:split | source scripts/example-timeline.lua`