### PR TITLE
feat(pr): display stacked PRs in the PR details section

### DIFF
--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -111,6 +111,8 @@ query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
   ---@field state octo.PullRequestState
   ---@field isDraft boolean
   ---@field isInMergeQueue boolean
+  ---@field reviewDecision? string
+  ---@field statusCheckRollup? { state: octo.StatusState }
 
   ---@class octo.PullRequestStackEntry
   ---@field position integer 1 is closest to the base branch
@@ -1607,6 +1609,10 @@ query($id: ID!) {
                 state
                 isDraft
                 isInMergeQueue
+                reviewDecision
+                statusCheckRollup {
+                  state
+                }
               }
             }
           }

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -104,10 +104,34 @@ query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
   ---@class octo.PullRequestTimelineItemsConnection : octo.fragments.PullRequestTimelineItemsConnection
   ---@field pageInfo octo.PageInfo
 
+  ---@class octo.StackPullRequest
+  ---@field number integer
+  ---@field title string
+  ---@field url string
+  ---@field state octo.PullRequestState
+  ---@field isDraft boolean
+  ---@field isInMergeQueue boolean
+
+  ---@class octo.PullRequestStackEntry
+  ---@field position integer 1 is closest to the base branch
+  ---@field pullRequest? octo.StackPullRequest null when not accessible
+
+  ---@class octo.PullRequestStack
+  ---@field id string
+  ---@field number integer
+  ---@field size integer
+  ---@field baseRefName string
+  ---@field entries { nodes: octo.PullRequestStackEntry[] }
+
+  ---@class octo.StackEntryHead
+  ---@field position integer
+  ---@field stack octo.PullRequestStack
+
   ---@class octo.PullRequest : octo.ReactionGroupsFragment
   ---@field id string
   ---@field isDraft boolean
   ---@field isInMergeQueue? boolean
+  ---@field stackEntry? octo.StackEntryHead github.com only, null when not part of a stack
   ---@field number integer
   ---@field state octo.PullRequestState
   ---@field title string
@@ -159,6 +183,7 @@ query($endCursor: String) {
       id
       isDraft
       isInMergeQueue
+      {stackEntry}
       number
       state
       title
@@ -1564,17 +1589,43 @@ query($id: ID!) {
 }
 ]]
 
+  -- Stacked PRs: github.com only, the stack fields do not exist on GHES
+  local stack_entry_field = [[stackEntry {
+        position
+        stack {
+          id
+          number
+          size
+          baseRefName
+          entries(first: 50) {
+            nodes {
+              position
+              pullRequest {
+                number
+                title
+                url
+                state
+                isDraft
+                isInMergeQueue
+              }
+            }
+          }
+        }
+      }]]
+
   -- Inject isInMergeQueue for github.com only (may not exist on GHES)
   if config.values.github_hostname == "" then
     local field = "isInMergeQueue"
     M.pull_requests = M.pull_requests:gsub("{isInMergeQueue}", field)
     M.search = M.search:gsub("{isInMergeQueue}", field)
     M.pull_request = M.pull_request:gsub("{isInMergeQueue}", field)
+    M.pull_request = M.pull_request:gsub("{stackEntry}", stack_entry_field)
   else
     -- Remove the placeholder lines for GHES (GraphQL ignores blank lines)
     M.pull_requests = M.pull_requests:gsub("%s*{isInMergeQueue}\n", "")
     M.search = M.search:gsub("%s*{isInMergeQueue}\n", "")
     M.pull_request = M.pull_request:gsub("%s*{isInMergeQueue}\n", "")
+    M.pull_request = M.pull_request:gsub("%s*{stackEntry}\n", "")
   end
 end
 

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -727,12 +727,13 @@ local stack_badge_map = {
 ---Badge shown for a PR in a stack listing: the PR state, or its merge
 ---readiness (approved reviews and green checks) when it is open.
 ---@param pr octo.StackPullRequest
----@return { [1]: string, [2]: string, [3]: string } label, bubble hl, icon hl
+---@return { [1]: string, [2]: string, [3]: string } badge # label, bubble highlight, icon highlight
 local function stack_badge(pr)
   local state = utils.get_displayed_state(false, pr.state, nil, pr.isDraft, pr.isInMergeQueue)
   local badge = stack_badge_map[state]
   if not badge then
-    local checks_ok = utils.is_blank(pr.statusCheckRollup) or pr.statusCheckRollup.state == "SUCCESS"
+    local rollup = pr.statusCheckRollup
+    local checks_ok = rollup == nil or rollup == vim.NIL or rollup.state == "SUCCESS"
     local review_ok = utils.is_blank(pr.reviewDecision) or pr.reviewDecision == "APPROVED"
     badge = (checks_ok and review_ok) and stack_badge_map.READY or stack_badge_map.NOT_READY
   end
@@ -745,7 +746,7 @@ end
 ---@return [string, string][][]
 function M.build_stack_details(stack_entry)
   local lines = {} ---@type [string, string][][]
-  if utils.is_blank(stack_entry) or utils.is_blank(stack_entry.stack) then
+  if stack_entry == nil or stack_entry == vim.NIL or utils.is_blank(stack_entry.stack) then
     return lines
   end
   local stack = stack_entry.stack
@@ -768,7 +769,7 @@ function M.build_stack_details(stack_entry)
     local is_current = entry.position == stack_entry.position
     local line = { { is_current and "  ▶ " or "    ", "OctoDetailsValue" } }
     local pr = entry.pullRequest
-    if utils.is_blank(pr) then
+    if pr == nil or pr == vim.NIL then
       table.insert(line, { "(not accessible)", "OctoMissingDetails" })
     else
       local badge = stack_badge(pr)

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -719,6 +719,58 @@ end
 ---@param issue octo.PullRequest|octo.Issue
 ---@param update? true
 ---@param include_status? boolean
+---Build virtual-text detail lines for the stack a PR belongs to.
+---Returns an empty list when the PR is not part of a stack.
+---@param stack_entry? octo.StackEntryHead
+---@return [string, string][][]
+function M.build_stack_details(stack_entry)
+  local lines = {} ---@type [string, string][][]
+  if utils.is_blank(stack_entry) or utils.is_blank(stack_entry.stack) then
+    return lines
+  end
+  local stack = stack_entry.stack
+
+  table.insert(lines, {
+    { "Stack: ", "OctoDetailsLabel" },
+    { string.format("%d/%d", stack_entry.position, stack.size), "OctoDetailsValue" },
+    { " (into ", "OctoDetailsLabel" },
+    { stack.baseRefName, "OctoDetailsValue" },
+    { ")", "OctoDetailsLabel" },
+  })
+
+  local entries = vim.list_slice(stack.entries.nodes)
+  -- Top of the stack first, base branch last, matching the GitHub UI
+  table.sort(entries, function(a, b)
+    return a.position > b.position
+  end)
+
+  for _, entry in ipairs(entries) do
+    local is_current = entry.position == stack_entry.position
+    local line = { { is_current and "  ▶ " or "    ", "OctoDetailsValue" } }
+    local pr = entry.pullRequest
+    if utils.is_blank(pr) then
+      table.insert(line, { "(not accessible)", "OctoMissingDetails" })
+    else
+      table.insert(
+        line,
+        utils.get_icon {
+          kind = "pull_request",
+          obj = pr --[[@as EntryObject]],
+        }
+      )
+      table.insert(line, { "#" .. tostring(pr.number) .. " ", "OctoDetailsValue" })
+      if is_current then
+        table.insert(line, { pr.title, "OctoDetailsValue" })
+      else
+        table.insert(line, { pr.title })
+      end
+    end
+    table.insert(lines, line)
+  end
+
+  return lines
+end
+
 function M.write_details(bufnr, issue, update, include_status)
   vim.api.nvim_buf_clear_namespace(bufnr, constants.OCTO_DETAILS_VT_NS, 0, -1)
 

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -714,11 +714,31 @@ local function add_status_detail(details, is_issue, state, state_reason, is_draf
     :write_detail_line(details)
 end
 
---- Write issue or PR details virtual text in buffer
----@param bufnr integer
----@param issue octo.PullRequest|octo.Issue
----@param update? true
----@param include_status? boolean
+-- Badge label and bubble highlight for each stack entry state
+local stack_badge_map = {
+  MERGED = { "MERGED", "OctoStateMergedBubble" },
+  CLOSED = { "CLOSED", "OctoStateClosedBubble" },
+  DRAFT = { "DRAFT", "OctoStateDraftBubble" },
+  QUEUED = { "QUEUED", "OctoStateQueuedBubble" },
+  READY = { "READY", "OctoStateApprovedBubble" },
+  NOT_READY = { "NOT READY", "OctoStatePendingBubble" },
+}
+
+---Badge shown for a PR in a stack listing: the PR state, or its merge
+---readiness (approved reviews and green checks) when it is open.
+---@param pr octo.StackPullRequest
+---@return [string, string][]
+local function stack_badge(pr)
+  local state = utils.get_displayed_state(false, pr.state, nil, pr.isDraft, pr.isInMergeQueue)
+  local badge = stack_badge_map[state]
+  if not badge then
+    local checks_ok = utils.is_blank(pr.statusCheckRollup) or pr.statusCheckRollup.state == "SUCCESS"
+    local review_ok = utils.is_blank(pr.reviewDecision) or pr.reviewDecision == "APPROVED"
+    badge = (checks_ok and review_ok) and stack_badge_map.READY or stack_badge_map.NOT_READY
+  end
+  return bubbles.make_bubble(badge[1], badge[2], { left_margin_width = 1 })
+end
+
 ---Build virtual-text detail lines for the stack a PR belongs to.
 ---Returns an empty list when the PR is not part of a stack.
 ---@param stack_entry? octo.StackEntryHead
@@ -764,6 +784,7 @@ function M.build_stack_details(stack_entry)
       else
         table.insert(line, { pr.title })
       end
+      vim.list_extend(line, stack_badge(pr))
     end
     table.insert(lines, line)
   end
@@ -771,6 +792,11 @@ function M.build_stack_details(stack_entry)
   return lines
 end
 
+--- Write issue or PR details virtual text in buffer
+---@param bufnr integer
+---@param issue octo.PullRequest|octo.Issue
+---@param update? true
+---@param include_status? boolean
 function M.write_details(bufnr, issue, update, include_status)
   vim.api.nvim_buf_clear_namespace(bufnr, constants.OCTO_DETAILS_VT_NS, 0, -1)
 

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -714,20 +714,20 @@ local function add_status_detail(details, is_issue, state, state_reason, is_draf
     :write_detail_line(details)
 end
 
--- Badge label and bubble highlight for each stack entry state
+-- Badge label, bubble highlight and matching icon highlight for each stack entry state
 local stack_badge_map = {
-  MERGED = { "MERGED", "OctoStateMergedBubble" },
-  CLOSED = { "CLOSED", "OctoStateClosedBubble" },
-  DRAFT = { "DRAFT", "OctoStateDraftBubble" },
-  QUEUED = { "QUEUED", "OctoStateQueuedBubble" },
-  READY = { "READY", "OctoStateApprovedBubble" },
-  NOT_READY = { "NOT READY", "OctoStatePendingBubble" },
+  MERGED = { "MERGED", "OctoStateMergedBubble", "OctoPurple" },
+  CLOSED = { "CLOSED", "OctoStateClosedBubble", "OctoRed" },
+  DRAFT = { "DRAFT", "OctoStateDraftBubble", "OctoGrey" },
+  QUEUED = { "QUEUED", "OctoStateQueuedBubble", "OctoYellow" },
+  READY = { "READY", "OctoStateApprovedBubble", "OctoGreen" },
+  NOT_READY = { "NOT READY", "OctoStatePendingBubble", "OctoYellow" },
 }
 
 ---Badge shown for a PR in a stack listing: the PR state, or its merge
 ---readiness (approved reviews and green checks) when it is open.
 ---@param pr octo.StackPullRequest
----@return [string, string][]
+---@return { [1]: string, [2]: string, [3]: string } label, bubble hl, icon hl
 local function stack_badge(pr)
   local state = utils.get_displayed_state(false, pr.state, nil, pr.isDraft, pr.isInMergeQueue)
   local badge = stack_badge_map[state]
@@ -736,7 +736,7 @@ local function stack_badge(pr)
     local review_ok = utils.is_blank(pr.reviewDecision) or pr.reviewDecision == "APPROVED"
     badge = (checks_ok and review_ok) and stack_badge_map.READY or stack_badge_map.NOT_READY
   end
-  return bubbles.make_bubble(badge[1], badge[2], { left_margin_width = 1 })
+  return badge
 end
 
 ---Build virtual-text detail lines for the stack a PR belongs to.
@@ -771,20 +771,20 @@ function M.build_stack_details(stack_entry)
     if utils.is_blank(pr) then
       table.insert(line, { "(not accessible)", "OctoMissingDetails" })
     else
-      table.insert(
-        line,
-        utils.get_icon {
-          kind = "pull_request",
-          obj = pr --[[@as EntryObject]],
-        }
-      )
+      local badge = stack_badge(pr)
+      local icon = utils.get_icon {
+        kind = "pull_request",
+        obj = pr --[[@as EntryObject]],
+      }
+      -- keep the state glyph but color it like the badge, matching the GitHub UI
+      table.insert(line, { icon[1], badge[3] })
       table.insert(line, { "#" .. tostring(pr.number) .. " ", "OctoDetailsValue" })
       if is_current then
         table.insert(line, { pr.title, "OctoDetailsValue" })
       else
         table.insert(line, { pr.title })
       end
-      vim.list_extend(line, stack_badge(pr))
+      vim.list_extend(line, bubbles.make_bubble(badge[1], badge[2], { left_margin_width = 1 }))
     end
     table.insert(lines, line)
   end

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -1025,6 +1025,11 @@ function M.write_details(bufnr, issue, update, include_status)
     }
     table.insert(details, branches_vt)
 
+    -- stacked PRs
+    for _, stack_line in ipairs(M.build_stack_details(issue.stackEntry)) do
+      table.insert(details, stack_line)
+    end
+
     -- review decision
     if issue.reviewDecision and issue.reviewDecision ~= vim.NIL then
       local decision_vt = {

--- a/lua/tests/plenary/stack_spec.lua
+++ b/lua/tests/plenary/stack_spec.lua
@@ -29,4 +29,85 @@ describe("stacked PRs", function()
       assert.is_nil(queries.pull_request:find("stackEntry", 1, true))
     end)
   end)
+
+  describe("build_stack_details", function()
+    local writers = require "octo.ui.writers"
+    local utils = require "octo.utils"
+
+    local function line_text(line)
+      local s = ""
+      for _, chunk in ipairs(line) do
+        s = s .. chunk[1]
+      end
+      return s
+    end
+
+    local function make_stack_entry()
+      return {
+        position = 2,
+        stack = {
+          id = "S_1",
+          number = 350,
+          size = 5,
+          baseRefName = "main",
+          entries = {
+            nodes = {
+              {
+                position = 1,
+                pullRequest = { number = 330, title = "Bottom PR", state = "MERGED", isDraft = false, url = "" },
+              },
+              {
+                position = 3,
+                pullRequest = { number = 343, title = "Top PR", state = "OPEN", isDraft = true, url = "" },
+              },
+              {
+                position = 2,
+                pullRequest = { number = 333, title = "Current PR", state = "OPEN", isDraft = false, url = "" },
+              },
+            },
+          },
+        },
+      }
+    end
+
+    it("returns no lines when the PR is not part of a stack", function()
+      eq({}, writers.build_stack_details(nil))
+      eq({}, writers.build_stack_details(vim.NIL))
+    end)
+
+    it("renders a header with position, size and base branch", function()
+      local lines = writers.build_stack_details(make_stack_entry())
+      eq("Stack: 2/5 (into main)", line_text(lines[1]))
+    end)
+
+    it("renders one line per entry, top of the stack first", function()
+      local lines = writers.build_stack_details(make_stack_entry())
+      eq(4, #lines)
+      assert.is_truthy(line_text(lines[2]):find("#343 Top PR", 1, true))
+      assert.is_truthy(line_text(lines[3]):find("#333 Current PR", 1, true))
+      assert.is_truthy(line_text(lines[4]):find("#330 Bottom PR", 1, true))
+    end)
+
+    it("marks the current PR with an arrow", function()
+      local lines = writers.build_stack_details(make_stack_entry())
+      assert.is_truthy(vim.startswith(line_text(lines[3]), "  ▶ "))
+      assert.is_truthy(vim.startswith(line_text(lines[2]), "    "))
+      assert.is_truthy(vim.startswith(line_text(lines[4]), "    "))
+    end)
+
+    it("uses the PR state icons", function()
+      local lines = writers.build_stack_details(make_stack_entry())
+      assert.is_truthy(line_text(lines[2]):find(utils.icons.pull_request.draft[1], 1, true))
+      assert.is_truthy(line_text(lines[3]):find(utils.icons.pull_request.open[1], 1, true))
+      assert.is_truthy(line_text(lines[4]):find(utils.icons.pull_request.merged[1], 1, true))
+    end)
+
+    it("handles inaccessible pull requests", function()
+      local stack_entry = make_stack_entry()
+      stack_entry.stack.entries.nodes[2].pullRequest = vim.NIL
+      local lines = writers.build_stack_details(stack_entry)
+      eq(4, #lines)
+      assert.is_truthy(line_text(lines[2]):find("not accessible", 1, true))
+    end)
+  end)
 end)

--- a/lua/tests/plenary/stack_spec.lua
+++ b/lua/tests/plenary/stack_spec.lua
@@ -1,0 +1,32 @@
+---@diagnostic disable
+local config = require "octo.config"
+local fragments = require "octo.gh.fragments"
+local queries = require "octo.gh.queries"
+
+config.setup {}
+fragments.setup()
+queries.setup()
+
+local eq = assert.are.same
+
+describe("stacked PRs", function()
+  describe("pull_request query gating", function()
+    after_each(function()
+      config.values.github_hostname = ""
+      queries.setup()
+    end)
+
+    it("includes stackEntry on github.com", function()
+      config.values.github_hostname = ""
+      queries.setup()
+      assert.is_truthy(queries.pull_request:find("stackEntry {", 1, true))
+      assert.is_nil(queries.pull_request:find("{stackEntry}", 1, true))
+    end)
+
+    it("omits stackEntry on GHES", function()
+      config.values.github_hostname = "github.example.com"
+      queries.setup()
+      assert.is_nil(queries.pull_request:find("stackEntry", 1, true))
+    end)
+  end)
+end)

--- a/lua/tests/plenary/stack_spec.lua
+++ b/lua/tests/plenary/stack_spec.lua
@@ -62,7 +62,15 @@ describe("stacked PRs", function()
               },
               {
                 position = 2,
-                pullRequest = { number = 333, title = "Current PR", state = "OPEN", isDraft = false, url = "" },
+                pullRequest = {
+                  number = 333,
+                  title = "Current PR",
+                  state = "OPEN",
+                  isDraft = false,
+                  url = "",
+                  reviewDecision = "APPROVED",
+                  statusCheckRollup = { state = "SUCCESS" },
+                },
               },
             },
           },
@@ -108,6 +116,60 @@ describe("stacked PRs", function()
       local lines = writers.build_stack_details(stack_entry)
       eq(4, #lines)
       assert.is_truthy(line_text(lines[2]):find("not accessible", 1, true))
+    end)
+
+    describe("state badges", function()
+      it("shows MERGED for merged PRs", function()
+        local lines = writers.build_stack_details(make_stack_entry())
+        assert.is_truthy(line_text(lines[4]):find("MERGED", 1, true))
+      end)
+
+      it("shows DRAFT for draft PRs", function()
+        local lines = writers.build_stack_details(make_stack_entry())
+        assert.is_truthy(line_text(lines[2]):find("DRAFT", 1, true))
+      end)
+
+      it("shows READY for open PRs with approved reviews and green checks", function()
+        local lines = writers.build_stack_details(make_stack_entry())
+        local text = line_text(lines[3])
+        assert.is_truthy(text:find("READY", 1, true))
+        assert.is_nil(text:find("NOT READY", 1, true))
+      end)
+
+      it("shows READY for open PRs with no required reviews and no checks", function()
+        local stack_entry = make_stack_entry()
+        stack_entry.stack.entries.nodes[3].pullRequest.reviewDecision = vim.NIL
+        stack_entry.stack.entries.nodes[3].pullRequest.statusCheckRollup = vim.NIL
+        local lines = writers.build_stack_details(stack_entry)
+        local text = line_text(lines[3])
+        assert.is_truthy(text:find("READY", 1, true))
+        assert.is_nil(text:find("NOT READY", 1, true))
+      end)
+
+      it("shows NOT READY when a review is still required", function()
+        local stack_entry = make_stack_entry()
+        stack_entry.stack.entries.nodes[3].pullRequest.reviewDecision = "REVIEW_REQUIRED"
+        local lines = writers.build_stack_details(stack_entry)
+        assert.is_truthy(line_text(lines[3]):find("NOT READY", 1, true))
+      end)
+
+      it("shows NOT READY when checks are failing", function()
+        local stack_entry = make_stack_entry()
+        stack_entry.stack.entries.nodes[3].pullRequest.statusCheckRollup = { state = "FAILURE" }
+        local lines = writers.build_stack_details(stack_entry)
+        assert.is_truthy(line_text(lines[3]):find("NOT READY", 1, true))
+      end)
+    end)
+  end)
+
+  describe("pull_request query stack fields", function()
+    it("fetches per-entry review and check state", function()
+      config.values.github_hostname = ""
+      queries.setup()
+      local sub = queries.pull_request:match "stackEntry %b{}"
+      assert.is_truthy(sub)
+      assert.is_truthy(sub:find("reviewDecision", 1, true))
+      assert.is_truthy(sub:find("statusCheckRollup", 1, true))
     end)
   end)
 end)

--- a/lua/tests/plenary/stack_spec.lua
+++ b/lua/tests/plenary/stack_spec.lua
@@ -159,6 +159,20 @@ describe("stacked PRs", function()
         local lines = writers.build_stack_details(stack_entry)
         assert.is_truthy(line_text(lines[3]):find("NOT READY", 1, true))
       end)
+
+      it("colors the state icon to match the badge", function()
+        local stack_entry = make_stack_entry()
+        stack_entry.stack.entries.nodes[3].pullRequest.reviewDecision = "REVIEW_REQUIRED"
+        local lines = writers.build_stack_details(stack_entry)
+        -- line = { marker, icon, "#number ", title, bubble... }: the icon is chunk 2
+        eq("OctoGrey", lines[2][2][2]) -- draft
+        eq("OctoYellow", lines[3][2][2]) -- open but not ready
+        eq("OctoPurple", lines[4][2][2]) -- merged
+
+        stack_entry.stack.entries.nodes[3].pullRequest.reviewDecision = "APPROVED"
+        lines = writers.build_stack_details(stack_entry)
+        eq("OctoGreen", lines[3][2][2]) -- open and ready
+      end)
     end)
   end)
 


### PR DESCRIPTION
> **This is the first PR of a series** bringing full GitHub Stacked Pull Requests support (#1539) to octo.nvim. The follow-ups are open and stacked on this PR in branch order — each is independently reviewable, and its own commits are called out at the top. Together, the series accomplishes:

| PR | Feature | Surface |
|---|---|---|
| this PR | **See the stack** — render a PR's stack in the details section: position/size, one line per PR with state badges (`MERGED`/`DRAFT`/`QUEUED`/`READY`/`NOT READY`), color-matched icons, current PR marked | PR buffer |
| #1548 | **Merge the stack** — atomic bottom-up merge of the PR and everything below it, merge-queue aware | `:Octo pr merge stack`, `<localleader>pk` |
| #1549 | **Navigate the stack** — jump one PR up or down, no-ops at the ends | `]s` / `[s` |
| #1550 | **Spot stacks in lists** — muted `⧉ position/size` counter after the title, in all four picker backends | `:Octo pr list`, `:Octo search` |
| #1551 | **Create a stack** — GitHub-style "Preview stack" float, then submit; detects stackable open PRs by their base branches even **without `gh stack init`** and links them via the API | `:Octo stack create`, `<localleader>sc` |
| #1552 | **Sync the stack** — propagate base-branch changes: fetch, cascade rebase, push; conflicts land in the quickfix list (scriptable equivalent of the UI's "Rebase stack", with signed commits) | `:Octo stack sync`, `<localleader>ss` |
| #1553 | **Check out the stack** — pull all of a stack's branches locally with tracking, from the PR you're viewing | `:Octo stack checkout`, `<localleader>so` |

Viewing features need only the GraphQL `stackEntry` API (github.com-gated for GHES safety). The operational commands shell out to the [gh-stack](https://github.com/github/gh-stack) CLI extension as an **optional** dependency, through octo's existing gh wrapper. Every feature is covered by plenary specs (~70 new tests across 7 spec files). The fork stack itself was created and repaired with the code it contains.

---

### Describe what this PR does / why we need it

GitHub is rolling out native Stacked Pull Requests, and the GraphQL API now exposes a `stackEntry` field on `PullRequest`. This PR renders that data in the PR buffer's details section so you can see, at a glance, that a PR belongs to a stack and where it sits:

<img width="545" height="337" alt="image" src="https://github.com/user-attachments/assets/a7331cf4-f240-4df2-90c9-51cae62ff015" />

- Header shows position/size and the stack's true base branch.
- One line per stack PR, top of the stack first (matching the GitHub UI), with octo's PR state icon colored to match a state bubble badge: `MERGED`, `CLOSED`, `DRAFT`, `QUEUED`, or merge readiness for open PRs (`READY` when reviews are approved and checks green, `NOT READY` otherwise).
- `▶` marks the PR you are viewing.

The section only renders when the PR is part of a stack. The `stackEntry` sub-query is injected at setup time for github.com only and stripped for GHES (same `{placeholder}` pattern the codebase already uses), since the stack fields do not exist on GHES.

### Does this pull request fix one issue?

Part of #1539 (first of the series above).

### Describe how you did it

- `gh/queries.lua`: gated `stackEntry { position stack { id number size baseRefName entries { position pullRequest {...} } } }` sub-query + LuaLS annotations.
- `ui/writers.lua`: a pure `build_stack_details(stack_entry)` helper converts the API shape into virtual-text detail lines; `write_details` appends them after the From/Into line. Badges reuse the existing `OctoState*Bubble` highlight groups via `bubbles.make_bubble`.

### Describe how to verify it

- `nvim --headless -c "PlenaryBustedDirectory lua/tests/plenary/ {minimal_init = 'lua/tests/minimal_init.vim'}"` — includes 20 new tests in `lua/tests/plenary/stack_spec.lua` (query gating on github.com vs GHES, line building, ordering, badges, icon colors, inaccessible entries).
- Live: `:Octo pr edit 330 github/gh-stack` (a real 5-PR stack) renders the section; any non-stacked PR renders unchanged. The fork stack ([fork #1](https://github.com/jcarlos7121/octo.nvim/pull/1)) also works as a live 7-PR demo.

### Special notes for reviews

- The stack fields returned live data with no preview headers in my testing, but they are new — the GHES gating keeps older instances safe.
- While in `write_details` I reattached its doc comment, which had drifted from the function.
- The series merges bottom-up per the table above; each follow-up's diff shrinks to just its own commits as its predecessor lands. Happy to adjust scope or UX on any of them.
- These PRs mirror a native GitHub stack on my fork, but fork PRs can't be stacked here: a stacked PR's base must be the branch below it, and fork branches can't serve as bases in this repo. If you'd prefer reviewing this as a native stack, I'm happy to help set it up from branches pushed to this repo — dogfooding included, since the create/link flow in the last PRs of this series is what built the fork's stack.

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt (n/a — render-only, no new commands or config)
