### PR TITLE
fix(pr): open PR in browser instead of repo root

### DIFF
--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -652,7 +652,12 @@ function M.setup()
         M.reload { verbose = true }
       end,
       browser = function()
-        navigation.open_in_browser()
+        local buffer = utils.get_current_buffer()
+        if buffer and buffer:isPullRequest() then
+          navigation.open_in_browser()
+        else
+          pcall(vim.cmd, "silent !gh pr view --web")
+        end
       end,
       url = function()
         M.copy_url()

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -656,7 +656,7 @@ function M.setup()
         if buffer and buffer:isPullRequest() then
           navigation.open_in_browser()
         else
-          pcall(vim.cmd, "silent !gh pr view --web")
+          gh.pr.view { web = true }
         end
       end,
       url = function()

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -36,22 +36,24 @@ function M.open_in_browser(kind, repo, number)
     return
   end
 
+  local function repo_ref(repo)
+    if remote == "github.com" then
+      return repo
+    end
+    return remote .. "/" .. repo
+  end
+
   if not kind and not repo then
     local buffer = utils.get_current_buffer()
     if not buffer then
-      local owner_repo = utils.get_remote_name()
-      if not owner_repo then
-        utils.error "No remote repository found"
-        return
-      end
-      cmd = string.format("gh repo view --web %s", owner_repo)
+      cmd = "gh pr view --web"
       ---@diagnostic disable-next-line: param-type-mismatch
       return pcall(vim.cmd, "silent !" .. cmd)
     end
     if buffer:isPullRequest() then
-      cmd = string.format("gh pr view --web -R %s/%s %d", remote, buffer.repo, buffer.number)
+      cmd = string.format("gh pr view --web -R %s %d", repo_ref(buffer.repo), buffer.number)
     elseif buffer:isIssue() then
-      cmd = string.format("gh issue view --web -R %s/%s %d", remote, buffer.repo, buffer.number)
+      cmd = string.format("gh issue view --web -R %s %d", repo_ref(buffer.repo), buffer.number)
     elseif buffer:isRepo() then
       cmd = string.format("gh repo view --web %s/%s", remote, buffer.repo)
     elseif buffer:isDiscussion() then
@@ -68,9 +70,9 @@ function M.open_in_browser(kind, repo, number)
     end
   else
     if kind == "pr" or kind == "pull_request" then
-      cmd = string.format("gh pr view --web -R %s/%s %d", remote, repo, number)
+      cmd = string.format("gh pr view --web -R %s %d", repo_ref(repo), number)
     elseif kind == "issue" then
-      cmd = string.format("gh issue view --web -R %s/%s %d", remote, repo, number)
+      cmd = string.format("gh issue view --web -R %s %d", repo_ref(repo), number)
     elseif kind == "repo" then
       assert(repo, "repo is required")
       cmd = string.format("gh repo view --web %s", repo.url)

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -29,70 +29,93 @@ end
 ---@param repo? string|{ url: string }
 ---@param number? integer|string
 function M.open_in_browser(kind, repo, number)
-  local cmd ---@type string
-  local remote = utils.get_remote_host()
-  if not remote then
-    utils.error "Cannot find repo remote host"
-    return
-  end
-
-  local function repo_ref(repo)
-    if remote == "github.com" then
-      return repo
-    end
-    return remote .. "/" .. repo
-  end
-
   if not kind and not repo then
     local buffer = utils.get_current_buffer()
     if not buffer then
-      cmd = "gh pr view --web"
-      ---@diagnostic disable-next-line: param-type-mismatch
-      return pcall(vim.cmd, "silent !" .. cmd)
+      local owner_repo = utils.get_remote_name()
+      if not owner_repo then
+        utils.error "No remote repository found"
+        return
+      end
+      gh.repo.view {
+        owner_repo,
+        web = true,
+      }
+      return
     end
     if buffer:isPullRequest() then
-      cmd = string.format("gh pr view --web -R %s %d", repo_ref(buffer.repo), buffer.number)
+      gh.pr.view {
+        buffer.number,
+        repo = buffer.repo,
+        web = true,
+      }
     elseif buffer:isIssue() then
-      cmd = string.format("gh issue view --web -R %s %d", repo_ref(buffer.repo), buffer.number)
+      gh.issue.view {
+        buffer.number,
+        repo = buffer.repo,
+        web = true,
+      }
     elseif buffer:isRepo() then
-      cmd = string.format("gh repo view --web %s/%s", remote, buffer.repo)
+      gh.repo.view {
+        buffer.repo,
+        web = true,
+      }
     elseif buffer:isDiscussion() then
-      local url = buffer:discussion().url
-      M.open_in_browser_raw(url)
-      return
+      M.open_in_browser_raw(buffer:discussion().url)
     elseif buffer:isRelease() then
       gh.release.view {
         buffer:release().tagName,
         repo = buffer.repo,
         web = true,
       }
-      return
     end
   else
     if kind == "pr" or kind == "pull_request" then
-      cmd = string.format("gh pr view --web -R %s %d", repo_ref(repo), number)
+      assert(repo, "repo is required")
+      gh.pr.view {
+        number,
+        repo = repo,
+        web = true,
+      }
     elseif kind == "issue" then
-      cmd = string.format("gh issue view --web -R %s %d", repo_ref(repo), number)
+      assert(repo, "repo is required")
+      gh.issue.view {
+        number,
+        repo = repo,
+        web = true,
+      }
     elseif kind == "repo" then
       assert(repo, "repo is required")
-      cmd = string.format("gh repo view --web %s", repo.url)
+      gh.repo.view {
+        type(repo) == "table" and repo.url or repo,
+        web = true,
+      }
     elseif kind == "gist" then
-      cmd = string.format("gh gist view --web %s", number)
+      gh.gist.view {
+        number,
+        web = true,
+      }
     elseif kind == "project" then
-      cmd = string.format("gh project view --owner %s --web %s", repo, number)
+      assert(repo, "repo is required")
+      gh.project.view {
+        number,
+        owner = repo,
+        web = true,
+      }
     elseif kind == "workflow_run" then
-      cmd = string.format("gh run view %s --web", number)
+      gh.run.view {
+        number,
+        web = true,
+      }
     elseif kind == "release" then
+      assert(repo, "repo is required")
       gh.release.view {
         number,
         repo = repo,
         web = true,
       }
-      return
     end
   end
-  ---@diagnostic disable-next-line: param-type-mismatch
-  pcall(vim.cmd, "silent !" .. cmd)
 end
 
 local function open_file_if_found(path, line)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fixes `:Octo pr browser` opening the repository root instead of the pull request page.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

Fixes #1543

### Describe how you did it

- In `navigation.open_in_browser()`, when no Octo buffer is found, fall back to `gh pr view --web` (which auto-detects the current branch's PR) instead of `gh repo view --web`.
- Build the `-R` flag with only `owner/repo` for github.com hosts via a new `repo_ref()` helper, keeping the `host/owner/repo` form for GitHub Enterprise.
- Guard `:Octo pr browser` in `commands.lua` so it opens the current PR buffer when present and otherwise falls back to branch-based PR detection.

### Describe how to verify it

1. Open an Octo PR buffer and run `:Octo pr browser`; the browser should open the PR page.
2. From a non-PR buffer in a git repo with an open PR, run `:Octo pr browser`; the browser should open the PR for the current branch.

### Special notes for reviews

N/A

### Checklist

- [ ] Passing tests and linting standards
- [ ] Documentation updates in README.md and doc/octo.txt
