### PR TITLE
feat(pr): merge a PR stack via gh stack merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ require"octo".setup {
       merge_pr = { lhs = "<localleader>pm", desc = "merge commit PR" },
       squash_and_merge_pr = { lhs = "<localleader>psm", desc = "squash and merge PR" },
       rebase_and_merge_pr = { lhs = "<localleader>prm", desc = "rebase and merge PR" },
+      merge_pr_stack = { lhs = "<localleader>pk", desc = "merge PR stack (this PR and all below it)" },
       merge_pr_queue = {
         lhs = "<localleader>pq",
         desc = "merge commit PR and add to merge queue (Merge queue must be enabled in the repo)",

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -244,6 +244,9 @@ See |octo-command-examples| for examples.
   diff                  Show PR diff.
   merge [strategy]      Merge the current PR using the specified strategy.
                         Strategies: `merge`, `rebase`, `squash`, `delete`
+                        Pass `stack` to merge the PR's whole stack (all PRs
+                        up to and including this one, bottom-up) via the
+                        gh-stack extension (github.com only).
   ready                 Mark a draft PR as ready for review.
   draft                 Send a ready for review PR back to draft.
   checks                Show the status of all checks run on the PR.

--- a/lua/octo/commands.lua
+++ b/lua/octo/commands.lua
@@ -2267,7 +2267,105 @@ function M.pr_checks(buffer)
   }
 end
 
+---Merge the current PR's stack (all PRs up to and including this one) via gh stack merge.
+function M.merge_pr_stack(...)
+  local buffer = utils.get_current_buffer()
+  if not buffer or not buffer:isPullRequest() then
+    return
+  end
+
+  local node = buffer:pullRequest()
+  local stack_entry = node.stackEntry
+  if utils.is_blank(stack_entry) or utils.is_blank(stack_entry.stack) then
+    utils.error("PR #" .. tostring(buffer.number) .. " is not part of a stack")
+    return
+  end
+
+  -- gh stack merge has no --repo flag: it resolves the repository from the
+  -- current checkout, so the buffer's repo must match it
+  local current_repo = utils.get_remote_name()
+  local buffer_repo = node.baseRepository.nameWithOwner
+  if current_repo ~= buffer_repo then
+    utils.error(
+      string.format("':Octo pr merge stack' must run inside a checkout of %s (current: %s)", buffer_repo, current_repo)
+    )
+    return
+  end
+
+  local conf = config.values
+  local merge_method = conf.default_merge_method
+  for _, param in ipairs(table.pack(...)) do
+    if utils.merge_method_to_flag[param] then
+      merge_method = param
+      break
+    end
+  end
+
+  -- everything at or below this PR's position merges, bottom-up
+  local to_merge = {} ---@type { position: integer, number: integer }[]
+  for _, entry in ipairs(stack_entry.stack.entries.nodes) do
+    if entry.position <= stack_entry.position and not utils.is_blank(entry.pullRequest) then
+      table.insert(to_merge, { position = entry.position, number = entry.pullRequest.number })
+    end
+  end
+  table.sort(to_merge, function(a, b)
+    return a.position < b.position
+  end)
+  local pr_list = {} ---@type string[]
+  for _, pr in ipairs(to_merge) do
+    table.insert(pr_list, "#" .. tostring(pr.number))
+  end
+
+  local question = string.format(
+    "Merge %d pull request(s) (%s) into %s?",
+    #pr_list,
+    table.concat(pr_list, ", "),
+    stack_entry.stack.baseRefName
+  )
+  if not utils.confirm(question) then
+    return
+  end
+
+  local opts = {
+    buffer.number,
+    yes = true,
+  }
+  opts[merge_method] = true
+  opts.opts = {
+    cb = function(output, stderr, exit_code)
+      local function select_message(primary, secondary, fallback)
+        if not utils.is_blank(primary) then
+          return primary
+        end
+        if not utils.is_blank(secondary) then
+          return secondary
+        end
+        return fallback
+      end
+
+      if exit_code == 0 then
+        utils.info(select_message(stderr, output, "Stack merged successfully"))
+      elseif stderr and stderr:find('unknown command "stack"', 1, true) then
+        utils.error "The gh-stack extension is required: run 'gh extension install github/gh-stack'"
+      else
+        utils.error(select_message(stderr, output, "Failed to merge stack"))
+      end
+      writers.write_state(buffer.bufnr)
+    end,
+  }
+
+  gh.stack.merge(opts)
+end
+
 function M.merge_pr(...)
+  local args = table.pack(...)
+  for i = 1, args.n do
+    if args[i] == "stack" then
+      table.remove(args, i)
+      return M.merge_pr_stack(unpack(args, 1, args.n - 1))
+    end
+  end
+
   local buffer = utils.get_current_buffer()
   if not buffer or not buffer:isPullRequest() then
     return

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -405,6 +405,7 @@ function M.get_default_values()
         merge_pr = { lhs = "<localleader>pm", desc = "merge commit PR" },
         squash_and_merge_pr = { lhs = "<localleader>psm", desc = "squash and merge PR" },
         rebase_and_merge_pr = { lhs = "<localleader>prm", desc = "rebase and merge PR" },
+        merge_pr_stack = { lhs = "<localleader>pk", desc = "merge PR stack (this PR and all below it)" },
         merge_pr_queue = {
           lhs = "<localleader>pq",
           desc = "merge commit PR and add to merge queue (Merge queue must be enabled in the repo)",

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -111,6 +111,8 @@ query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
   ---@field state octo.PullRequestState
   ---@field isDraft boolean
   ---@field isInMergeQueue boolean
+  ---@field reviewDecision? string
+  ---@field statusCheckRollup? { state: octo.StatusState }
 
   ---@class octo.PullRequestStackEntry
   ---@field position integer 1 is closest to the base branch
@@ -1607,6 +1609,10 @@ query($id: ID!) {
                 state
                 isDraft
                 isInMergeQueue
+                reviewDecision
+                statusCheckRollup {
+                  state
+                }
               }
             }
           }

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -104,10 +104,34 @@ query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
   ---@class octo.PullRequestTimelineItemsConnection : octo.fragments.PullRequestTimelineItemsConnection
   ---@field pageInfo octo.PageInfo
 
+  ---@class octo.StackPullRequest
+  ---@field number integer
+  ---@field title string
+  ---@field url string
+  ---@field state octo.PullRequestState
+  ---@field isDraft boolean
+  ---@field isInMergeQueue boolean
+
+  ---@class octo.PullRequestStackEntry
+  ---@field position integer 1 is closest to the base branch
+  ---@field pullRequest? octo.StackPullRequest null when not accessible
+
+  ---@class octo.PullRequestStack
+  ---@field id string
+  ---@field number integer
+  ---@field size integer
+  ---@field baseRefName string
+  ---@field entries { nodes: octo.PullRequestStackEntry[] }
+
+  ---@class octo.StackEntryHead
+  ---@field position integer
+  ---@field stack octo.PullRequestStack
+
   ---@class octo.PullRequest : octo.ReactionGroupsFragment
   ---@field id string
   ---@field isDraft boolean
   ---@field isInMergeQueue? boolean
+  ---@field stackEntry? octo.StackEntryHead github.com only, null when not part of a stack
   ---@field number integer
   ---@field state octo.PullRequestState
   ---@field title string
@@ -159,6 +183,7 @@ query($endCursor: String) {
       id
       isDraft
       isInMergeQueue
+      {stackEntry}
       number
       state
       title
@@ -1564,17 +1589,43 @@ query($id: ID!) {
 }
 ]]
 
+  -- Stacked PRs: github.com only, the stack fields do not exist on GHES
+  local stack_entry_field = [[stackEntry {
+        position
+        stack {
+          id
+          number
+          size
+          baseRefName
+          entries(first: 50) {
+            nodes {
+              position
+              pullRequest {
+                number
+                title
+                url
+                state
+                isDraft
+                isInMergeQueue
+              }
+            }
+          }
+        }
+      }]]
+
   -- Inject isInMergeQueue for github.com only (may not exist on GHES)
   if config.values.github_hostname == "" then
     local field = "isInMergeQueue"
     M.pull_requests = M.pull_requests:gsub("{isInMergeQueue}", field)
     M.search = M.search:gsub("{isInMergeQueue}", field)
     M.pull_request = M.pull_request:gsub("{isInMergeQueue}", field)
+    M.pull_request = M.pull_request:gsub("{stackEntry}", stack_entry_field)
   else
     -- Remove the placeholder lines for GHES (GraphQL ignores blank lines)
     M.pull_requests = M.pull_requests:gsub("%s*{isInMergeQueue}\n", "")
     M.search = M.search:gsub("%s*{isInMergeQueue}\n", "")
     M.pull_request = M.pull_request:gsub("%s*{isInMergeQueue}\n", "")
+    M.pull_request = M.pull_request:gsub("%s*{stackEntry}\n", "")
   end
 end
 

--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -310,6 +310,9 @@ return {
   merge_pr = function()
     require("octo.commands").merge_pr "merge"
   end,
+  merge_pr_stack = function()
+    require("octo.commands").merge_pr "stack"
+  end,
   merge_pr_queue = function()
     require("octo.commands").merge_pr("merge", "queue")
   end,

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -727,12 +727,13 @@ local stack_badge_map = {
 ---Badge shown for a PR in a stack listing: the PR state, or its merge
 ---readiness (approved reviews and green checks) when it is open.
 ---@param pr octo.StackPullRequest
----@return { [1]: string, [2]: string, [3]: string } label, bubble hl, icon hl
+---@return { [1]: string, [2]: string, [3]: string } badge # label, bubble highlight, icon highlight
 local function stack_badge(pr)
   local state = utils.get_displayed_state(false, pr.state, nil, pr.isDraft, pr.isInMergeQueue)
   local badge = stack_badge_map[state]
   if not badge then
-    local checks_ok = utils.is_blank(pr.statusCheckRollup) or pr.statusCheckRollup.state == "SUCCESS"
+    local rollup = pr.statusCheckRollup
+    local checks_ok = rollup == nil or rollup == vim.NIL or rollup.state == "SUCCESS"
     local review_ok = utils.is_blank(pr.reviewDecision) or pr.reviewDecision == "APPROVED"
     badge = (checks_ok and review_ok) and stack_badge_map.READY or stack_badge_map.NOT_READY
   end
@@ -745,7 +746,7 @@ end
 ---@return [string, string][][]
 function M.build_stack_details(stack_entry)
   local lines = {} ---@type [string, string][][]
-  if utils.is_blank(stack_entry) or utils.is_blank(stack_entry.stack) then
+  if stack_entry == nil or stack_entry == vim.NIL or utils.is_blank(stack_entry.stack) then
     return lines
   end
   local stack = stack_entry.stack
@@ -768,7 +769,7 @@ function M.build_stack_details(stack_entry)
     local is_current = entry.position == stack_entry.position
     local line = { { is_current and "  ▶ " or "    ", "OctoDetailsValue" } }
     local pr = entry.pullRequest
-    if utils.is_blank(pr) then
+    if pr == nil or pr == vim.NIL then
       table.insert(line, { "(not accessible)", "OctoMissingDetails" })
     else
       local badge = stack_badge(pr)

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -719,6 +719,58 @@ end
 ---@param issue octo.PullRequest|octo.Issue
 ---@param update? true
 ---@param include_status? boolean
+---Build virtual-text detail lines for the stack a PR belongs to.
+---Returns an empty list when the PR is not part of a stack.
+---@param stack_entry? octo.StackEntryHead
+---@return [string, string][][]
+function M.build_stack_details(stack_entry)
+  local lines = {} ---@type [string, string][][]
+  if utils.is_blank(stack_entry) or utils.is_blank(stack_entry.stack) then
+    return lines
+  end
+  local stack = stack_entry.stack
+
+  table.insert(lines, {
+    { "Stack: ", "OctoDetailsLabel" },
+    { string.format("%d/%d", stack_entry.position, stack.size), "OctoDetailsValue" },
+    { " (into ", "OctoDetailsLabel" },
+    { stack.baseRefName, "OctoDetailsValue" },
+    { ")", "OctoDetailsLabel" },
+  })
+
+  local entries = vim.list_slice(stack.entries.nodes)
+  -- Top of the stack first, base branch last, matching the GitHub UI
+  table.sort(entries, function(a, b)
+    return a.position > b.position
+  end)
+
+  for _, entry in ipairs(entries) do
+    local is_current = entry.position == stack_entry.position
+    local line = { { is_current and "  ▶ " or "    ", "OctoDetailsValue" } }
+    local pr = entry.pullRequest
+    if utils.is_blank(pr) then
+      table.insert(line, { "(not accessible)", "OctoMissingDetails" })
+    else
+      table.insert(
+        line,
+        utils.get_icon {
+          kind = "pull_request",
+          obj = pr --[[@as EntryObject]],
+        }
+      )
+      table.insert(line, { "#" .. tostring(pr.number) .. " ", "OctoDetailsValue" })
+      if is_current then
+        table.insert(line, { pr.title, "OctoDetailsValue" })
+      else
+        table.insert(line, { pr.title })
+      end
+    end
+    table.insert(lines, line)
+  end
+
+  return lines
+end
+
 function M.write_details(bufnr, issue, update, include_status)
   vim.api.nvim_buf_clear_namespace(bufnr, constants.OCTO_DETAILS_VT_NS, 0, -1)
 

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -714,11 +714,31 @@ local function add_status_detail(details, is_issue, state, state_reason, is_draf
     :write_detail_line(details)
 end
 
---- Write issue or PR details virtual text in buffer
----@param bufnr integer
----@param issue octo.PullRequest|octo.Issue
----@param update? true
----@param include_status? boolean
+-- Badge label and bubble highlight for each stack entry state
+local stack_badge_map = {
+  MERGED = { "MERGED", "OctoStateMergedBubble" },
+  CLOSED = { "CLOSED", "OctoStateClosedBubble" },
+  DRAFT = { "DRAFT", "OctoStateDraftBubble" },
+  QUEUED = { "QUEUED", "OctoStateQueuedBubble" },
+  READY = { "READY", "OctoStateApprovedBubble" },
+  NOT_READY = { "NOT READY", "OctoStatePendingBubble" },
+}
+
+---Badge shown for a PR in a stack listing: the PR state, or its merge
+---readiness (approved reviews and green checks) when it is open.
+---@param pr octo.StackPullRequest
+---@return [string, string][]
+local function stack_badge(pr)
+  local state = utils.get_displayed_state(false, pr.state, nil, pr.isDraft, pr.isInMergeQueue)
+  local badge = stack_badge_map[state]
+  if not badge then
+    local checks_ok = utils.is_blank(pr.statusCheckRollup) or pr.statusCheckRollup.state == "SUCCESS"
+    local review_ok = utils.is_blank(pr.reviewDecision) or pr.reviewDecision == "APPROVED"
+    badge = (checks_ok and review_ok) and stack_badge_map.READY or stack_badge_map.NOT_READY
+  end
+  return bubbles.make_bubble(badge[1], badge[2], { left_margin_width = 1 })
+end
+
 ---Build virtual-text detail lines for the stack a PR belongs to.
 ---Returns an empty list when the PR is not part of a stack.
 ---@param stack_entry? octo.StackEntryHead
@@ -764,6 +784,7 @@ function M.build_stack_details(stack_entry)
       else
         table.insert(line, { pr.title })
       end
+      vim.list_extend(line, stack_badge(pr))
     end
     table.insert(lines, line)
   end
@@ -771,6 +792,11 @@ function M.build_stack_details(stack_entry)
   return lines
 end
 
+--- Write issue or PR details virtual text in buffer
+---@param bufnr integer
+---@param issue octo.PullRequest|octo.Issue
+---@param update? true
+---@param include_status? boolean
 function M.write_details(bufnr, issue, update, include_status)
   vim.api.nvim_buf_clear_namespace(bufnr, constants.OCTO_DETAILS_VT_NS, 0, -1)
 

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -714,20 +714,20 @@ local function add_status_detail(details, is_issue, state, state_reason, is_draf
     :write_detail_line(details)
 end
 
--- Badge label and bubble highlight for each stack entry state
+-- Badge label, bubble highlight and matching icon highlight for each stack entry state
 local stack_badge_map = {
-  MERGED = { "MERGED", "OctoStateMergedBubble" },
-  CLOSED = { "CLOSED", "OctoStateClosedBubble" },
-  DRAFT = { "DRAFT", "OctoStateDraftBubble" },
-  QUEUED = { "QUEUED", "OctoStateQueuedBubble" },
-  READY = { "READY", "OctoStateApprovedBubble" },
-  NOT_READY = { "NOT READY", "OctoStatePendingBubble" },
+  MERGED = { "MERGED", "OctoStateMergedBubble", "OctoPurple" },
+  CLOSED = { "CLOSED", "OctoStateClosedBubble", "OctoRed" },
+  DRAFT = { "DRAFT", "OctoStateDraftBubble", "OctoGrey" },
+  QUEUED = { "QUEUED", "OctoStateQueuedBubble", "OctoYellow" },
+  READY = { "READY", "OctoStateApprovedBubble", "OctoGreen" },
+  NOT_READY = { "NOT READY", "OctoStatePendingBubble", "OctoYellow" },
 }
 
 ---Badge shown for a PR in a stack listing: the PR state, or its merge
 ---readiness (approved reviews and green checks) when it is open.
 ---@param pr octo.StackPullRequest
----@return [string, string][]
+---@return { [1]: string, [2]: string, [3]: string } label, bubble hl, icon hl
 local function stack_badge(pr)
   local state = utils.get_displayed_state(false, pr.state, nil, pr.isDraft, pr.isInMergeQueue)
   local badge = stack_badge_map[state]
@@ -736,7 +736,7 @@ local function stack_badge(pr)
     local review_ok = utils.is_blank(pr.reviewDecision) or pr.reviewDecision == "APPROVED"
     badge = (checks_ok and review_ok) and stack_badge_map.READY or stack_badge_map.NOT_READY
   end
-  return bubbles.make_bubble(badge[1], badge[2], { left_margin_width = 1 })
+  return badge
 end
 
 ---Build virtual-text detail lines for the stack a PR belongs to.
@@ -771,20 +771,20 @@ function M.build_stack_details(stack_entry)
     if utils.is_blank(pr) then
       table.insert(line, { "(not accessible)", "OctoMissingDetails" })
     else
-      table.insert(
-        line,
-        utils.get_icon {
-          kind = "pull_request",
-          obj = pr --[[@as EntryObject]],
-        }
-      )
+      local badge = stack_badge(pr)
+      local icon = utils.get_icon {
+        kind = "pull_request",
+        obj = pr --[[@as EntryObject]],
+      }
+      -- keep the state glyph but color it like the badge, matching the GitHub UI
+      table.insert(line, { icon[1], badge[3] })
       table.insert(line, { "#" .. tostring(pr.number) .. " ", "OctoDetailsValue" })
       if is_current then
         table.insert(line, { pr.title, "OctoDetailsValue" })
       else
         table.insert(line, { pr.title })
       end
-      vim.list_extend(line, stack_badge(pr))
+      vim.list_extend(line, bubbles.make_bubble(badge[1], badge[2], { left_margin_width = 1 }))
     end
     table.insert(lines, line)
   end

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -1025,6 +1025,11 @@ function M.write_details(bufnr, issue, update, include_status)
     }
     table.insert(details, branches_vt)
 
+    -- stacked PRs
+    for _, stack_line in ipairs(M.build_stack_details(issue.stackEntry)) do
+      table.insert(details, stack_line)
+    end
+
     -- review decision
     if issue.reviewDecision and issue.reviewDecision ~= vim.NIL then
       local decision_vt = {

--- a/lua/octo/utils.lua
+++ b/lua/octo/utils.lua
@@ -716,6 +716,13 @@ function M.insert_delete_flag(args, delete)
   end
 end
 
+---Ask the user a yes/no question. Returns true when the user confirms.
+---@param question string
+---@return boolean
+function M.confirm(question)
+  return vim.fn.confirm(question, "&Yes\n&No", 2) == 1
+end
+
 ---Merges a PR by number
 function M.merge_pr(pr_number)
   if not Job then

--- a/lua/tests/plenary/merge_stack_spec.lua
+++ b/lua/tests/plenary/merge_stack_spec.lua
@@ -1,0 +1,192 @@
+---@diagnostic disable
+local eq = assert.are.same
+
+describe("merge_pr_stack:", function()
+  local commands
+  local gh
+  local utils
+  local config
+  local captured_opts
+  local confirm_questions
+  local confirm_answer
+  local info_messages
+  local error_messages
+
+  -- Minimal fake PR buffer for a PR that sits at position 2 of a 3-PR stack
+  local function make_stack_entry()
+    return {
+      position = 2,
+      stack = {
+        id = "S_1",
+        number = 350,
+        size = 3,
+        baseRefName = "main",
+        entries = {
+          nodes = {
+            {
+              position = 3,
+              pullRequest = { number = 343, title = "Top PR", state = "OPEN", isDraft = false, url = "" },
+            },
+            {
+              position = 1,
+              pullRequest = { number = 330, title = "Bottom PR", state = "OPEN", isDraft = false, url = "" },
+            },
+            {
+              position = 2,
+              pullRequest = { number = 333, title = "Current PR", state = "OPEN", isDraft = false, url = "" },
+            },
+          },
+        },
+      },
+    }
+  end
+
+  local function make_pr_buffer(pr_number, repo, stack_entry)
+    return {
+      number = pr_number,
+      repo = repo,
+      isPullRequest = function()
+        return true
+      end,
+      pullRequest = function()
+        return {
+          baseRepository = { nameWithOwner = repo },
+          stackEntry = stack_entry,
+        }
+      end,
+      bufnr = 1,
+    }
+  end
+
+  local stack_entry
+
+  before_each(function()
+    captured_opts = nil
+    confirm_questions = {}
+    confirm_answer = true
+    info_messages = {}
+    error_messages = {}
+    stack_entry = make_stack_entry()
+
+    -- Normally defined when octo/init.lua loads; ensure it exists when this
+    -- spec runs standalone so writers.write_state can early-return
+    _G.octo_buffers = _G.octo_buffers or {}
+
+    commands = require "octo.commands"
+    gh = require "octo.gh"
+    utils = require "octo.utils"
+    config = require "octo.config"
+
+    config.setup { default_merge_method = "merge" }
+
+    utils.get_current_buffer = function()
+      return make_pr_buffer(333, "owner/repo", stack_entry)
+    end
+
+    utils.get_remote_name = function()
+      return "owner/repo"
+    end
+
+    utils.confirm = function(question)
+      table.insert(confirm_questions, question)
+      return confirm_answer
+    end
+
+    utils.info = function(msg)
+      table.insert(info_messages, msg)
+    end
+
+    utils.error = function(msg)
+      table.insert(error_messages, msg)
+    end
+
+    -- Shadow the dynamic gh.stack subcommand to capture opts instead of running gh
+    gh.stack = {
+      merge = function(opts)
+        captured_opts = opts
+      end,
+    }
+  end)
+
+  after_each(function()
+    package.loaded["octo.gh"] = nil
+    package.loaded["octo.commands"] = nil
+    package.loaded["octo.utils"] = nil
+  end)
+
+  it("merge_pr('stack') calls gh stack merge with the PR number, --yes and default method", function()
+    commands.merge_pr "stack"
+
+    assert.is_not_nil(captured_opts)
+    eq(333, captured_opts[1])
+    eq(true, captured_opts.yes)
+    eq(true, captured_opts.merge)
+    eq(nil, captured_opts.squash)
+    eq(nil, captured_opts.rebase)
+  end)
+
+  it("merge_pr('stack', 'squash') uses the squash method", function()
+    commands.merge_pr("stack", "squash")
+
+    assert.is_not_nil(captured_opts)
+    eq(true, captured_opts.squash)
+    eq(nil, captured_opts.merge)
+  end)
+
+  it("errors when the PR is not part of a stack", function()
+    stack_entry = nil
+    commands.merge_pr "stack"
+
+    eq(nil, captured_opts)
+    eq(1, #error_messages)
+    assert.is_truthy(error_messages[1]:find("not part of a stack", 1, true))
+  end)
+
+  it("errors when the current checkout is a different repo", function()
+    utils.get_remote_name = function()
+      return "other/repo"
+    end
+    commands.merge_pr "stack"
+
+    eq(nil, captured_opts)
+    eq(1, #error_messages)
+    assert.is_truthy(error_messages[1]:find("owner/repo", 1, true))
+  end)
+
+  it("does not merge when the confirmation is declined", function()
+    confirm_answer = false
+    commands.merge_pr "stack"
+
+    eq(nil, captured_opts)
+    eq(1, #confirm_questions)
+  end)
+
+  it("confirmation lists only the PRs at or below the current position", function()
+    commands.merge_pr "stack"
+
+    eq(1, #confirm_questions)
+    local question = confirm_questions[1]
+    assert.is_truthy(question:find("#330", 1, true))
+    assert.is_truthy(question:find("#333", 1, true))
+    assert.is_nil(question:find("#343", 1, true))
+    assert.is_truthy(question:find("main", 1, true))
+  end)
+
+  it("reports success with a fallback message when gh output is blank", function()
+    commands.merge_pr "stack"
+
+    assert.is_not_nil(captured_opts)
+    captured_opts.opts.cb("", "", 0)
+    eq(1, #info_messages)
+    eq("Stack merged successfully", info_messages[1])
+  end)
+
+  it("suggests installing the gh-stack extension when the command is unknown", function()
+    commands.merge_pr "stack"
+
+    assert.is_not_nil(captured_opts)
+    captured_opts.opts.cb("", 'unknown command "stack" for "gh"', 1)
+    eq(1, #error_messages)
+    assert.is_truthy(error_messages[1]:find("gh extension install github/gh-stack", 1, true))
+  end)
+end)

--- a/lua/tests/plenary/stack_spec.lua
+++ b/lua/tests/plenary/stack_spec.lua
@@ -29,4 +29,85 @@ describe("stacked PRs", function()
       assert.is_nil(queries.pull_request:find("stackEntry", 1, true))
     end)
   end)
+
+  describe("build_stack_details", function()
+    local writers = require "octo.ui.writers"
+    local utils = require "octo.utils"
+
+    local function line_text(line)
+      local s = ""
+      for _, chunk in ipairs(line) do
+        s = s .. chunk[1]
+      end
+      return s
+    end
+
+    local function make_stack_entry()
+      return {
+        position = 2,
+        stack = {
+          id = "S_1",
+          number = 350,
+          size = 5,
+          baseRefName = "main",
+          entries = {
+            nodes = {
+              {
+                position = 1,
+                pullRequest = { number = 330, title = "Bottom PR", state = "MERGED", isDraft = false, url = "" },
+              },
+              {
+                position = 3,
+                pullRequest = { number = 343, title = "Top PR", state = "OPEN", isDraft = true, url = "" },
+              },
+              {
+                position = 2,
+                pullRequest = { number = 333, title = "Current PR", state = "OPEN", isDraft = false, url = "" },
+              },
+            },
+          },
+        },
+      }
+    end
+
+    it("returns no lines when the PR is not part of a stack", function()
+      eq({}, writers.build_stack_details(nil))
+      eq({}, writers.build_stack_details(vim.NIL))
+    end)
+
+    it("renders a header with position, size and base branch", function()
+      local lines = writers.build_stack_details(make_stack_entry())
+      eq("Stack: 2/5 (into main)", line_text(lines[1]))
+    end)
+
+    it("renders one line per entry, top of the stack first", function()
+      local lines = writers.build_stack_details(make_stack_entry())
+      eq(4, #lines)
+      assert.is_truthy(line_text(lines[2]):find("#343 Top PR", 1, true))
+      assert.is_truthy(line_text(lines[3]):find("#333 Current PR", 1, true))
+      assert.is_truthy(line_text(lines[4]):find("#330 Bottom PR", 1, true))
+    end)
+
+    it("marks the current PR with an arrow", function()
+      local lines = writers.build_stack_details(make_stack_entry())
+      assert.is_truthy(vim.startswith(line_text(lines[3]), "  ▶ "))
+      assert.is_truthy(vim.startswith(line_text(lines[2]), "    "))
+      assert.is_truthy(vim.startswith(line_text(lines[4]), "    "))
+    end)
+
+    it("uses the PR state icons", function()
+      local lines = writers.build_stack_details(make_stack_entry())
+      assert.is_truthy(line_text(lines[2]):find(utils.icons.pull_request.draft[1], 1, true))
+      assert.is_truthy(line_text(lines[3]):find(utils.icons.pull_request.open[1], 1, true))
+      assert.is_truthy(line_text(lines[4]):find(utils.icons.pull_request.merged[1], 1, true))
+    end)
+
+    it("handles inaccessible pull requests", function()
+      local stack_entry = make_stack_entry()
+      stack_entry.stack.entries.nodes[2].pullRequest = vim.NIL
+      local lines = writers.build_stack_details(stack_entry)
+      eq(4, #lines)
+      assert.is_truthy(line_text(lines[2]):find("not accessible", 1, true))
+    end)
+  end)
 end)

--- a/lua/tests/plenary/stack_spec.lua
+++ b/lua/tests/plenary/stack_spec.lua
@@ -1,0 +1,32 @@
+---@diagnostic disable
+local config = require "octo.config"
+local fragments = require "octo.gh.fragments"
+local queries = require "octo.gh.queries"
+
+config.setup {}
+fragments.setup()
+queries.setup()
+
+local eq = assert.are.same
+
+describe("stacked PRs", function()
+  describe("pull_request query gating", function()
+    after_each(function()
+      config.values.github_hostname = ""
+      queries.setup()
+    end)
+
+    it("includes stackEntry on github.com", function()
+      config.values.github_hostname = ""
+      queries.setup()
+      assert.is_truthy(queries.pull_request:find("stackEntry {", 1, true))
+      assert.is_nil(queries.pull_request:find("{stackEntry}", 1, true))
+    end)
+
+    it("omits stackEntry on GHES", function()
+      config.values.github_hostname = "github.example.com"
+      queries.setup()
+      assert.is_nil(queries.pull_request:find("stackEntry", 1, true))
+    end)
+  end)
+end)

--- a/lua/tests/plenary/stack_spec.lua
+++ b/lua/tests/plenary/stack_spec.lua
@@ -62,7 +62,15 @@ describe("stacked PRs", function()
               },
               {
                 position = 2,
-                pullRequest = { number = 333, title = "Current PR", state = "OPEN", isDraft = false, url = "" },
+                pullRequest = {
+                  number = 333,
+                  title = "Current PR",
+                  state = "OPEN",
+                  isDraft = false,
+                  url = "",
+                  reviewDecision = "APPROVED",
+                  statusCheckRollup = { state = "SUCCESS" },
+                },
               },
             },
           },
@@ -108,6 +116,60 @@ describe("stacked PRs", function()
       local lines = writers.build_stack_details(stack_entry)
       eq(4, #lines)
       assert.is_truthy(line_text(lines[2]):find("not accessible", 1, true))
+    end)
+
+    describe("state badges", function()
+      it("shows MERGED for merged PRs", function()
+        local lines = writers.build_stack_details(make_stack_entry())
+        assert.is_truthy(line_text(lines[4]):find("MERGED", 1, true))
+      end)
+
+      it("shows DRAFT for draft PRs", function()
+        local lines = writers.build_stack_details(make_stack_entry())
+        assert.is_truthy(line_text(lines[2]):find("DRAFT", 1, true))
+      end)
+
+      it("shows READY for open PRs with approved reviews and green checks", function()
+        local lines = writers.build_stack_details(make_stack_entry())
+        local text = line_text(lines[3])
+        assert.is_truthy(text:find("READY", 1, true))
+        assert.is_nil(text:find("NOT READY", 1, true))
+      end)
+
+      it("shows READY for open PRs with no required reviews and no checks", function()
+        local stack_entry = make_stack_entry()
+        stack_entry.stack.entries.nodes[3].pullRequest.reviewDecision = vim.NIL
+        stack_entry.stack.entries.nodes[3].pullRequest.statusCheckRollup = vim.NIL
+        local lines = writers.build_stack_details(stack_entry)
+        local text = line_text(lines[3])
+        assert.is_truthy(text:find("READY", 1, true))
+        assert.is_nil(text:find("NOT READY", 1, true))
+      end)
+
+      it("shows NOT READY when a review is still required", function()
+        local stack_entry = make_stack_entry()
+        stack_entry.stack.entries.nodes[3].pullRequest.reviewDecision = "REVIEW_REQUIRED"
+        local lines = writers.build_stack_details(stack_entry)
+        assert.is_truthy(line_text(lines[3]):find("NOT READY", 1, true))
+      end)
+
+      it("shows NOT READY when checks are failing", function()
+        local stack_entry = make_stack_entry()
+        stack_entry.stack.entries.nodes[3].pullRequest.statusCheckRollup = { state = "FAILURE" }
+        local lines = writers.build_stack_details(stack_entry)
+        assert.is_truthy(line_text(lines[3]):find("NOT READY", 1, true))
+      end)
+    end)
+  end)
+
+  describe("pull_request query stack fields", function()
+    it("fetches per-entry review and check state", function()
+      config.values.github_hostname = ""
+      queries.setup()
+      local sub = queries.pull_request:match "stackEntry %b{}"
+      assert.is_truthy(sub)
+      assert.is_truthy(sub:find("reviewDecision", 1, true))
+      assert.is_truthy(sub:find("statusCheckRollup", 1, true))
     end)
   end)
 end)

--- a/lua/tests/plenary/stack_spec.lua
+++ b/lua/tests/plenary/stack_spec.lua
@@ -159,6 +159,20 @@ describe("stacked PRs", function()
         local lines = writers.build_stack_details(stack_entry)
         assert.is_truthy(line_text(lines[3]):find("NOT READY", 1, true))
       end)
+
+      it("colors the state icon to match the badge", function()
+        local stack_entry = make_stack_entry()
+        stack_entry.stack.entries.nodes[3].pullRequest.reviewDecision = "REVIEW_REQUIRED"
+        local lines = writers.build_stack_details(stack_entry)
+        -- line = { marker, icon, "#number ", title, bubble... }: the icon is chunk 2
+        eq("OctoGrey", lines[2][2][2]) -- draft
+        eq("OctoYellow", lines[3][2][2]) -- open but not ready
+        eq("OctoPurple", lines[4][2][2]) -- merged
+
+        stack_entry.stack.entries.nodes[3].pullRequest.reviewDecision = "APPROVED"
+        lines = writers.build_stack_details(stack_entry)
+        eq("OctoGreen", lines[3][2][2]) -- open and ready
+      end)
     end)
   end)
 


### PR DESCRIPTION
> Part of the Stacked Pull Requests series for #1539. **Stacked on #1547** — until it merges, this diff includes the commits of the PRs below it in the stack; this PR's own changes are the **last 3 commit(s)**.

## Summary

<img width="667" height="402" alt="image" src="https://github.com/user-attachments/assets/0af30ba2-be79-4cd4-b729-53e31b53cea2" />


Adds `stack` as an `:Octo pr merge` strategy: merges the current PR **and every PR below it in its stack** via GitHub's atomic stack merge.

```
:Octo pr merge stack [merge|squash|rebase]
```

Also mapped as `merge_pr_stack` (`<localleader>pk`) in PR buffers.

## Implementation

Shells out to `gh stack merge <pr> --yes` (the gh-stack CLI extension) through octo's dynamic gh wrapper — the same pattern as the existing `gh pr merge` path. The merge is all-or-nothing bottom-up and merge-queue aware (enqueues instead of merging when the base uses a queue).

Guards:
- The PR must be part of a stack (uses the `stackEntry` data from the details PR).
- The current checkout must match the PR's repo (`gh stack merge` has no `--repo` flag).
- A confirmation dialog lists exactly which PRs will merge (positions at or below the current PR).
- Missing extension → clear hint: `gh extension install github/gh-stack`.

The gh-stack extension is an **optional** dependency: nothing else in octo requires it, and the error message explains how to install it. The underlying REST API (`PUT .../pulls/{n}/merge-async`) is undocumented, so wrapping GitHub's own CLI was chosen over calling it directly.

## Tests

`lua/tests/plenary/merge_stack_spec.lua` — arg construction, method flags, guards, confirmation scoping, error paths.

