### PR TITLE
fix: update branch name checking to be case sensitive (desc)

### DIFF
--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -646,13 +646,13 @@ function M.get_upstream_branch_from_config(pr)
   return ""
 end
 
--- Determines if we are locally in a branch matting the pr head ref when
+-- Determines if we are locally in a branch matching the pr head ref when
 -- the remote and branch information is stored in the branch's git config values
 -- The gh CLI tool stores remote info directly in {branch.{branch}.x} configuration
 -- fields and does not create a remote
 ---@param pr PullRequest
 function M.in_pr_branch_config_tracked(pr)
-  return M.get_upstream_branch_from_config(pr):lower() == pr.head_ref_name
+  return M.get_upstream_branch_from_config(pr) == pr.head_ref_name
 end
 
 --- Determines if we are locally are in a branch matching the pr head ref


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

In GitHub, repository names are case insensitive (e.g. https://github.com/Patina-Network/codebloom and https://github.com/Patina-Network/CoDeBLOOm point to the same repo); however, branches are case sensitive (https://github.com/Patina-Network/codebloom/tree/TAN-20 => 200 while https://github.com/Patina-Network/codebloom/tree/Tan-20 => 404). technically, it would be okay to call lower() on both remote & local (aka ignore casing and compare branches) & work for 99% of scenarios, but removing .lower() in this case should match expectations

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #1534

### Describe how you did it

1. Clone `https://github.com/tahminator/codebloom`
1.5. ensure that `octo.nvim` has `use_local_fs` set to `true`
2. Attempt to start a review on `936`
3. Observe that the PR review process will start, but the local FS will not be used due to the fact that the buffer using local is predicated on the fact that we are on the right branch.

### Describe how to verify it

1. Clone `https://github.com/tahminator/codebloom`
1.5. ensure that `octo.nvim` has `use_local_fs` set to `true`
2. Attempt to start a review on `936`
3. Observe that the PR review process will start & the local FS will now be used, since it can now be matched

### Special notes for reviews

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
