### PR TITLE
fix(telescope): guard against nil preview_bufnr in open_preview_buffer

### DIFF
--- a/lua/octo/pickers/telescope/provider.lua
+++ b/lua/octo/pickers/telescope/provider.lua
@@ -62,8 +62,11 @@ end
 local function open_preview_buffer(command)
   return function(prompt_bufnr)
     actions.close(prompt_bufnr)
-    ---@type integer
+    ---@type integer|nil
     local preview_bufnr = require("telescope.state").get_global_key "last_preview_bufnr"
+    if preview_bufnr == nil then
+      return
+    end
     if command == "default" then
       vim.cmd(string.format(":buffer %d", preview_bufnr))
     elseif command == "horizontal" then


### PR DESCRIPTION
### Describe what this PR does / why we need it

`open_preview_buffer` in the Telescope provider calls `telescope.state.get_global_key("last_preview_bufnr")`, which can return `nil` when no preview buffer exists (e.g. the previewer failed to render, or previews are disabled). The value is then passed directly to `string.format(":buffer %d", preview_bufnr)`, which throws a Lua error because `%d` requires a number.

### Does this pull request fix one issue?

Fixes #1538

### Describe how you did it

Added a nil guard before the `string.format` calls. If `preview_bufnr` is `nil`, the function returns early. Also corrected the type annotation from `---@type integer` to `---@type integer|nil` to accurately reflect the return type of `get_global_key`.

### Describe how to verify it

1. Open a Telescope picker via Octo (e.g. `:Octo review commits` or changed files)
2. Ensure no preview buffer has been rendered (trigger a previewer error or disable previews)
3. Select an entry — before this fix a Lua error is thrown; after, it returns silently

### Special notes for reviews

`get_global_key` is typed as returning `any`, so the nil case is always possible. The silent early return is intentional — there is no meaningful fallback action when no preview buffer exists.

### Checklist

- [x] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt