### PR TITLE
feat: add OctoReviewDiffDelete and OctoReviewDiffAdd highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,6 +871,8 @@ Also, you can use [`cmp-emoji`](https://github.com/hrsh7th/cmp-emoji) or [`blink
 | _OctoStateClosedFloat_            | OctoRedFloat       |
 | _OctoStateMergedFloat_            | OctoPurpleFloat    |
 | _OctoStateDraftFloat_             | OctoGreyFloat      |
+| _OctoReviewDiffDelete_            | DiffDelete         |
+| _OctoReviewDiffAdd_               | DiffAdd            |
 | _OctoReviewDiffDeleteText_        | OctoRed            |
 | _OctoReviewDiffAddText_           | OctoGreen          |
 

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -32,7 +32,7 @@ If any check fails, follow the advice shown in the report.
 
 LUA API                                         *octo-lua-api*
 
-The plugin exposes a Lua API to iteract with GitHub CLI which powers the
+The plugin exposes a Lua API to interact with GitHub CLI which powers the
 plugin.
 
 The `octo.gh` module is meant to mirror the GitHub CLI as closely as possible.
@@ -585,6 +585,8 @@ HIGHLIGHT GROUPS                                *octo-highlights*
   `OctoStateCommented`          `Normal`
   `OctoStateDismissed`          `OctoStateClosed`
   `OctoStateSkipped`            `Comment`
+  `OctoReviewDiffDelete`        `DiffDelete`
+  `OctoReviewDiffAdd`           `DiffAdd`
   `OctoReviewDiffDeleteText`    GitHub color
   `OctoReviewDiffAddText`       GitHub color
 

--- a/lua/octo/reviews/layout.lua
+++ b/lua/octo/reviews/layout.lua
@@ -83,12 +83,12 @@ function Layout:init_layout()
   self.left_winid = vim.api.nvim_get_current_win()
   vim.api.nvim_win_set_hl_ns(self.left_winid, constants.OCTO_REVIEW_LEFT_HIGHLIGHT_NS)
   vim.api.nvim_set_hl(constants.OCTO_REVIEW_LEFT_HIGHLIGHT_NS, "DiffText", { link = "OctoReviewDiffDeleteText" })
-  vim.api.nvim_set_hl(constants.OCTO_REVIEW_LEFT_HIGHLIGHT_NS, "DiffChange", { link = "DiffDelete" })
+  vim.api.nvim_set_hl(constants.OCTO_REVIEW_LEFT_HIGHLIGHT_NS, "DiffChange", { link = "OctoReviewDiffDelete" })
   vim.cmd "belowright vsp"
   self.right_winid = vim.api.nvim_get_current_win()
   vim.api.nvim_win_set_hl_ns(self.right_winid, constants.OCTO_REVIEW_RIGHT_HIGHLIGHT_NS)
   vim.api.nvim_set_hl(constants.OCTO_REVIEW_RIGHT_HIGHLIGHT_NS, "DiffText", { link = "OctoReviewDiffAddText" })
-  vim.api.nvim_set_hl(constants.OCTO_REVIEW_RIGHT_HIGHLIGHT_NS, "DiffChange", { link = "DiffAdd" })
+  vim.api.nvim_set_hl(constants.OCTO_REVIEW_RIGHT_HIGHLIGHT_NS, "DiffChange", { link = "OctoReviewDiffAdd" })
   self.file_panel:open()
 end
 

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -56,6 +56,8 @@ local function get_hl_groups()
     Strikethrough = { fg = colors.grey, strikethrough = true },
     Underline = { fg = colors.white, underline = true },
     Bubble = { fg = colors.white, bg = colors.grey },
+    ReviewDiffDelete = { bg = M.get_background_color_of_highlight_group "DiffDelete" },
+    ReviewDiffAdd = { bg = M.get_background_color_of_highlight_group "DiffAdd" },
     ReviewDiffDeleteText = { fg = colors.white, bg = colors.dark_red },
     ReviewDiffAddText = { fg = colors.white, bg = colors.dark_green },
   }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/pwntester/octo.nvim/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Adds new `OctoReviewDiffDelete` and `OctoReviewDiffAdd` highlights so users can better customise the colours that are used in the diff view. This follows up on https://github.com/pwntester/octo.nvim/pull/1500. These new highlights default to `DiffDelete` and `DiffAdd` so nothing changes for existing users.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE


### Describe how to verify it

Adjust the `OctoReviewDiffDelete` `OctoReviewDiffAdd` highlights via `vim.api.nvim_set_hl` e.g. `vim.api.nvim_set_hl(0, "OctoReviewDiffDelete", {bg = "#172a3a"})`. Then open up a review with some changes and you should see the deleted lines now have `#172a3a` as their background colour.

### Checklist

- [x] Passing tests and linting standards
- [x] Documentation updates in README.md and doc/octo.txt
