### PR TITLE
feat(pr): list CI checks in the PR details section

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ require"octo".setup {
       goto_file = { lhs = "gf", desc = "go to file" },
       stack_up = { lhs = "]s", desc = "open the next PR up the stack" },
       stack_down = { lhs = "[s", desc = "open the next PR down the stack" },
+      goto_check = { lhs = "<localleader>gc", desc = "open the CI check under the cursor" },
       add_assignee = { lhs = "<localleader>aa", desc = "add assignee" },
       remove_assignee = { lhs = "<localleader>ad", desc = "remove assignee" },
       create_label = { lhs = "<localleader>lc", desc = "create label" },

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ require"octo".setup {
     use_signcolumn = false, -- show "modified" marks on the sign column
     use_statuscolumn = true, -- show "modified" marks on the status column
     use_foldtext = true,
+    fold_checks = true, -- fold the CI checks list in the PR details, closed by default
   },
   issues = {
     order_by = { -- criteria to sort results of `Octo issue list`
@@ -453,6 +454,7 @@ require"octo".setup {
       stack_up = { lhs = "]s", desc = "open the next PR up the stack" },
       stack_down = { lhs = "[s", desc = "open the next PR down the stack" },
       goto_check = { lhs = "<localleader>gc", desc = "open the CI check under the cursor" },
+      toggle_checks = { lhs = "<localleader>tc", desc = "fold or unfold the CI checks list" },
       add_assignee = { lhs = "<localleader>aa", desc = "add assignee" },
       remove_assignee = { lhs = "<localleader>ad", desc = "remove assignee" },
       create_label = { lhs = "<localleader>lc", desc = "create label" },

--- a/doc/octo.txt
+++ b/doc/octo.txt
@@ -524,6 +524,27 @@ Octo provides a built-in omnifunc completion for issues, PRs and users that you 
 
 Also,you can use [`cmp-emoji`](https://github.com/hrsh7th/cmp-emoji) or [`blink-emoji.nvim`](https://github.com/moyiz/blink-emoji.nvim) to get markdown emoji completion.
 
+CI CHECKS                                       *octo-checks*
+
+  A pull request buffer lists the CI checks of its head commit in the details
+  section, grouped by outcome -- failures first, then running, skipped and
+  passed checks, each with how long it took.
+
+  The list is folded away behind its summary line, so the counts stay on
+  screen while the rows do not: >
+
+      Checks: 1 failed · 1 skipped · 12 passed  ▸ 14 checks
+
+<  Toggle it with `<localleader>tc` (`toggle_checks`) from anywhere in the
+  buffer, or with the usual fold keys (`za`, `zo`, `zc`) while the cursor is on
+  it. The fold stays as you left it when the buffer reloads. Set
+  `ui.fold_checks = false` to render the list unfolded and create no fold.
+
+  With the cursor on a check, `<localleader>gc` (`goto_check`) opens it: the
+  workflow run in an octo buffer for a GitHub Actions job, the check's target
+  URL in the browser for anything else.
+
+
 HIGHLIGHT GROUPS                                *octo-highlights*
 
   Highlight group             Defaults to~
@@ -563,6 +584,7 @@ HIGHLIGHT GROUPS                                *octo-highlights*
   `OctoStateChangesRequested`   `OctoStateClosed`
   `OctoStateCommented`          `Normal`
   `OctoStateDismissed`          `OctoStateClosed`
+  `OctoStateSkipped`            `Comment`
   `OctoReviewDiffDeleteText`    GitHub color
   `OctoReviewDiffAddText`       GitHub color
 

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -434,6 +434,7 @@ function M.get_default_values()
         goto_file = { lhs = "gf", desc = "go to file" },
         stack_up = { lhs = "]s", desc = "open the next PR up the stack" },
         stack_down = { lhs = "[s", desc = "open the next PR down the stack" },
+        goto_check = { lhs = "<localleader>gc", desc = "open the CI check under the cursor" },
         add_assignee = { lhs = "<localleader>aa", desc = "add assignee" },
         remove_assignee = { lhs = "<localleader>ad", desc = "remove assignee" },
         create_label = { lhs = "<localleader>lc", desc = "create label" },

--- a/lua/octo/config.lua
+++ b/lua/octo/config.lua
@@ -69,6 +69,7 @@ local M = {}
 ---@field use_signcolumn boolean
 ---@field use_statuscolumn boolean
 ---@field use_foldtext boolean
+---@field fold_checks boolean
 
 ---@class OctoConfigIssues
 ---@field order_by OctoConfigOrderBy
@@ -275,6 +276,7 @@ function M.get_default_values()
       use_signcolumn = false, -- show "modified" marks on the sign column
       use_statuscolumn = true, -- show "modified" marks on the status column
       use_foldtext = true,
+      fold_checks = true, -- fold the CI checks list in the PR details, closed by default
     },
     issues = {
       order_by = { -- criteria to sort results of `Octo issue list`
@@ -435,6 +437,7 @@ function M.get_default_values()
         stack_up = { lhs = "]s", desc = "open the next PR up the stack" },
         stack_down = { lhs = "[s", desc = "open the next PR down the stack" },
         goto_check = { lhs = "<localleader>gc", desc = "open the CI check under the cursor" },
+        toggle_checks = { lhs = "<localleader>tc", desc = "fold or unfold the CI checks list" },
         add_assignee = { lhs = "<localleader>aa", desc = "add assignee" },
         remove_assignee = { lhs = "<localleader>ad", desc = "remove assignee" },
         create_label = { lhs = "<localleader>lc", desc = "create label" },
@@ -793,6 +796,7 @@ function M.validate_config()
       validate_type(config.ui.use_signcolumn, "ui.use_signcolumn", "boolean")
       validate_type(config.ui.use_statuscolumn, "ui.use_statuscolumn", "boolean")
       validate_type(config.ui.use_foldtext, "ui.use_foldtext", "boolean")
+      validate_type(config.ui.fold_checks, "ui.fold_checks", "boolean")
     end
     if validate_type(config.colors, "colors", "table") then
       ---@diagnostic disable-next-line: no-unknown

--- a/lua/octo/folds.lua
+++ b/lua/octo/folds.lua
@@ -1,4 +1,5 @@
 local config = require "octo.config"
+local constants = require "octo.constants"
 
 local M = {}
 
@@ -22,6 +23,48 @@ function M.create(bufnr, start_line, end_line, is_opened)
       vim.cmd(string.format("%d,%dfoldopen", start_line, end_line))
     end
   end)
+end
+
+---@class octo.ChecksFold
+---@field start integer first line of the fold
+---@field stop integer last line of the fold
+---@field summary_line integer line of the "Checks:" summary
+---@field count integer checks hidden while the fold is closed
+
+---Fold the per-check lines of the CI checks section, closed unless asked
+---otherwise. With `use_foldtext` the summary line joins the fold and stands in
+---for it while closed (see `foldtext`); without it the summary stays out of the
+---fold so it remains visible either way.
+---@param bufnr integer
+---@param summary_line integer line holding the "Checks:" summary
+---@param last_line integer line of the last check
+---@param is_open boolean
+---@return octo.ChecksFold? nil when there is nothing to fold
+function M.create_checks(bufnr, summary_line, last_line, is_open)
+  if last_line <= summary_line then
+    return nil
+  end
+  local first = summary_line + 1
+  local start = config.values.ui.use_foldtext and summary_line or first
+
+  local ok = pcall(vim.api.nvim_buf_call, bufnr, function()
+    if vim.fn.foldlevel(first) == 0 then
+      M.create(bufnr, first, last_line, is_open)
+      return
+    end
+    -- a re-render walked over an existing fold: only the state may need moving
+    local closed = vim.fn.foldclosed(start) ~= -1
+    if closed and is_open then
+      vim.cmd(start .. "foldopen")
+    elseif not closed and not is_open then
+      vim.cmd(start .. "foldclose")
+    end
+  end)
+  if not ok then
+    return nil
+  end
+
+  return { start = start, stop = last_line, summary_line = summary_line, count = last_line - summary_line }
 end
 
 --- Parse lines for <details>...</details> HTML blocks.
@@ -278,8 +321,50 @@ end
 --- whitespace before the fold icon has no background. For <details> folds,
 --- displays the summary text from the overlay extmark.
 function M.foldtext()
-  local buf = vim.api.nvim_get_current_buf()
-  local lnum = vim.v.foldstart
+  return M.foldtext_for(vim.api.nvim_get_current_buf(), vim.v.foldstart)
+end
+
+---Chunks a closed CI checks fold shows in place of the lines it hides: the
+---summary itself when the summary is folded away with them, else a count.
+---@param bufnr integer
+---@param lnum integer first line of the fold
+---@return [string, string][]?
+local function checks_foldtext(bufnr, lnum)
+  local buffer = octo_buffers and octo_buffers[bufnr]
+  local checks = buffer and buffer.checksFold ---@type octo.ChecksFold?
+  if checks == nil or lnum ~= checks.start then
+    return nil
+  end
+
+  local hidden = { string.format("  %s %d checks", "▸", checks.count), "OctoDetailsLabel" }
+  if lnum ~= checks.summary_line then
+    -- the summary is still on screen above the fold: only say what is hidden
+    return { { "    ", "OctoDetailsValue" }, hidden }
+  end
+
+  local extmark = vim.api.nvim_buf_get_extmarks(
+    bufnr,
+    constants.OCTO_DETAILS_VT_NS,
+    { lnum - 1, 0 },
+    { lnum - 1, -1 },
+    { details = true }
+  )[1]
+  local virt_text = vim.tbl_get(extmark or {}, 4, "virt_text") ---@type [string, string][]?
+  if virt_text == nil then
+    return { { "    ", "OctoDetailsValue" }, hidden }
+  end
+  local chunks = vim.deepcopy(virt_text)
+  table.insert(chunks, hidden)
+  return chunks
+end
+
+---@param buf integer
+---@param lnum integer first line of the fold
+function M.foldtext_for(buf, lnum)
+  local checks = checks_foldtext(buf, lnum)
+  if checks then
+    return checks
+  end
   local details_ns = vim.api.nvim_create_namespace "octo_details_folds"
 
   -- Check for <details> fold extmarks first

--- a/lua/octo/gh/queries.lua
+++ b/lua/octo/gh/queries.lua
@@ -129,6 +129,20 @@ query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
   ---@field position integer
   ---@field stack octo.PullRequestStack
 
+  ---@class octo.StatusCheckRollupContext
+  ---@field __typename "CheckRun"|"StatusContext"
+  ---@field name? string CheckRun: job name
+  ---@field status? string CheckRun: QUEUED|IN_PROGRESS|COMPLETED|...
+  ---@field conclusion? string CheckRun: SUCCESS|FAILURE|SKIPPED|...
+  ---@field startedAt? string
+  ---@field completedAt? string
+  ---@field detailsUrl? string
+  ---@field checkSuite? { workflowRun?: { workflow: { name: string } } }
+  ---@field context? string StatusContext: check name
+  ---@field state? octo.StatusState StatusContext state
+  ---@field description? string
+  ---@field targetUrl? string
+
   ---@class octo.PullRequest : octo.ReactionGroupsFragment
   ---@field id string
   ---@field isDraft boolean
@@ -172,7 +186,7 @@ query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
   ---@field labels octo.fragments.LabelConnection
   ---@field assignees octo.fragments.AssigneeConnection
   ---@field reviewRequests { totalCount: integer, nodes: { requestedReviewer: { name: string }|{ login: string }|{ login: string, isViewer: boolean } }[] }
-  ---@field statusCheckRollup { state: octo.StatusState }
+  ---@field statusCheckRollup { state: octo.StatusState, contexts?: { nodes: octo.StatusCheckRollupContext[] } }
   ---@field mergeStateStatus octo.MergeStateStatus
   ---@field mergeable octo.MergeableState
   ---@field autoMergeRequest { enabledBy: { login: string }, mergeMethod: string }
@@ -296,6 +310,32 @@ query($endCursor: String) {
       }
       statusCheckRollup {
         state
+        contexts(first: 100) {
+          nodes {
+            __typename
+            ... on CheckRun {
+              name
+              status
+              conclusion
+              startedAt
+              completedAt
+              detailsUrl
+              checkSuite {
+                workflowRun {
+                  workflow {
+                    name
+                  }
+                }
+              }
+            }
+            ... on StatusContext {
+              context
+              state
+              description
+              targetUrl
+            }
+          }
+        }
       }
       mergeStateStatus
       mergeable

--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -376,6 +376,9 @@ return {
   goto_check = function()
     require("octo.navigation").go_to_check()
   end,
+  toggle_checks = function()
+    require("octo.navigation").toggle_checks()
+  end,
   next_comment = function()
     require("octo.navigation").next_comment()
   end,

--- a/lua/octo/mappings.lua
+++ b/lua/octo/mappings.lua
@@ -373,6 +373,9 @@ return {
   stack_down = function()
     require("octo.navigation").go_to_stack_neighbor(-1)
   end,
+  goto_check = function()
+    require("octo.navigation").go_to_check()
+  end,
   next_comment = function()
     require("octo.navigation").next_comment()
   end,

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -22,6 +22,7 @@ local M = {}
 ---@field number integer
 ---@field repo string
 ---@field checkByLine? table<integer, octo.StatusCheckRollupContext> buffer line -> CI check (PR buffers)
+---@field checksFold? octo.ChecksFold fold covering the CI checks list (PR buffers)
 ---@field kind octo.NodeKind|"reviewthread"
 ---@field titleMetadata TitleMetadata
 ---@field bodyMetadata BodyMetadata

--- a/lua/octo/model/octo-buffer.lua
+++ b/lua/octo/model/octo-buffer.lua
@@ -21,6 +21,7 @@ local M = {}
 ---@field bufnr integer
 ---@field number integer
 ---@field repo string
+---@field checkByLine? table<integer, octo.StatusCheckRollupContext> buffer line -> CI check (PR buffers)
 ---@field kind octo.NodeKind|"reviewthread"
 ---@field titleMetadata TitleMetadata
 ---@field bodyMetadata BodyMetadata

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -33,6 +33,34 @@ function M.go_to_stack_neighbor(offset)
   -- already at that end of the stack: do nothing
 end
 
+---Fold the CI checks list away, or bring it back. The summary line stays put
+---either way: it is the counts, not the list, that are worth the screen space.
+function M.toggle_checks()
+  local buffer = utils.get_current_buffer()
+  if not buffer or not buffer:isPullRequest() then
+    return
+  end
+  local fold = buffer.checksFold
+  if fold == nil then
+    utils.info "No CI checks list to fold"
+    return
+  end
+
+  local closed = vim.fn.foldclosed(fold.start) ~= -1
+  local command = string.format("%d%s", fold.start, closed and "foldopen" or "foldclose")
+  -- a closure rather than `pcall(vim.cmd, ...)`: vim.cmd is a callable table,
+  -- which the language server refuses to pass as a function
+  local ok = pcall(function()
+    vim.cmd(command)
+  end)
+  if not ok then
+    utils.error("Cannot fold the CI checks list at line " .. fold.start)
+    return
+  end
+  -- a re-render must not undo the reader's choice
+  vim.b[buffer.bufnr].octo_checks_unfolded = closed
+end
+
 ---Open the CI check rendered on the given line of the current PR buffer: the
 ---workflow run when it is an Actions job, the target URL otherwise.
 ---@param line? integer 1-indexed buffer line, defaults to the cursor line
@@ -48,14 +76,15 @@ function M.go_to_check(line)
     return
   end
 
-  local url = context.detailsUrl
-  if utils.is_blank(url) then
-    url = context.targetUrl
+  local link = context.detailsUrl
+  if link == nil or link == vim.NIL or link == "" then
+    link = context.targetUrl
   end
-  if utils.is_blank(url) then
+  if link == nil or link == vim.NIL or link == "" then
     utils.info("No link for " .. (context.name or context.context or "this check"))
     return
   end
+  local url = link ---@type string
 
   local run_id = url:match "runs/(%d+)"
   if run_id then

--- a/lua/octo/navigation.lua
+++ b/lua/octo/navigation.lua
@@ -33,6 +33,38 @@ function M.go_to_stack_neighbor(offset)
   -- already at that end of the stack: do nothing
 end
 
+---Open the CI check rendered on the given line of the current PR buffer: the
+---workflow run when it is an Actions job, the target URL otherwise.
+---@param line? integer 1-indexed buffer line, defaults to the cursor line
+function M.go_to_check(line)
+  local buffer = utils.get_current_buffer()
+  if not buffer or not buffer:isPullRequest() then
+    return
+  end
+  line = line or vim.fn.line "."
+  local context = buffer.checkByLine and buffer.checkByLine[line]
+  if not context then
+    utils.info "No CI check under the cursor"
+    return
+  end
+
+  local url = context.detailsUrl
+  if utils.is_blank(url) then
+    url = context.targetUrl
+  end
+  if utils.is_blank(url) then
+    utils.info("No link for " .. (context.name or context.context or "this check"))
+    return
+  end
+
+  local run_id = url:match "runs/(%d+)"
+  if run_id then
+    require("octo.workflow_runs").render { id = run_id, repo = buffer.repo }
+    return
+  end
+  M.open_in_browser_raw(url)
+end
+
 --[[
 Opens a url in your default browser, bypassing gh.
 

--- a/lua/octo/ui/colors.lua
+++ b/lua/octo/ui/colors.lua
@@ -116,6 +116,8 @@ local function get_hl_links()
     StateCompleted = "OctoPurple",
     StateNotPlanned = "OctoGrey",
     StateDraft = "OctoGrey",
+    -- the colorscheme's own dimmed foreground: readable on light and dark alike
+    StateSkipped = "Comment",
     StateQueued = "OctoYellow",
     StateMerged = "OctoPurple",
     StatePending = "OctoYellow",

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -793,6 +793,152 @@ function M.build_stack_details(stack_entry)
   return lines
 end
 
+-- How a check outcome is displayed: glyph, highlight and summary label
+local check_outcome_display = {
+  failed = { "✗ ", "OctoStateDismissed", "failed" },
+  running = { "● ", "OctoStatePending", "running" },
+  skipped = { "⊘ ", "OctoGrey", "skipped" },
+  passed = { "✓ ", "OctoStateApproved", "passed" },
+}
+
+-- Listing order: the checks that need attention come first
+local check_outcome_order = { "failed", "running", "skipped", "passed" }
+
+local check_run_conclusion_outcomes = {
+  SUCCESS = "passed",
+  FAILURE = "failed",
+  TIMED_OUT = "failed",
+  ACTION_REQUIRED = "failed",
+  STARTUP_FAILURE = "failed",
+  SKIPPED = "skipped",
+  NEUTRAL = "skipped",
+  CANCELLED = "skipped",
+  STALE = "skipped",
+}
+
+local status_context_state_outcomes = {
+  SUCCESS = "passed",
+  PENDING = "running",
+  EXPECTED = "running",
+  FAILURE = "failed",
+  ERROR = "failed",
+}
+
+---Outcome bucket of a single check
+---@param context octo.StatusCheckRollupContext
+---@return "failed"|"running"|"skipped"|"passed"
+local function check_outcome(context)
+  if context.__typename == "CheckRun" then
+    if context.status ~= "COMPLETED" then
+      return "running"
+    end
+    return check_run_conclusion_outcomes[context.conclusion] or "skipped"
+  end
+  return status_context_state_outcomes[context.state] or "skipped"
+end
+
+---Display name of a single check: "workflow / job" when the workflow is known
+---@param context octo.StatusCheckRollupContext
+---@return string
+local function check_name(context)
+  if context.__typename ~= "CheckRun" then
+    return context.context or "check"
+  end
+  local name = context.name or "check"
+  local suite = context.checkSuite
+  if utils.is_blank(suite) or utils.is_blank(suite.workflowRun) then
+    return name
+  end
+  local workflow = suite.workflowRun.workflow
+  if utils.is_blank(workflow) or utils.is_blank(workflow.name) then
+    return name
+  end
+  return workflow.name .. " / " .. name
+end
+
+---How long a finished check took, or nil while it is still running
+---@param context octo.StatusCheckRollupContext
+---@return string?
+local function check_duration(context)
+  local started, completed = context.startedAt, context.completedAt
+  if utils.is_blank(started) or utils.is_blank(completed) then
+    return nil
+  end
+  local ok, seconds = pcall(utils.seconds_between, started, completed)
+  if not ok or type(seconds) ~= "number" or seconds < 0 then
+    return nil
+  end
+  return utils.format_seconds(seconds)
+end
+
+---Build virtual-text detail lines for a PR's CI checks: a summary line with
+---the counts per outcome, followed by one line per check.
+---@param rollup? { state: octo.StatusState, contexts?: { nodes: octo.StatusCheckRollupContext[] } }
+---@return [string, string][][]
+function M.build_checks_details(rollup)
+  local lines = {} ---@type [string, string][][]
+  if utils.is_blank(rollup) then
+    return lines
+  end
+
+  local contexts = {} ---@type octo.StatusCheckRollupContext[]
+  if not utils.is_blank(rollup.contexts) and not utils.is_blank(rollup.contexts.nodes) then
+    contexts = rollup.contexts.nodes
+  end
+
+  -- No per-check data (older GHES, or a PR without checks): keep the rollup line
+  if #contexts == 0 then
+    local state = rollup.state
+    local state_info = utils.state_map[state]
+    if utils.is_blank(state_info) then
+      return lines
+    end
+    table.insert(lines, {
+      { "Checks: ", "OctoDetailsLabel" },
+      { state_info.symbol .. state, state_info.hl },
+    })
+    return lines
+  end
+
+  local buckets = { failed = {}, running = {}, skipped = {}, passed = {} } ---@type table<string, octo.StatusCheckRollupContext[]>
+  for _, context in ipairs(contexts) do
+    table.insert(buckets[check_outcome(context)], context)
+  end
+
+  local summary = { { "Checks: ", "OctoDetailsLabel" } } ---@type [string, string][]
+  local first = true
+  for _, outcome in ipairs(check_outcome_order) do
+    local count = #buckets[outcome]
+    if count > 0 then
+      local display = check_outcome_display[outcome]
+      if not first then
+        table.insert(summary, { " · ", "OctoDetailsLabel" })
+      end
+      table.insert(summary, { string.format("%d %s", count, display[3]), display[2] })
+      first = false
+    end
+  end
+  table.insert(lines, summary)
+
+  for _, outcome in ipairs(check_outcome_order) do
+    local display = check_outcome_display[outcome]
+    for _, context in ipairs(buckets[outcome]) do
+      local line = {
+        { "    ", "OctoDetailsValue" },
+        { display[1], display[2] },
+        { check_name(context) },
+      } ---@type [string, string][]
+      local duration = check_duration(context)
+      if duration then
+        table.insert(line, { "  " .. duration, "OctoDetailsLabel" })
+      end
+      table.insert(lines, line)
+    end
+  end
+
+  return lines
+end
+
 --- Write issue or PR details virtual text in buffer
 ---@param bufnr integer
 ---@param issue octo.PullRequest|octo.Issue
@@ -1067,16 +1213,8 @@ function M.write_details(bufnr, issue, update, include_status)
     end
 
     -- checks
-    if issue.statusCheckRollup and issue.statusCheckRollup ~= vim.NIL then
-      local state = issue.statusCheckRollup.state
-      local state_info = utils.state_map[state]
-      ---@type string
-      local message = state_info.symbol .. state
-      local checks_vt = {
-        { "Checks: ", "OctoDetailsLabel" },
-        { message, state_info.hl },
-      }
-      table.insert(details, checks_vt)
+    for _, checks_line in ipairs(M.build_checks_details(issue.statusCheckRollup)) do
+      table.insert(details, checks_line)
     end
 
     -- merge state

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -797,7 +797,7 @@ end
 local check_outcome_display = {
   failed = { "✗ ", "OctoStateDismissed", "failed" },
   running = { "● ", "OctoStatePending", "running" },
-  skipped = { "⊘ ", "OctoGrey", "skipped" },
+  skipped = { "⊘ ", "OctoStateSkipped", "skipped" },
   passed = { "✓ ", "OctoStateApproved", "passed" },
 }
 
@@ -846,14 +846,22 @@ local function check_name(context)
   end
   local name = context.name or "check"
   local suite = context.checkSuite
-  if utils.is_blank(suite) or utils.is_blank(suite.workflowRun) then
+  if suite == nil or suite == vim.NIL then
     return name
   end
-  local workflow = suite.workflowRun.workflow
-  if utils.is_blank(workflow) or utils.is_blank(workflow.name) then
+  local run = suite.workflowRun
+  if run == nil or run == vim.NIL then
     return name
   end
-  return workflow.name .. " / " .. name
+  local workflow = run.workflow
+  if workflow == nil or workflow == vim.NIL then
+    return name
+  end
+  local workflow_name = workflow.name
+  if workflow_name == nil or workflow_name == vim.NIL or workflow_name == "" then
+    return name
+  end
+  return workflow_name .. " / " .. name
 end
 
 ---How long a finished check took, or nil while it is still running
@@ -879,13 +887,14 @@ end
 function M.build_checks_details(rollup)
   local lines = {} ---@type [string, string][][]
   local contexts_by_offset = {} ---@type table<integer, octo.StatusCheckRollupContext>
-  if utils.is_blank(rollup) then
+  if rollup == nil or rollup == vim.NIL then
     return lines, contexts_by_offset
   end
 
   local contexts = {} ---@type octo.StatusCheckRollupContext[]
-  if not utils.is_blank(rollup.contexts) and not utils.is_blank(rollup.contexts.nodes) then
-    contexts = rollup.contexts.nodes
+  local rollup_contexts = rollup.contexts
+  if rollup_contexts ~= nil and rollup_contexts ~= vim.NIL and not utils.is_blank(rollup_contexts.nodes) then
+    contexts = rollup_contexts.nodes
   end
 
   -- No per-check data (older GHES, or a PR without checks): keep the rollup line
@@ -925,11 +934,12 @@ function M.build_checks_details(rollup)
   for _, outcome in ipairs(check_outcome_order) do
     local display = check_outcome_display[outcome]
     for _, context in ipairs(buckets[outcome]) do
+      ---@type [string, string][]
       local line = {
         { "    ", "OctoDetailsValue" },
         { display[1], display[2] },
-        { check_name(context) },
-      } ---@type [string, string][]
+        { check_name(context), "Normal" },
+      }
       local duration = check_duration(context)
       if duration then
         table.insert(line, { "  " .. duration, "OctoDetailsLabel" })
@@ -953,6 +963,8 @@ function M.write_details(bufnr, issue, update, include_status)
   local is_issue = detect_issue_from_url(issue.url)
   local details = {} ---@type [string, string][][]
   local check_by_index = {} ---@type table<integer, octo.StatusCheckRollupContext> detail index -> check
+  local checks_summary_index ---@type integer? detail index of the "Checks:" summary
+  local checks_last_index ---@type integer? detail index of the last check
 
   if include_status then
     add_status_detail(details, is_issue, issue.state, issue.stateReason, issue.isDraft, issue.isInMergeQueue)
@@ -1221,6 +1233,11 @@ function M.write_details(bufnr, issue, update, include_status)
     for offset, checks_line in ipairs(checks_lines) do
       table.insert(details, checks_line)
       check_by_index[#details] = checks_contexts[offset]
+      if offset == 1 then
+        checks_summary_index = #details
+      elseif checks_contexts[offset] then
+        checks_last_index = #details
+      end
     end
 
     -- merge state
@@ -1293,16 +1310,31 @@ function M.write_details(bufnr, issue, update, include_status)
 
   -- write details as virtual text, remembering which lines hold CI checks
   local check_by_line = {} ---@type table<integer, octo.StatusCheckRollupContext>
+  local checks_summary_line ---@type integer?
+  local checks_last_line ---@type integer?
   for i, d in ipairs(details) do
     M.write_virtual_text(bufnr, constants.OCTO_DETAILS_VT_NS, line - 1, d)
     if check_by_index[i] then
       check_by_line[line] = check_by_index[i]
+    end
+    if i == checks_summary_index then
+      checks_summary_line = line
+    end
+    if i == checks_last_index then
+      checks_last_line = line
     end
     line = line + 1
   end
   local buffer = octo_buffers[bufnr]
   if buffer then
     buffer.checkByLine = check_by_line
+    -- a long list of checks costs more screen than it is worth, so it is folded
+    -- away behind its summary until asked for, and stays as the reader left it
+    buffer.checksFold = nil
+    if config.values.ui.fold_checks and checks_summary_line and checks_last_line then
+      local is_open = vim.b[bufnr].octo_checks_unfolded == true
+      buffer.checksFold = folds.create_checks(bufnr, checks_summary_line, checks_last_line, is_open)
+    end
   end
 end
 

--- a/lua/octo/ui/writers.lua
+++ b/lua/octo/ui/writers.lua
@@ -874,11 +874,13 @@ end
 ---Build virtual-text detail lines for a PR's CI checks: a summary line with
 ---the counts per outcome, followed by one line per check.
 ---@param rollup? { state: octo.StatusState, contexts?: { nodes: octo.StatusCheckRollupContext[] } }
----@return [string, string][][]
+---@return [string, string][][] lines
+---@return table<integer, octo.StatusCheckRollupContext> contexts # check per line offset, for cursor navigation
 function M.build_checks_details(rollup)
   local lines = {} ---@type [string, string][][]
+  local contexts_by_offset = {} ---@type table<integer, octo.StatusCheckRollupContext>
   if utils.is_blank(rollup) then
-    return lines
+    return lines, contexts_by_offset
   end
 
   local contexts = {} ---@type octo.StatusCheckRollupContext[]
@@ -891,13 +893,13 @@ function M.build_checks_details(rollup)
     local state = rollup.state
     local state_info = utils.state_map[state]
     if utils.is_blank(state_info) then
-      return lines
+      return lines, contexts_by_offset
     end
     table.insert(lines, {
       { "Checks: ", "OctoDetailsLabel" },
       { state_info.symbol .. state, state_info.hl },
     })
-    return lines
+    return lines, contexts_by_offset
   end
 
   local buckets = { failed = {}, running = {}, skipped = {}, passed = {} } ---@type table<string, octo.StatusCheckRollupContext[]>
@@ -933,10 +935,11 @@ function M.build_checks_details(rollup)
         table.insert(line, { "  " .. duration, "OctoDetailsLabel" })
       end
       table.insert(lines, line)
+      contexts_by_offset[#lines] = context
     end
   end
 
-  return lines
+  return lines, contexts_by_offset
 end
 
 --- Write issue or PR details virtual text in buffer
@@ -949,6 +952,7 @@ function M.write_details(bufnr, issue, update, include_status)
 
   local is_issue = detect_issue_from_url(issue.url)
   local details = {} ---@type [string, string][][]
+  local check_by_index = {} ---@type table<integer, octo.StatusCheckRollupContext> detail index -> check
 
   if include_status then
     add_status_detail(details, is_issue, issue.state, issue.stateReason, issue.isDraft, issue.isInMergeQueue)
@@ -1213,8 +1217,10 @@ function M.write_details(bufnr, issue, update, include_status)
     end
 
     -- checks
-    for _, checks_line in ipairs(M.build_checks_details(issue.statusCheckRollup)) do
+    local checks_lines, checks_contexts = M.build_checks_details(issue.statusCheckRollup)
+    for offset, checks_line in ipairs(checks_lines) do
       table.insert(details, checks_line)
+      check_by_index[#details] = checks_contexts[offset]
     end
 
     -- merge state
@@ -1285,10 +1291,18 @@ function M.write_details(bufnr, issue, update, include_status)
     M.write_block(bufnr, empty_lines, line)
   end
 
-  -- write details as virtual text
-  for _, d in ipairs(details) do
+  -- write details as virtual text, remembering which lines hold CI checks
+  local check_by_line = {} ---@type table<integer, octo.StatusCheckRollupContext>
+  for i, d in ipairs(details) do
     M.write_virtual_text(bufnr, constants.OCTO_DETAILS_VT_NS, line - 1, d)
+    if check_by_index[i] then
+      check_by_line[line] = check_by_index[i]
+    end
     line = line + 1
+  end
+  local buffer = octo_buffers[bufnr]
+  if buffer then
+    buffer.checkByLine = check_by_line
   end
 end
 

--- a/lua/tests/plenary/check_navigation_spec.lua
+++ b/lua/tests/plenary/check_navigation_spec.lua
@@ -1,0 +1,95 @@
+---@diagnostic disable
+local eq = assert.are.same
+
+describe("go_to_check:", function()
+  local navigation
+  local utils
+  local rendered
+  local browsed
+  local info_messages
+
+  local function pr_buffer()
+    return {
+      repo = "owner/repo",
+      isPullRequest = function()
+        return true
+      end,
+      checkByLine = {
+        [8] = {
+          __typename = "CheckRun",
+          name = "system_tests",
+          detailsUrl = "https://github.com/owner/repo/actions/runs/123/job/456",
+        },
+        [9] = {
+          __typename = "StatusContext",
+          context = "license/cla",
+          targetUrl = "https://cla.example.com/status",
+        },
+        [10] = { __typename = "CheckRun", name = "no-url" },
+      },
+    }
+  end
+
+  before_each(function()
+    rendered = nil
+    browsed = nil
+    info_messages = {}
+
+    package.loaded["octo.workflow_runs"] = {
+      render = function(opts)
+        rendered = opts
+      end,
+    }
+
+    navigation = require "octo.navigation"
+    utils = require "octo.utils"
+
+    utils.info = function(msg)
+      table.insert(info_messages, msg)
+    end
+    navigation.open_in_browser_raw = function(url)
+      browsed = url
+    end
+    utils.get_current_buffer = pr_buffer
+  end)
+
+  after_each(function()
+    package.loaded["octo.navigation"] = nil
+    package.loaded["octo.utils"] = nil
+    package.loaded["octo.workflow_runs"] = nil
+  end)
+
+  it("opens the workflow run of the check under the cursor", function()
+    navigation.go_to_check(8)
+    eq({ id = "123", repo = "owner/repo" }, rendered)
+    eq(nil, browsed)
+  end)
+
+  it("opens external status contexts in the browser", function()
+    navigation.go_to_check(9)
+    eq("https://cla.example.com/status", browsed)
+    eq(nil, rendered)
+  end)
+
+  it("notifies when the check has no link", function()
+    navigation.go_to_check(10)
+    eq(nil, rendered)
+    eq(nil, browsed)
+    eq(1, #info_messages)
+  end)
+
+  it("notifies when the line holds no check", function()
+    navigation.go_to_check(3)
+    eq(nil, rendered)
+    eq(1, #info_messages)
+  end)
+
+  it("does nothing outside PR buffers", function()
+    utils.get_current_buffer = function()
+      return nil
+    end
+    navigation.go_to_check(8)
+    eq(nil, rendered)
+    eq(0, #info_messages)
+  end)
+end)

--- a/lua/tests/plenary/checks_fold_spec.lua
+++ b/lua/tests/plenary/checks_fold_spec.lua
@@ -1,0 +1,282 @@
+---@diagnostic disable
+local eq = assert.are.same
+local config = require "octo.config"
+local constants = require "octo.constants"
+local folds = require "octo.folds"
+
+---A buffer of empty lines in a real window: manual folds live in the window
+---@param count integer
+local function scratch(count)
+  local lines = {}
+  for _ = 1, count do
+    table.insert(lines, "")
+  end
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  local win = vim.api.nvim_open_win(bufnr, true, {
+    relative = "editor",
+    width = 120,
+    height = 60,
+    row = 0,
+    col = 0,
+  })
+  return bufnr, win
+end
+
+---@param bufnr integer
+---@param line integer
+---@param chunks [string, string][]
+local function details_text(bufnr, line, chunks)
+  vim.api.nvim_buf_set_extmark(bufnr, constants.OCTO_DETAILS_VT_NS, line - 1, 0, {
+    virt_text = chunks,
+    virt_text_pos = "eol",
+  })
+end
+
+describe("checks fold:", function()
+  local bufnr
+  local win
+  local original_foldtext
+
+  before_each(function()
+    _G.octo_buffers = _G.octo_buffers or {}
+    original_foldtext = config.values.ui.use_foldtext
+    config.values.ui.use_foldtext = true
+    bufnr, win = scratch(20)
+  end)
+
+  after_each(function()
+    config.values.ui.use_foldtext = original_foldtext
+    _G.octo_buffers[bufnr] = nil
+    pcall(vim.api.nvim_win_close, win, true)
+    pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+  end)
+
+  describe("create_checks", function()
+    it("folds the checks away behind the summary line", function()
+      local fold = folds.create_checks(bufnr, 5, 9, false)
+
+      eq({ start = 5, stop = 9, summary_line = 5, count = 4 }, fold)
+      eq(5, vim.fn.foldclosed(5)) -- the summary stands in for the fold
+      eq(9, vim.fn.foldclosedend(5))
+      eq(-1, vim.fn.foldclosed(10)) -- the detail below it is untouched
+    end)
+
+    it("keeps the summary out of the fold without octo's foldtext", function()
+      config.values.ui.use_foldtext = false
+      local fold = folds.create_checks(bufnr, 5, 9, false)
+
+      eq(6, fold.start)
+      eq(-1, vim.fn.foldclosed(5)) -- summary still readable
+      eq(6, vim.fn.foldclosed(6))
+    end)
+
+    it("leaves the fold open when asked", function()
+      local fold = folds.create_checks(bufnr, 5, 9, true)
+
+      eq(-1, vim.fn.foldclosed(fold.start))
+      eq(1, vim.fn.foldlevel(fold.start)) -- the fold exists, it is just open
+    end)
+
+    it("has nothing to fold with a summary and no checks", function()
+      eq(nil, folds.create_checks(bufnr, 5, 5, false))
+      eq(0, vim.fn.foldlevel(5))
+    end)
+
+    it("moves the state of an existing fold rather than nesting a new one", function()
+      folds.create_checks(bufnr, 5, 9, false)
+      local fold = folds.create_checks(bufnr, 5, 9, true) -- a re-render
+
+      eq(5, fold.start)
+      eq(1, vim.fn.foldlevel(6)) -- still one fold, not two
+      eq(-1, vim.fn.foldclosed(5))
+    end)
+  end)
+
+  describe("foldtext", function()
+    it("shows the summary and the number of checks it hides", function()
+      details_text(bufnr, 5, { { "Checks: ", "OctoDetailsLabel" }, { "1 failed", "OctoStateDismissed" } })
+      _G.octo_buffers[bufnr] = { checksFold = folds.create_checks(bufnr, 5, 9, false) }
+
+      local chunks = folds.foldtext_for(bufnr, 5)
+      eq("Checks: ", chunks[1][1])
+      eq("1 failed", chunks[2][1])
+      assert.is_truthy(chunks[3][1]:find("4 checks", 1, true))
+    end)
+
+    it("shows only the count when the summary stays on screen", function()
+      config.values.ui.use_foldtext = false
+      details_text(bufnr, 5, { { "Checks: ", "OctoDetailsLabel" } })
+      local fold = folds.create_checks(bufnr, 5, 9, false)
+      _G.octo_buffers[bufnr] = { checksFold = fold }
+
+      local chunks = folds.foldtext_for(bufnr, fold.start)
+      eq(2, #chunks)
+      assert.is_truthy(chunks[2][1]:find("4 checks", 1, true))
+      assert.is_falsy(chunks[1][1]:find("Checks:", 1, true))
+    end)
+
+    it("leaves other folds to the usual foldtext", function()
+      details_text(bufnr, 12, { { "    ", "Normal" } })
+      _G.octo_buffers[bufnr] = { checksFold = folds.create_checks(bufnr, 5, 9, false) }
+
+      eq({ { "    ", "Normal" } }, folds.foldtext_for(bufnr, 12))
+    end)
+  end)
+
+  describe("write_details", function()
+    local writers = require "octo.ui.writers"
+
+    ---@param name string
+    ---@param conclusion string
+    local function check(name, conclusion)
+      return {
+        __typename = "CheckRun",
+        name = name,
+        status = "COMPLETED",
+        conclusion = conclusion,
+        startedAt = vim.NIL,
+        completedAt = vim.NIL,
+        checkSuite = { workflowRun = { workflow = { name = "CI" } } },
+      }
+    end
+
+    local function pull_request()
+      return {
+        url = "https://github.com/owner/repo/pull/7",
+        number = 7,
+        state = "OPEN",
+        author = { login = "someone" },
+        createdAt = "2026-08-01T10:00:00Z",
+        headRefName = "feature_a",
+        baseRefName = "master",
+        labels = { nodes = {} },
+        timelineItems = { nodes = {} },
+        reactionGroups = {},
+        assignees = { nodes = {} },
+        reviewRequests = { totalCount = 0, nodes = {} },
+        latestReviews = { nodes = {} },
+        milestone = vim.NIL,
+        projectCards = { nodes = {} },
+        projectItems = { nodes = {} },
+        additions = 3,
+        deletions = 1,
+        changedFiles = 2,
+        commits = { totalCount = 2 },
+        merged = false,
+        mergeable = "MERGEABLE",
+        mergeStateStatus = "CLEAN",
+        isDraft = false,
+        viewerSubscription = "SUBSCRIBED",
+        statusCheckRollup = {
+          state = "FAILURE",
+          contexts = {
+            nodes = {
+              check("a", "FAILURE"),
+              check("b", "SUCCESS"),
+              check("c", "SKIPPED"),
+              check("d", "SUCCESS"),
+            },
+          },
+        },
+      }
+    end
+
+    it("folds the rendered checks list and keeps the checks navigable", function()
+      _G.octo_buffers[bufnr] = { bufnr = bufnr }
+      writers.write_details(bufnr, pull_request(), false, true)
+
+      local fold = _G.octo_buffers[bufnr].checksFold
+      eq(4, fold.count)
+      eq(fold.summary_line, fold.start) -- octo's foldtext stands in for it
+      eq(fold.start, vim.fn.foldclosed(fold.start))
+      eq(fold.stop, vim.fn.foldclosedend(fold.start))
+
+      -- the summary the reader sees while it is closed
+      local chunks = folds.foldtext_for(bufnr, fold.start)
+      local text = ""
+      for _, chunk in ipairs(chunks) do
+        text = text .. chunk[1]
+      end
+      assert.is_truthy(text:find("1 failed", 1, true))
+      assert.is_truthy(text:find("▸ 4 checks", 1, true))
+
+      -- and the folded lines still answer `goto_check`
+      eq(4, vim.tbl_count(_G.octo_buffers[bufnr].checkByLine))
+    end)
+
+    it("renders the list unfolded when the option is off", function()
+      config.values.ui.fold_checks = false
+      _G.octo_buffers[bufnr] = { bufnr = bufnr }
+      writers.write_details(bufnr, pull_request(), false, true)
+
+      eq(nil, _G.octo_buffers[bufnr].checksFold)
+      eq(0, vim.fn.foldlevel(13))
+      config.values.ui.fold_checks = true
+    end)
+  end)
+
+  describe("toggle_checks", function()
+    local navigation
+    local utils
+    local buffer
+    local info_messages
+
+    before_each(function()
+      info_messages = {}
+      navigation = require "octo.navigation"
+      utils = require "octo.utils"
+      utils.info = function(msg)
+        table.insert(info_messages, msg)
+      end
+      buffer = {
+        bufnr = bufnr,
+        isPullRequest = function()
+          return true
+        end,
+        checksFold = folds.create_checks(bufnr, 5, 9, false),
+      }
+      utils.get_current_buffer = function()
+        return buffer
+      end
+    end)
+
+    after_each(function()
+      package.loaded["octo.navigation"] = nil
+      package.loaded["octo.utils"] = nil
+      -- the outer after_each may already have wiped the buffer
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.b[bufnr].octo_checks_unfolded = nil
+      end
+    end)
+
+    it("unfolds a closed list and folds it back", function()
+      navigation.toggle_checks()
+      eq(-1, vim.fn.foldclosed(5))
+      eq(true, vim.b[bufnr].octo_checks_unfolded)
+
+      navigation.toggle_checks()
+      eq(5, vim.fn.foldclosed(5))
+      eq(false, vim.b[bufnr].octo_checks_unfolded)
+    end)
+
+    it("says so when the PR has no checks list", function()
+      buffer.checksFold = nil
+      navigation.toggle_checks()
+
+      eq(1, #info_messages)
+      assert.is_truthy(info_messages[1]:find("checks", 1, true))
+      eq(5, vim.fn.foldclosed(5)) -- the fold in the window is left alone
+    end)
+
+    it("does nothing outside a pull request buffer", function()
+      buffer.isPullRequest = function()
+        return false
+      end
+      navigation.toggle_checks()
+
+      eq(0, #info_messages)
+      eq(5, vim.fn.foldclosed(5))
+    end)
+  end)
+end)

--- a/lua/tests/plenary/checks_section_spec.lua
+++ b/lua/tests/plenary/checks_section_spec.lua
@@ -103,6 +103,16 @@ describe("checks section:", function()
     assert.is_truthy(text:find("license/cla", 1, true))
   end)
 
+  it("maps each row to its check for cursor navigation", function()
+    local lines, contexts = writers.build_checks_details(make_rollup())
+    eq(6, #lines)
+    eq(nil, contexts[1]) -- the summary line is not a check
+    eq("system_tests", contexts[2].name)
+    eq("migrations", contexts[3].name)
+    eq("deploy", contexts[4].name)
+    eq("license/cla", contexts[6].context)
+  end)
+
   it("handles a rollup whose contexts are all successful", function()
     local rollup = {
       state = "SUCCESS",

--- a/lua/tests/plenary/checks_section_spec.lua
+++ b/lua/tests/plenary/checks_section_spec.lua
@@ -73,6 +73,33 @@ describe("checks section:", function()
     assert.is_truthy(summary:find("2 passed", 1, true))
   end)
 
+  ---@param lines [string, string][][]
+  ---@param needle string
+  ---@return string? highlight
+  local function highlight_of(lines, needle)
+    for _, line in ipairs(lines) do
+      for _, chunk in ipairs(line) do
+        if chunk[1]:find(needle, 1, true) then
+          return chunk[2]
+        end
+      end
+    end
+    return nil
+  end
+
+  it("dims skipped checks with a highlight the colorscheme owns", function()
+    local lines = writers.build_checks_details(make_rollup())
+    -- OctoGrey is a background colour: as a foreground it disappears on a dark
+    -- theme, which is what a reviewer on gruvbox reported
+    eq("OctoStateSkipped", highlight_of(lines, "1 skipped"))
+    eq("OctoStateSkipped", highlight_of(lines, "⊘"))
+  end)
+
+  it("resolves the skipped highlight to the colorscheme's dimmed foreground", function()
+    require("octo.ui.colors").setup()
+    eq("Comment", vim.api.nvim_get_hl(0, { name = "OctoStateSkipped" }).link)
+  end)
+
   it("lists one row per check, failures first then running", function()
     local lines = writers.build_checks_details(make_rollup())
     eq(6, #lines) -- summary + 5 contexts

--- a/lua/tests/plenary/checks_section_spec.lua
+++ b/lua/tests/plenary/checks_section_spec.lua
@@ -1,0 +1,119 @@
+---@diagnostic disable
+local eq = assert.are.same
+local writers = require "octo.ui.writers"
+
+local function line_text(line)
+  local text = ""
+  for _, chunk in ipairs(line) do
+    text = text .. chunk[1]
+  end
+  return text
+end
+
+local function all_text(lines)
+  local parts = {}
+  for _, line in ipairs(lines) do
+    table.insert(parts, line_text(line))
+  end
+  return table.concat(parts, "\n")
+end
+
+local function check_run(name, workflow, status, conclusion, started, completed)
+  return {
+    __typename = "CheckRun",
+    name = name,
+    status = status,
+    conclusion = conclusion or vim.NIL,
+    startedAt = started or vim.NIL,
+    completedAt = completed or vim.NIL,
+    checkSuite = { workflowRun = { workflow = { name = workflow } } },
+  }
+end
+
+local function make_rollup()
+  return {
+    state = "FAILURE",
+    contexts = {
+      nodes = {
+        check_run("docker_build", "CI", "COMPLETED", "SUCCESS", "2026-08-24T10:00:00Z", "2026-08-24T10:03:00Z"),
+        check_run("system_tests", "CI", "COMPLETED", "FAILURE", "2026-08-24T10:00:00Z", "2026-08-24T10:04:00Z"),
+        check_run("deploy", "Review App", "COMPLETED", "SKIPPED"),
+        check_run("migrations", "CI", "IN_PROGRESS", nil, "2026-08-24T10:00:00Z"),
+        {
+          __typename = "StatusContext",
+          context = "license/cla",
+          state = "SUCCESS",
+          description = "All committers signed",
+        },
+      },
+    },
+  }
+end
+
+describe("checks section:", function()
+  it("renders nothing without a rollup", function()
+    eq({}, writers.build_checks_details(nil))
+    eq({}, writers.build_checks_details(vim.NIL))
+  end)
+
+  it("keeps a single summary line when contexts are unavailable", function()
+    local lines = writers.build_checks_details { state = "SUCCESS" }
+    eq(1, #lines)
+    assert.is_truthy(line_text(lines[1]):find("Checks:", 1, true))
+    assert.is_truthy(line_text(lines[1]):find("SUCCESS", 1, true))
+  end)
+
+  it("summarizes the checks by outcome", function()
+    local lines = writers.build_checks_details(make_rollup())
+    local summary = line_text(lines[1])
+    assert.is_truthy(summary:find("Checks:", 1, true))
+    assert.is_truthy(summary:find("1 failed", 1, true))
+    assert.is_truthy(summary:find("1 running", 1, true))
+    assert.is_truthy(summary:find("1 skipped", 1, true))
+    assert.is_truthy(summary:find("2 passed", 1, true))
+  end)
+
+  it("lists one row per check, failures first then running", function()
+    local lines = writers.build_checks_details(make_rollup())
+    eq(6, #lines) -- summary + 5 contexts
+    assert.is_truthy(line_text(lines[2]):find("system_tests", 1, true))
+    assert.is_truthy(line_text(lines[3]):find("migrations", 1, true))
+  end)
+
+  it("qualifies check runs with their workflow name", function()
+    local lines = writers.build_checks_details(make_rollup())
+    assert.is_truthy(line_text(lines[2]):find("CI / system_tests", 1, true))
+  end)
+
+  it("shows the duration of finished checks only", function()
+    local text = all_text(writers.build_checks_details(make_rollup()))
+    assert.is_truthy(text:find("4m", 1, true)) -- system_tests took 4 minutes
+    assert.is_truthy(text:find("3m", 1, true)) -- docker_build took 3 minutes
+    local running_row
+    for _, line in ipairs(writers.build_checks_details(make_rollup())) do
+      if line_text(line):find("migrations", 1, true) then
+        running_row = line_text(line)
+      end
+    end
+    assert.is_nil(running_row:find "%d+[ms]") -- no duration while running
+  end)
+
+  it("renders status contexts by their context name", function()
+    local text = all_text(writers.build_checks_details(make_rollup()))
+    assert.is_truthy(text:find("license/cla", 1, true))
+  end)
+
+  it("handles a rollup whose contexts are all successful", function()
+    local rollup = {
+      state = "SUCCESS",
+      contexts = {
+        nodes = { check_run("build", "CI", "COMPLETED", "SUCCESS", "2026-08-24T10:00:00Z", "2026-08-24T10:00:30Z") },
+      },
+    }
+    local lines = writers.build_checks_details(rollup)
+    eq(2, #lines)
+    assert.is_truthy(line_text(lines[1]):find("1 passed", 1, true))
+    assert.is_nil(line_text(lines[1]):find("failed", 1, true))
+    assert.is_truthy(line_text(lines[2]):find("30s", 1, true))
+  end)
+end)


### PR DESCRIPTION
Hi!

I found myself going back and forth between the PR buffer and `Octo pr runs` so I thought I might as well already add it to the PR buffer for display, and it also includes a key shortcut to go to the run buffer if placed the cursor on it.


## Summary

The PR buffer's details section only showed the rollup state (`Checks: ✓SUCCESS`), so finding out *which* check failed meant leaving the buffer for `:Octo pr checks`. It now lists the checks inline, GitHub-style:

<img width="439" height="376" alt="image" src="https://github.com/user-attachments/assets/aebe4006-179d-443b-abcb-cda8aa9a98f3" />


- **Summary line** with counts per outcome, each in its own colour — the terminal equivalent of GitHub's "1 failing, 2 skipped, 18 successful checks".
- **One row per check**: outcome glyph, workflow-qualified name (`workflow / job`, matching how GitHub labels them), and duration for finished checks.
- **Ordered by what needs attention**: failing → running → skipped → passed.
- Lives in the details block, so it folds with the rest of the details and refreshes on reload/poll like every other detail line.

## Implementation

- `statusCheckRollup.contexts(first: 100)` added to the existing `pull_request` query, covering both `CheckRun` (Actions jobs: `status`, `conclusion`, `startedAt`/`completedAt`, `checkSuite.workflowRun.workflow.name`) and `StatusContext` (external statuses: `context`, `state`). **No additional API request** — it rides along with the data the buffer already fetches.
- `writers.build_checks_details(rollup)` is a pure builder returning detail lines, so it is unit-testable without a buffer.
- Outcome mapping: non-completed runs are *running*; `SUCCESS` is *passed*; `FAILURE`/`TIMED_OUT`/`ACTION_REQUIRED`/`STARTUP_FAILURE` are *failed*; `SKIPPED`/`NEUTRAL`/`CANCELLED`/`STALE` are *skipped*. Durations reuse `utils.seconds_between` + `utils.format_seconds`.
- If `contexts` is missing (older GHES, or no checks at all), the previous single rollup line is rendered unchanged.

## Tests

`lua/tests/plenary/checks_section_spec.lua` — 8 tests: no rollup, contexts-unavailable fallback, summary counts, row ordering, workflow-qualified naming, durations only for finished checks, `StatusContext` rows, all-green case. Full suite green (15 spec files).

Verified against live data: an all-green PR renders 6 rows with workflow names resolved, and a 20-check PR renders the skipped-first ordering correctly.

## Possible follow-up

A 20-check repo produces 20 rows, which pushes the PR body down. If that feels long in practice, the natural knob is a config option to cap the list or to collapse the *passed* rows into the summary line only (failing/running/skipped are the actionable ones). Not added yet — deliberately kept configuration-free until the default is proven annoying.


---

## Follow-up in this branch: jump to the check under the cursor

The rows are real buffer lines, so the cursor can address them:

| Mapping | Action |
|---|---|
| `<localleader>gc` (`goto_check`) | open the check the cursor sits on |

- **Actions jobs** open in octo's own workflow run viewer (`octo.workflow_runs.render`, the same view `:Octo pr checks` reaches with `<CR>`) — the run id is parsed out of `detailsUrl`.
- **Other statuses** (external CI, CLA bots) open their `targetUrl` in the browser.
- A check with no link, or a line with no check, just reports that instead of doing something surprising.

`write_details` records a line → check map on the buffer while it writes the detail lines, so the mapping stays exact regardless of how many other detail lines are present.

Tests: `lua/tests/plenary/check_navigation_spec.lua` (5 tests: workflow run, external URL, no link, no check on line, non-PR buffer) plus one added to `checks_section_spec.lua` for the per-row context map.

---

*Split note: the two buffer-navigation shortcuts that were originally on this branch — `gp` to return to the PR from a workflow run, and `<localleader>q` to close an Octo buffer — now live in #13 so this PR stays focused on the checks list.*